### PR TITLE
feat(oidc-mock-provider): add bin script for running mock identity provider server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14473,6 +14473,12 @@
       "name": "@mongodb-js/oidc-mock-provider",
       "version": "0.5.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "oidc-mock-provider": "bin/oidc-mock-provider.js"
+      },
       "devDependencies": {
         "@mongodb-js/eslint-config-devtools": "0.9.3",
         "@mongodb-js/mocha-config-compass": "^0.10.0",
@@ -14491,6 +14497,44 @@
         "prettier": "2.3.2",
         "sinon": "^9.2.3",
         "typescript": "^4.3.5"
+      }
+    },
+    "packages/oidc-mock-provider/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/oidc-mock-provider/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/oidc-mock-provider/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "packages/sbom-tools": {
@@ -17109,7 +17153,39 @@
         "nyc": "^15.1.0",
         "prettier": "2.3.2",
         "sinon": "^9.2.3",
-        "typescript": "^4.3.5"
+        "typescript": "^4.3.5",
+        "yargs": "17.7.2"
+      },
+      "dependencies": {
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "yargs": {
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
+        }
       }
     },
     "@mongodb-js/prettier-config-compass": {

--- a/packages/oidc-mock-provider/bin/oidc-mock-provider.js
+++ b/packages/oidc-mock-provider/bin/oidc-mock-provider.js
@@ -38,9 +38,6 @@ const DEFAULT_TOKEN_PAYLOAD = {
     getTokenPayload() {
       return DEFAULT_TOKEN_PAYLOAD;
     },
-    overrideRequestHandler() {
-      return () => {};
-    },
     port: argv.port ?? DEFAULT_PORT,
     hostname: argv.host ?? DEFAULT_HOST,
   };

--- a/packages/oidc-mock-provider/bin/oidc-mock-provider.js
+++ b/packages/oidc-mock-provider/bin/oidc-mock-provider.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+'use strict';
+
+const { OIDCMockProvider } = require('..');
+
+const DEFAULT_PORT = 28200;
+const DEFAULT_HOST = 'localhost';
+
+const argv = require('yargs')
+  .option('port', {
+    alias: 'p',
+    type: 'string',
+    desc: 'Port to run the server on. Defaults to 0 (auto-assigns to a random port).',
+  })
+  .option('host', {
+    alias: 'h',
+    type: 'string',
+    desc: 'Hostname for the server to listen upon. Defaults to localhost.',
+  })
+  .example(
+    '$0 -p 28200',
+    'Start the OIDC mock identity provider server on port 28200'
+  )
+  .help().argv;
+
+const DEFAULT_TOKEN_PAYLOAD = {
+  expires_in: 3600,
+  payload: {
+    // Define the user information stored inside the access tokens.
+    groups: ['testgroup'],
+    sub: 'testuser',
+    aud: 'resource-server-audience-value',
+  },
+};
+
+(async function main() {
+  const oidcMockProviderConfig = {
+    getTokenPayload() {
+      return DEFAULT_TOKEN_PAYLOAD;
+    },
+    overrideRequestHandler() {
+      return () => {};
+    },
+    port: argv.port ?? DEFAULT_PORT,
+    hostname: argv.host ?? DEFAULT_HOST,
+  };
+  const mockIdentityProvider = await OIDCMockProvider.create(
+    oidcMockProviderConfig
+  );
+
+  console.log(
+    `Started OIDC mock identity provider server. Listening on ${oidcMockProviderConfig.hostname}:${oidcMockProviderConfig.port}.`
+  );
+  console.log(
+    'OIDC mock identity provider server issuer:',
+    mockIdentityProvider.issuer
+  );
+})();

--- a/packages/oidc-mock-provider/package.json
+++ b/packages/oidc-mock-provider/package.json
@@ -19,8 +19,13 @@
     "url": "https://github.com/mongodb-js/devtools-shared.git"
   },
   "files": [
-    "dist"
+    "dist",
+    "bin",
+    "package.json"
   ],
+  "bin": {
+    "oidc-mock-provider": "bin/oidc-mock-provider.js"
+  },
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "exports": {
@@ -44,6 +49,9 @@
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "reformat": "npm run prettier -- --write ."
+  },
+  "dependencies": {
+    "yargs": "17.7.2"
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-devtools": "0.9.3",

--- a/packages/oidc-mock-provider/src/index.ts
+++ b/packages/oidc-mock-provider/src/index.ts
@@ -49,6 +49,11 @@ export interface OIDCMockProviderConfig {
    * Optional port number for the server to listen on.
    */
   port?: number;
+
+  /**
+   * Optional hostname for the server to listen on.
+   */
+  hostname?: string;
 }
 
 /**
@@ -59,7 +64,7 @@ export interface OIDCMockProviderConfig {
  */
 export class OIDCMockProvider {
   public httpServer: HTTPServer;
-  public issuer: string; // localhost URL of the HTTP server
+  public issuer: string; // URL of the HTTP server
 
   // This provider only supports a single RSA key currently.
   private kid: string;
@@ -81,10 +86,10 @@ export class OIDCMockProvider {
   }
 
   private async init(): Promise<this> {
-    this.httpServer.listen(this.config.port ?? 0);
+    this.httpServer.listen(this.config.port ?? 0, this.config.hostname);
     await once(this.httpServer, 'listening');
     const { port } = this.httpServer.address() as AddressInfo;
-    this.issuer = `http://localhost:${port}`;
+    this.issuer = `http://${this.config.hostname ?? 'localhost'}:${port}`;
     this.kid = await randomString(8, 'hex');
     this.keys = await promisify(crypto.generateKeyPair)('rsa', {
       modulusLength: 2048,


### PR DESCRIPTION
Also adds an option `hostname` to the config options.