### PR TITLE
chore: remove references to prettier-config-compass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2738,15 +2738,6 @@
       "resolved": "packages/oidc-mock-provider",
       "link": true
     },
-    "node_modules/@mongodb-js/prettier-config-compass": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/prettier-config-compass/-/prettier-config-compass-0.5.0.tgz",
-      "integrity": "sha512-9ERwDhZ/b/beAeNHBgyS6xqh121H1gaRXlW+UeTjnOc2UXnyyvdhZMz43p0U2onhIAJFUchEuitn5a1v2VppXQ==",
-      "dev": true,
-      "peerDependencies": {
-        "prettier": "2.3.2"
-      }
-    },
     "node_modules/@mongodb-js/prettier-config-devtools": {
       "resolved": "configs/prettier-config-devtools",
       "link": true
@@ -17600,7 +17591,7 @@
       "devDependencies": {
         "@mongodb-js/eslint-config-devtools": "0.9.5",
         "@mongodb-js/mocha-config-compass": "^0.10.0",
-        "@mongodb-js/prettier-config-compass": "^0.5.0",
+        "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-compass": "^0.6.0",
         "@types/debug": "^4.1.8",
         "@types/download": "^8.0.2",
@@ -17693,7 +17684,7 @@
       "devDependencies": {
         "@mongodb-js/eslint-config-devtools": "0.9.5",
         "@mongodb-js/mocha-config-compass": "^0.10.0",
-        "@mongodb-js/prettier-config-compass": "^0.5.0",
+        "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-compass": "^0.6.0",
         "@types/chai": "^4.2.21",
         "@types/debug": "^4.1.8",
@@ -20218,7 +20209,7 @@
       "requires": {
         "@mongodb-js/eslint-config-devtools": "0.9.5",
         "@mongodb-js/mocha-config-compass": "^0.10.0",
-        "@mongodb-js/prettier-config-compass": "^0.5.0",
+        "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-compass": "^0.6.0",
         "@types/debug": "^4.1.8",
         "@types/download": "^8.0.2",
@@ -20460,12 +20451,6 @@
           "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
         }
       }
-    },
-    "@mongodb-js/prettier-config-compass": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/prettier-config-compass/-/prettier-config-compass-0.5.0.tgz",
-      "integrity": "sha512-9ERwDhZ/b/beAeNHBgyS6xqh121H1gaRXlW+UeTjnOc2UXnyyvdhZMz43p0U2onhIAJFUchEuitn5a1v2VppXQ==",
-      "dev": true
     },
     "@mongodb-js/prettier-config-devtools": {
       "version": "file:configs/prettier-config-devtools",
@@ -27946,7 +27931,7 @@
         "@mongodb-js/eslint-config-devtools": "0.9.5",
         "@mongodb-js/mocha-config-compass": "^0.10.0",
         "@mongodb-js/mongodb-downloader": "^0.2.0",
-        "@mongodb-js/prettier-config-compass": "^0.5.0",
+        "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-compass": "^0.6.0",
         "@types/chai": "^4.2.21",
         "@types/debug": "^4.1.8",

--- a/packages/mongodb-downloader/.depcheckrc
+++ b/packages/mongodb-downloader/.depcheckrc
@@ -1,5 +1,5 @@
 ignores:
- - '@mongodb-js/prettier-config-compass'
+ - '@mongodb-js/prettier-config-devtools'
  - '@mongodb-js/tsconfig-compass'
  - '@types/chai'
  - '@types/sinon-chai'

--- a/packages/mongodb-downloader/.prettierrc.json
+++ b/packages/mongodb-downloader/.prettierrc.json
@@ -1,1 +1,1 @@
-"@mongodb-js/prettier-config-compass"
+"@mongodb-js/prettier-config-devtools"

--- a/packages/mongodb-downloader/package.json
+++ b/packages/mongodb-downloader/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@mongodb-js/eslint-config-devtools": "0.9.5",
     "@mongodb-js/mocha-config-compass": "^0.10.0",
-    "@mongodb-js/prettier-config-compass": "^0.5.0",
+    "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-compass": "^0.6.0",
     "@types/debug": "^4.1.8",
     "@types/download": "^8.0.2",

--- a/packages/mongodb-runner/.depcheckrc
+++ b/packages/mongodb-runner/.depcheckrc
@@ -1,5 +1,5 @@
 ignores:
- - '@mongodb-js/prettier-config-compass'
+ - '@mongodb-js/prettier-config-devtools'
  - '@mongodb-js/tsconfig-compass'
  - '@types/chai'
  - '@types/sinon-chai'

--- a/packages/mongodb-runner/.prettierrc.json
+++ b/packages/mongodb-runner/.prettierrc.json
@@ -1,1 +1,1 @@
-"@mongodb-js/prettier-config-compass"
+"@mongodb-js/prettier-config-devtools"

--- a/packages/mongodb-runner/package.json
+++ b/packages/mongodb-runner/package.json
@@ -58,7 +58,7 @@
   "devDependencies": {
     "@mongodb-js/eslint-config-devtools": "0.9.5",
     "@mongodb-js/mocha-config-compass": "^0.10.0",
-    "@mongodb-js/prettier-config-compass": "^0.5.0",
+    "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-compass": "^0.6.0",
     "@types/chai": "^4.2.21",
     "@types/debug": "^4.1.8",


### PR DESCRIPTION
Accidentally added back with mongodb-runner