### PR TITLE
chore(mongodb-constants): move tests from ace-autocompleter package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13226,6 +13226,7 @@
         "@types/chai": "^4.2.21",
         "@types/mocha": "^9.0.0",
         "@types/sinon-chai": "^3.2.5",
+        "acorn": "^8.8.0",
         "chai": "^4.3.6",
         "depcheck": "^1.4.1",
         "eslint": "^7.25.0",
@@ -13235,6 +13236,18 @@
         "prettier": "2.3.2",
         "sinon": "^9.2.3",
         "typescript": "^4.3.5"
+      }
+    },
+    "packages/mongodb-constants/node_modules/acorn": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "scripts": {
@@ -15514,6 +15527,7 @@
         "@types/chai": "^4.2.21",
         "@types/mocha": "^9.0.0",
         "@types/sinon-chai": "^3.2.5",
+        "acorn": "*",
         "chai": "^4.3.6",
         "depcheck": "^1.4.1",
         "eslint": "^7.25.0",
@@ -15523,6 +15537,14 @@
         "prettier": "2.3.2",
         "sinon": "^9.2.3",
         "typescript": "^4.3.5"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.8.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+          "dev": true
+        }
       }
     },
     "@mongodb-js/prettier-config-compass": {

--- a/packages/mongodb-constants/package.json
+++ b/packages/mongodb-constants/package.json
@@ -53,6 +53,7 @@
     "@types/chai": "^4.2.21",
     "@types/mocha": "^9.0.0",
     "@types/sinon-chai": "^3.2.5",
+    "acorn": "^8.8.0",
     "chai": "^4.3.6",
     "depcheck": "^1.4.1",
     "eslint": "^7.25.0",

--- a/packages/mongodb-constants/src/stage-operators.spec.ts
+++ b/packages/mongodb-constants/src/stage-operators.spec.ts
@@ -1,10 +1,63 @@
 import { expect } from 'chai';
+import * as acorn from 'acorn';
 import { STAGE_OPERATORS } from './stage-operators';
 
-describe('STAGE_OPERATORS', function () {
-  it('should have comments without syntax errors', function () {
-    STAGE_OPERATORS.forEach(({ comment }) => {
-      expect(() => eval(comment)).to.not.throw();
+// Replaces any placeholder with a variable,
+// the resulting snippet should always be parseable.
+function replacePlaceholders(snippet: string): string {
+  return snippet
+    .replace(/\${\d+:?[A-z1-9.()]*}/g, 'x')
+    .replace(/\.\.\./g, 'rest');
+}
+
+describe('stage operators', function () {
+  STAGE_OPERATORS.forEach((operator) => {
+    it(`${operator.name} has a properly formatted comment`, function () {
+      expect(
+        operator.comment.startsWith('/**\n'),
+        'expected comment to be open'
+      ).to.be.true;
+
+      const commentLines = operator.comment.split('\n');
+      commentLines.shift();
+      commentLines.pop();
+      commentLines.pop();
+
+      for (const commentLine of commentLines) {
+        expect(
+          /^ \*( |$)/.test(commentLine),
+          'expected comment to be indented properly'
+        ).to.be.true;
+
+        const spaces =
+          /^ */.exec(commentLine.replace(/^ \* ?/, ''))?.[0].length ?? -1;
+        expect(spaces % 2, 'expected comment to be indented properly').to.equal(
+          0
+        );
+      }
+
+      expect(
+        operator.comment.endsWith('\n */\n'),
+        'expected comment to be closed properly'
+      ).to.be.true;
+    });
+
+    it(`${operator.name} has a properly formatted snippet`, function () {
+      const snippet = replacePlaceholders(operator.snippet);
+
+      expect(
+        () => acorn.parseExpressionAt(snippet, 0, { ecmaVersion: 'latest' }),
+        'expected snippet to parse'
+      ).not.to.throw();
+
+      const snippetLines = snippet.split('\n');
+
+      for (const snippetLine of snippetLines) {
+        const spaces = /^ */.exec(snippetLine)?.[0].length ?? -1;
+        expect(spaces % 2, 'expected snippet to be indented properly').to.equal(
+          0
+        );
+      }
     });
   });
 });

--- a/packages/mongodb-constants/src/stage-operators.ts
+++ b/packages/mongodb-constants/src/stage-operators.ts
@@ -1,3 +1,4 @@
+import type { ENVS } from './env';
 import { ATLAS, ADL, ON_PREM } from './env';
 
 import {
@@ -6,6 +7,24 @@ import {
   ANY_COLLECTION_NAMESPACE,
   COLLECTION,
 } from './ns';
+
+type StageOperator = {
+  readonly name: string;
+  readonly value: string;
+  readonly label: string;
+  readonly outputStage: boolean;
+  readonly fullScan: boolean;
+  readonly firstStage: boolean;
+  readonly score: number;
+  readonly env: readonly typeof ENVS[number][];
+  readonly meta: 'stage';
+  readonly version: `${number}.${number}.${number}`;
+  readonly apiVersions: readonly number[];
+  readonly namespaces: readonly typeof ANY_NAMESPACE[number][];
+  readonly description: string;
+  readonly comment: string;
+  readonly snippet: string;
+};
 
 /**
  * The stage operators.
@@ -987,6 +1006,13 @@ const STAGE_OPERATORS = [
 }`,
   },
 ] as const;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+(function assertStageOperatorsSceme(_operators: readonly StageOperator[]) {
+  // This will fail on compile time if stage operators are not matching the type
+  // scheme while allowing us to export their types as const allowing for a
+  // stricter type definitions in the user code
+})(STAGE_OPERATORS);
 
 /**
  * The list of stage operator names.


### PR DESCRIPTION
Didn't notice that these existed when moving code from ace-autocompleter