### PR TITLE
fix: make $out options more clear in aggregation pipeline builder COMPASS-6304

### DIFF
--- a/packages/mongodb-constants/src/stage-operators.ts
+++ b/packages/mongodb-constants/src/stage-operators.ts
@@ -582,13 +582,13 @@ const STAGE_OPERATORS = [
  * s3Url: A S3 URL to save the data.
  * atlas: Parameters to save to Atlas. Example:
  * {
-    atlas: {
-      db: 'string',
-      coll: 'string',
-      projectId: 'string',
-      clusterName: 'string'
-    }
-  }
+ *   atlas: {
+ *     db: 'string',
+ *     coll: 'string',
+ *     projectId: 'string',
+ *     clusterName: 'string'
+ *   }
+ * }
  */
 `,
     snippet: `{

--- a/packages/mongodb-constants/src/stage-operators.ts
+++ b/packages/mongodb-constants/src/stage-operators.ts
@@ -579,8 +579,9 @@ const STAGE_OPERATORS = [
     description:
       'Writes the result of a pipeline to an Atlas cluster or S3 bucket.',
     comment: `/**
- * s3Url: A S3 URL to save the data.
- * atlas: Parameters to save to Atlas. Example:
+ * Use any one of the following:
+ * s3: Parameters to save the data to S3.
+ * atlas: Parameters to save the data to Atlas. Example:
  * {
  *   atlas: {
  *     db: 'string',

--- a/packages/mongodb-constants/src/stage-operators.ts
+++ b/packages/mongodb-constants/src/stage-operators.ts
@@ -580,16 +580,29 @@ const STAGE_OPERATORS = [
       'Writes the result of a pipeline to an Atlas cluster or S3 bucket.',
     comment: `/**
  * s3Url: A S3 URL to save the data.
- * atlas: Parameters to save to Atlas.
+ * atlas: Parameters to save to Atlas. Example:
+ * {
+    atlas: {
+      db: 'string',
+      coll: 'string',
+      projectId: 'string',
+      clusterName: 'string'
+    }
+  }
  */
 `,
     snippet: `{
-  s3: '\${1:s3url}',
-  atlas: {
-    db: '\${2:db}',
-    coll: '\${3:coll}',
-    projectId: '\${4:projectId}',
-    clusterName: '\${5:clusterName}'
+  s3: {
+    bucket: '\${1:string}',
+    region: '\${2:string}',
+    filename: '\${3:string}',
+    format: {
+      name: '\${4:string}',
+      maxFileSize: '\${5:bytes}',
+      maxRowGroupSize: '\${6:string}',
+      columnCompression: '\${7:string}'
+    },
+    errorMode: '\${8:string}'
   }
 }`,
   },


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  Use `feat`, `fix` for user facing changes that should be part of release notes.

  # Semantic Versioning:

  Package versions will be bumped automatically according to the PR title:

  - The words `BREAKING CHANGE` in the title will cause a **major** bump to all the packages changed in the PR. All dependants will also have a major bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - A subject starting with `feat` will cause a **minor** bump to all the packages changed in the PR. All dependants will also have a minor bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - Any other change to any package will cause a `patch` bump to the package and all its dependants.
-->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Instead of showing both Atlas and S3 options at the same time for the `$out` stage in the aggregation builder, which can be confusing to users, show the `$out` to S3 syntax by default. This template is updated to the following snippet, which is outlined in our [docs](https://www.mongodb.com/docs/atlas/data-federation/supported-unsupported/pipeline/out/#syntax) : 

```code:json
/**
 * Use any one of the following:
 * s3: Parameters to save the data to S3.
 * atlas: Parameters to save the data to Atlas. Example:
 * {
 *   atlas: {
 *     db: 'string',
 *     coll: 'string',
 *     projectId: 'string',
 *     clusterName: 'string'
 *   }
 * }
 */
{
  s3: {
    bucket: 'string',
    region: 'string',
    filename: 'string',
    format: {
      name: 'string',
      maxFileSize: 'bytes',
      maxRowGroupSize: 'string',
      columnCompression: 'string'
    },
    errorMode: 'string'
  }
}
```

We also include the Atlas options in a comment within the stage to make it clear to users that they should choose either S3 or Atlas within a single stage. 

## Checklist
- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
