### PR TITLE
chore: bumps the affected semver installation creating downstream vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16424,7 +16424,7 @@
         "ora": "^5.4.0",
         "pacote": "^11.3.5",
         "pkg-up": "^3.1.0",
-        "semver": "^7.3.7",
+        "semver": "^7.5.3",
         "toposort": "^2.0.2"
       },
       "bin": {
@@ -18833,7 +18833,7 @@
         "@mongodb-js/tsconfig-compass": "^0.6.0",
         "@types/chai": "^4.2.21",
         "@types/mocha": "^9.0.0",
-        "@types/semver": "7.5.0",
+        "@types/semver": "^7.5.0",
         "@types/sinon-chai": "^3.2.5",
         "acorn": "^8.8.0",
         "chai": "^4.3.6",
@@ -18881,7 +18881,7 @@
         "pacote": "^11.3.5",
         "pkg-up": "^3.1.0",
         "prettier": "2.3.2",
-        "semver": "^7.3.7",
+        "semver": "^7.5.3",
         "toposort": "^2.0.2"
       },
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3694,9 +3694,9 @@
       }
     },
     "node_modules/@types/semver": {
-      "version": "7.3.13",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true
     },
     "node_modules/@types/sinon": {
@@ -16362,7 +16362,7 @@
       "version": "0.6.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "semver": "^7.3.8"
+        "semver": "^7.5.3"
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-devtools": "0.9.5",
@@ -16371,7 +16371,7 @@
         "@mongodb-js/tsconfig-compass": "^0.6.0",
         "@types/chai": "^4.2.21",
         "@types/mocha": "^9.0.0",
-        "@types/semver": "^7.3.13",
+        "@types/semver": "^7.5.0",
         "@types/sinon-chai": "^3.2.5",
         "acorn": "^8.8.0",
         "chai": "^4.3.6",
@@ -16398,9 +16398,9 @@
       }
     },
     "packages/mongodb-constants/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -18833,7 +18833,7 @@
         "@mongodb-js/tsconfig-compass": "^0.6.0",
         "@types/chai": "^4.2.21",
         "@types/mocha": "^9.0.0",
-        "@types/semver": "^7.3.13",
+        "@types/semver": "7.5.0",
         "@types/sinon-chai": "^3.2.5",
         "acorn": "^8.8.0",
         "chai": "^4.3.6",
@@ -18843,7 +18843,7 @@
         "mocha": "^8.4.0",
         "nyc": "^15.1.0",
         "prettier": "2.3.2",
-        "semver": "^7.3.8",
+        "semver": "^7.5.3",
         "sinon": "^9.2.3",
         "typescript": "^4.3.5"
       },
@@ -18855,9 +18855,9 @@
           "dev": true
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -19913,9 +19913,9 @@
       }
     },
     "@types/semver": {
-      "version": "7.3.13",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true
     },
     "@types/sinon": {

--- a/packages/mongodb-constants/package.json
+++ b/packages/mongodb-constants/package.json
@@ -52,7 +52,7 @@
     "@mongodb-js/tsconfig-compass": "^0.6.0",
     "@types/chai": "^4.2.21",
     "@types/mocha": "^9.0.0",
-    "@types/semver": "^7.3.13",
+    "@types/semver": "^7.5.0",
     "@types/sinon-chai": "^3.2.5",
     "acorn": "^8.8.0",
     "chai": "^4.3.6",
@@ -66,6 +66,6 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "semver": "^7.3.8"
+    "semver": "^7.5.3"
   }
 }

--- a/packages/monorepo-tools/package.json
+++ b/packages/monorepo-tools/package.json
@@ -44,8 +44,8 @@
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-devtools": "0.9.5",
-    "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/mocha-config-compass": "^0.10.0",
+    "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "depcheck": "^1.4.1",
     "eslint": "^7.25.0",
     "prettier": "2.3.2"
@@ -53,14 +53,14 @@
   "dependencies": {
     "chalk": "^4.1.1",
     "find-up": "^4.1.0",
+    "git-log-parser": "^1.2.0",
+    "glob": "^10.2.7",
     "minimist": "^1.2.5",
     "ora": "^5.4.0",
     "pacote": "^11.3.5",
     "pkg-up": "^3.1.0",
-    "toposort": "^2.0.2",
-    "glob": "^10.2.7",
-    "git-log-parser": "^1.2.0",
-    "semver": "^7.3.7"
+    "semver": "^7.5.3",
+    "toposort": "^2.0.2"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  Use `feat`, `fix` for user facing changes that should be part of release notes.

  # Semantic Versioning:

  Package versions will be bumped automatically according to the PR title:

  - The words `BREAKING CHANGE` in the title will cause a **major** bump to all the packages changed in the PR. All dependants will also have a major bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - A subject starting with `feat` will cause a **minor** bump to all the packages changed in the PR. All dependants will also have a minor bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - Any other change to any package will cause a `patch` bump to the package and all its dependants.
-->

## Description
Bumps the semver version to 7.5.3, addressing the vulnerabilities reported by Snyk.
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Checklist
- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
