### PR TITLE
fix(sbom-tools): truncate origins array

### DIFF
--- a/packages/sbom-tools/src/commands/generate-vulnerability-report.spec.ts
+++ b/packages/sbom-tools/src/commands/generate-vulnerability-report.spec.ts
@@ -512,9 +512,7 @@ patch: {}
       mockJiraSearchApi('pkg1@1.0.0', 'v1').reply(200, { total: 0 });
 
       const createIssue = sinon.spy();
-      mockCreateIssueApi(createIssue).reply(200, {
-        res: { key: 'TICKET-123' },
-      });
+      mockCreateIssueApi(createIssue).reply(200, { key: 'TICKET-123' });
 
       const { error } = await runGenerateReport(
         {
@@ -565,7 +563,88 @@ Vulnerability description
 
 h4. Vulnerable Paths
 
-# {{pkg1@1.0.0}}
+# {{x > y > z}}
+
+h4. Links
+
+- [v1|https://security.snyk.io/vuln/v1]
+- [pkg1@1.0.0 vulnerabilities|https://security.snyk.io/package/npm/pkg1/1.0.0]
+- [CVE-1|https://nvd.nist.gov/vuln/detail/CVE-1]
+`,
+          issuetype: { name: 'Build Failure' },
+          components: [{ name: 'Vulnerability Management' }],
+          priority: { name: 'Minor - P4' },
+          duedate: '2023-03-26',
+        },
+      });
+    });
+
+    it('creates a ticket and truncates origins if > 10', async function () {
+      mockJiraSearchApi('pkg1@1.0.0', 'v1').reply(200, { total: 0 });
+
+      const createIssue = sinon.spy();
+      mockCreateIssueApi(createIssue).reply(200, { key: 'TICKET-123' });
+
+      const { error } = await runGenerateReport(
+        {
+          '.snyk': '',
+          'dependencies.json': JSON.stringify([
+            { name: 'pkg1', version: '1.0.0' },
+          ]),
+          'snyk-report.json': JSON.stringify({
+            vulnerabilities: new Array(11).fill('').map((_, i) =>
+              vulnerabilityToSnyk({
+                id: 'v1',
+                cves: ['CVE-1'],
+                origins: [`path ${i + 1}`],
+                title: 'Vulnerability title',
+                description: 'Vulnerability description',
+                urls: [],
+                severity: 'low',
+                score: 0.1,
+                vulnerableSemver: '<=2.0.0',
+                fixedIn: ['2.0.0'],
+                packageName: 'pkg1',
+                packageVersion: '1.0.0',
+              })
+            ),
+          }),
+        },
+        { createJiraIssues: true }
+      );
+
+      expect(error?.message).to.be.undefined;
+      expect(createIssue).to.have.been.calledOnceWith({
+        fields: {
+          project: { key: 'MY-PROJECT' },
+          summary: 'Vulnerability v1 found on pkg1@1.0.0',
+          description: `h4. Vulnerability Details
+
+- *Affected Package*: pkg1
+- *Affected Version*: 1.0.0
+- *Fixed In*: 2.0.0
+- *Severity*: low
+- *Cvss score*: 0.1
+
+h4. Vulnerability Description
+
+{panel:title=v1}
+Vulnerability description
+{panel}
+
+h4. Vulnerable Paths
+
+# {{path 1}}
+# {{path 2}}
+# {{path 3}}
+# {{path 4}}
+# {{path 5}}
+# {{path 6}}
+# {{path 7}}
+# {{path 8}}
+# {{path 9}}
+# {{path 10}}
+# and other 1 vulnerable path.
 
 h4. Links
 
@@ -585,9 +664,7 @@ h4. Links
       mockJiraSearchApi('pkg1@1.0.0', 'v1').reply(200, { total: 0 });
 
       const createIssue = sinon.spy();
-      mockCreateIssueApi(createIssue).reply(200, {
-        res: { key: 'TICKET-123' },
-      });
+      mockCreateIssueApi(createIssue).reply(200, { key: 'TICKET-123' });
 
       process.env.JIRA_VULNERABILITY_BUILD_INFO = `- commit: ...`;
       const { error } = await runGenerateReport(
@@ -638,7 +715,7 @@ Vulnerability description
 
 h4. Vulnerable Paths
 
-# {{pkg1@1.0.0}}
+# {{x > y > z}}
 
 h4. Links
 
@@ -664,9 +741,7 @@ h4. Build Info
       mockJiraSearchApi('pkg1@1.0.0', 'v1').reply(200, { total: 1 });
 
       const createIssue = sinon.spy();
-      mockCreateIssueApi(createIssue).reply(200, {
-        res: { key: 'TICKET-123' },
-      });
+      mockCreateIssueApi(createIssue).reply(200, { key: 'TICKET-123' });
 
       const { error } = await runGenerateReport(
         {
@@ -704,9 +779,7 @@ h4. Build Info
       mockJiraSearchApi('pkg1@1.0.0', 'v1').reply(200, { total: 0 });
 
       const createIssue = sinon.spy();
-      mockCreateIssueApi(createIssue).reply(200, {
-        res: { key: 'TICKET-123' },
-      });
+      mockCreateIssueApi(createIssue).reply(200, { key: 'TICKET-123' });
 
       const { error } = await runGenerateReport(
         {
@@ -756,9 +829,7 @@ patch: {}
       });
 
       const createIssue = sinon.spy();
-      mockCreateIssueApi(createIssue).reply(200, {
-        res: { key: 'TICKET-123' },
-      });
+      mockCreateIssueApi(createIssue).reply(200, { key: 'TICKET-123' });
 
       const { error } = await runGenerateReport(
         {
@@ -844,9 +915,7 @@ h4. Links
       );
 
       const createIssue = sinon.spy();
-      mockCreateIssueApi(createIssue).reply(200, {
-        res: { key: 'TICKET-123' },
-      });
+      mockCreateIssueApi(createIssue).reply(200, { key: 'TICKET-123' });
 
       const { error } = await runGenerateReport(
         {

--- a/packages/sbom-tools/src/jira.ts
+++ b/packages/sbom-tools/src/jira.ts
@@ -90,11 +90,11 @@ async function createJiraTicket(
   });
 
   if (!response.ok) {
-    throw new Error(`HTTP error: ${response.status}.`);
+    throw new Error(`HTTP error: ${response.status}. ${await response.text()}`);
   }
 
-  const key: string = (await response.json())?.res?.key;
-  console.info('Created issue: ', `${jiraBaseUrl}/browse/${key}`);
+  const key: string = (await response.json())?.key;
+  console.info('Created issue:', `${jiraBaseUrl}/browse/${key}`);
 }
 
 const JIRA_ISSUE_TYPE = 'Build Failure';
@@ -135,6 +135,25 @@ function severityToDueDate(severity: Severity) {
   );
 }
 
+const formatOrigins = (origins: string[]) => {
+  let text = origins
+    .slice(0, 10)
+    .map((o) => `# {{${o}}}`)
+    .join('\n');
+
+  const remaining = origins.slice(10).length;
+
+  if (remaining) {
+    text =
+      text +
+      `\n# and other ${remaining} vulnerable ${
+        remaining === 1 ? 'path' : 'paths'
+      }.`;
+  }
+
+  return text;
+};
+
 export const buildJiraDescription = (
   vulnerability: VulnerabilityInfo
 ): string => {
@@ -157,7 +176,7 @@ ${vulnerability.description}
 
 h4. Vulnerable Paths
 
-${vulnerability.origins.map((o) => `# {{${o}}}`).join('\n')}
+${formatOrigins(vulnerability.origins)}
 
 h4. Links
 

--- a/packages/sbom-tools/src/vulnerability.ts
+++ b/packages/sbom-tools/src/vulnerability.ts
@@ -119,6 +119,7 @@ export function vulnerabilityToSnyk(
     packageName,
     packageVersion,
     score,
+    origins,
     cves,
     vulnerableSemver,
     fixedIn,
@@ -165,7 +166,10 @@ export function vulnerabilityToSnyk(
     modificationTime: '-',
     socialTrendAlert: false,
     severityWithCritical: severity,
-    from: [`${packageName}@${packageVersion}`],
+    from:
+      origins && origins.length
+        ? [...origins]
+        : [`${packageName}@${packageVersion}`],
     upgradePath: [],
     isUpgradable: true,
     isPatchable: false,


### PR DESCRIPTION
- Truncates the `origins` array to 10 in order to avoid limits on the length of the description
- Fix the reported ticket url
- Also report error text in case the ticket creation fails 