### PR TITLE
chore(bump-monorepo-packages): modernize JS and fix bump calculation

### DIFF
--- a/packages/bump-monorepo-packages/src/get-conventional-bump.js
+++ b/packages/bump-monorepo-packages/src/get-conventional-bump.js
@@ -6,7 +6,7 @@
  *    BREAKING CHANGE or BREAKING CHANGES or
  *    subject has ! after the scope (ie. feat! or feat(..)!:)
  * -> then is a major bump
- * if subject starts with feat or fix
+ * if subject starts with feat
  * -> then is a minor bump
  * everything else is a patch.
  *
@@ -24,7 +24,7 @@ function getConventionalBump(commit) {
     return 'major';
   }
 
-  if (/^(feat|fix)[:(]/.test(subject)) {
+  if (/^(feat)[:(]/.test(subject)) {
     return 'minor';
   }
 

--- a/packages/bump-monorepo-packages/src/get-conventional-bump.spec.js
+++ b/packages/bump-monorepo-packages/src/get-conventional-bump.spec.js
@@ -27,6 +27,11 @@ describe('getConventionalBump', function () {
     );
 
     assert.equal(
+      getConventionalBump({ subject: 'fix: msg', body: '' }),
+      'patch'
+    );
+
+    assert.equal(
       getConventionalBump({ subject: 'feat(scope): msg', body: '' }),
       'minor'
     );


### PR DESCRIPTION
Use async functions wherever possible and fix the bump level
determination (`fix:` is semver-patch).

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  Use `feat`, `fix` for user facing changes that should be part of release notes.

  # Semantic Versioning:

  Package versions will be bumped automatically according to the PR title:

  - The words `BREAKING CHANGE` in the title will cause a **major** bump to all the packages changed in the PR. All dependants will also have a major bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - A subject starting with `feat` will cause a **minor** bump to all the packages changed in the PR. All dependants will also have a minor bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - Any other change to any package will cause a `patch` bump to the package and all its dependants.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Checklist
- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
