### PR TITLE
chore: disallow eqeqeq and console statements in lint rules MONGOSH-1505

### DIFF
--- a/configs/eslint-config-devtools/common.js
+++ b/configs/eslint-config-devtools/common.js
@@ -1,6 +1,16 @@
 'use strict';
 
+const jsRules = {
+  eqeqeq: 'error',
+  'no-console': 'error',
+};
+
+const jsxRules = {
+  ...jsRules,
+};
+
 const tsRules = {
+  ...jsRules,
   '@typescript-eslint/no-unused-vars': 'error',
   '@typescript-eslint/no-unsafe-assignment': 'off',
   '@typescript-eslint/no-unsafe-call': 'off',
@@ -19,6 +29,7 @@ const tsxRules = {
 };
 
 const testRules = {
+  ...jsRules,
   'mocha/no-exclusive-tests': 'error',
   'mocha/no-hooks-for-single-case': 'off',
   'mocha/no-setup-in-describe': 'off',
@@ -74,6 +85,7 @@ const jsOverrides = {
   ...jsParserOptions,
   env: { node: true, es6: true },
   extends: [...jsConfigurations],
+  rules: { ...jsRules },
 };
 
 const jsxOverrides = {
@@ -81,6 +93,7 @@ const jsxOverrides = {
   ...jsParserOptions,
   env: { node: true, browser: true, es6: true },
   extends: [...jsConfigurations, ...reactConfigurations],
+  rules: { ...jsxRules },
 };
 
 const tsOverrides = {
@@ -114,6 +127,8 @@ const testOverrides = {
 };
 
 module.exports = {
+  jsRules,
+  jsxRules,
   tsRules,
   tsxRules,
   testRules,

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "bump-packages": "bump-monorepo-packages",
     "check-ci": "lerna run check",
     "check": "lerna run check --stream",
+    "lint": "lerna run lint --stream",
     "compile-changed": "lerna run compile --stream --since origin/HEAD",
     "create-workspace": "node ./scripts/src/create-workspace.js",
     "depalign": "depalign",

--- a/packages/mongodb-downloader/src/index.ts
+++ b/packages/mongodb-downloader/src/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import fetch from 'node-fetch';
 import tar from 'tar';
 import { promisify } from 'util';

--- a/packages/mongodb-runner/src/cli.ts
+++ b/packages/mongodb-runner/src/cli.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import yargs from 'yargs';
 import { MongoCluster } from './mongocluster';
 import os from 'os';

--- a/packages/monorepo-tools/src/bump-packages.ts
+++ b/packages/monorepo-tools/src/bump-packages.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import childProcess from 'child_process';
 import { promises as fs } from 'fs';
 // @ts-expect-error No definitions available

--- a/packages/monorepo-tools/src/depalign.ts
+++ b/packages/monorepo-tools/src/depalign.ts
@@ -1,4 +1,5 @@
 #! /usr/bin/env node
+/* eslint-disable no-console */
 
 import path from 'path';
 import { promises as fs } from 'fs';
@@ -56,7 +57,7 @@ async function main(args: ParsedArgs) {
   }
 
   const depalignrcPath =
-    typeof args.config == 'string'
+    typeof args.config === 'string'
       ? path.resolve(process.cwd(), args.config)
       : path.join(process.cwd(), '.depalignrc.json');
 

--- a/packages/monorepo-tools/src/precommit.ts
+++ b/packages/monorepo-tools/src/precommit.ts
@@ -1,4 +1,5 @@
 #! /usr/bin/env node
+/* eslint-disable no-console */
 
 import path from 'path';
 import pkgUp from 'pkg-up';

--- a/packages/monorepo-tools/src/utils/bump-packages.spec.ts
+++ b/packages/monorepo-tools/src/utils/bump-packages.spec.ts
@@ -74,6 +74,7 @@ describe('bump-packages', function () {
   };
 
   const runBumpVersion = () => {
+    // eslint-disable-next-line no-console
     console.log('runBumpVersion');
     const { status } = childProcess.spawnSync(
       'node',

--- a/packages/monorepo-tools/src/where.ts
+++ b/packages/monorepo-tools/src/where.ts
@@ -1,4 +1,5 @@
 #! /usr/bin/env node
+/* eslint-disable no-console */
 
 /**
  * Usage:

--- a/packages/oidc-mock-provider/bin/oidc-mock-provider.js
+++ b/packages/oidc-mock-provider/bin/oidc-mock-provider.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable no-console */
 'use strict';
 
 const { OIDCMockProvider } = require('..');

--- a/packages/sbom-tools/src/commands/generate-third-party-notices.ts
+++ b/packages/sbom-tools/src/commands/generate-third-party-notices.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import crypto from 'crypto';
 import spdxSatisfies from 'spdx-satisfies';
 

--- a/packages/sbom-tools/src/commands/generate-vulnerability-report.ts
+++ b/packages/sbom-tools/src/commands/generate-vulnerability-report.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { promises as fs } from 'fs';
 import _ from 'lodash';
 

--- a/packages/sbom-tools/src/commands/scan-node-js.ts
+++ b/packages/sbom-tools/src/commands/scan-node-js.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import fetch from 'node-fetch';
 import semver from 'semver';
 import nv from '@pkgjs/nv';

--- a/packages/sbom-tools/src/jira.ts
+++ b/packages/sbom-tools/src/jira.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import fetch from 'node-fetch';
 import type { Severity, VulnerabilityInfo } from './vulnerability';
 import { hasExpiredPolicy } from './vulnerability';

--- a/packages/sbom-tools/src/production-deps.ts
+++ b/packages/sbom-tools/src/production-deps.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import path from 'path';
 import findUp from 'find-up';
 import fs from 'fs';

--- a/scripts/src/create-workspace.js
+++ b/scripts/src/create-workspace.js
@@ -1,4 +1,5 @@
 #! /usr/bin/env node
+/* eslint-disable no-console */
 
 const path = require('path');
 const { promises: fs } = require('fs');


### PR DESCRIPTION
This came out of the mongosh eslint PR.

For consistency there's now a jsRules and jsxRules as well which we might have to remember to spread back in where those rules get extended.