### PR TITLE
fix(mongodb-constants): remove 'term' operator from $search stage template COMPASS-6817

### DIFF
--- a/packages/mongodb-constants/src/stage-operators.ts
+++ b/packages/mongodb-constants/src/stage-operators.ts
@@ -739,7 +739,6 @@ const STAGE_OPERATORS = [
     comment: `/**
  * index: The name of the Search index.
  * text: Analyzed search, with required fields of query and path, the analyzed field(s) to search.
- * term: Un-analyzed search.
  * compound: Combines ops.
  * span: Find in text field regions.
  * exists: Test for presence of a field.


### PR DESCRIPTION
COMPASS-6817