### PR TITLE
feat(mongodb-runner): add ConnectionString getter to MongoCluster

### DIFF
--- a/.github/workflows/check-test.yaml
+++ b/.github/workflows/check-test.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install Deps Ubuntu
         if: ${{ runner.os == 'Linux' }}
-        run: sudo apt-get -y install libkrb5-dev libsecret-1-dev net-tools libstdc++6 gnome-keyring
+        run: sudo apt-get -y update && sudo apt-get -y install libkrb5-dev libsecret-1-dev net-tools libstdc++6 gnome-keyring
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout

--- a/packages/mongodb-runner/package.json
+++ b/packages/mongodb-runner/package.json
@@ -53,6 +53,7 @@
     "@mongodb-js/mongodb-downloader": "^0.2.6",
     "debug": "^4.3.4",
     "mongodb": "^5.6.0",
+    "mongodb-connection-string-url": "^2.6.0",
     "yargs": "^17.7.2"
   },
   "devDependencies": {

--- a/packages/mongodb-runner/src/index.ts
+++ b/packages/mongodb-runner/src/index.ts
@@ -1,3 +1,4 @@
 export { MongoServer, MongoServerOptions } from './mongoserver';
 
 export { MongoCluster, MongoClusterOptions } from './mongocluster';
+export type { ConnectionString } from 'mongodb-connection-string-url';

--- a/packages/mongodb-runner/src/mongocluster.ts
+++ b/packages/mongodb-runner/src/mongocluster.ts
@@ -1,5 +1,6 @@
 import type { MongoServerOptions } from './mongoserver';
 import { MongoServer } from './mongoserver';
+import { ConnectionString } from 'mongodb-connection-string-url';
 import type { DownloadOptions } from '@mongodb-js/mongodb-downloader';
 import { downloadMongoDb } from '@mongodb-js/mongodb-downloader';
 import { MongoClient } from 'mongodb';
@@ -62,6 +63,10 @@ export class MongoCluster {
     return `mongodb://${this.hostport}/${
       this.replSetName ? `?replicaSet=${this.replSetName}` : ''
     }`;
+  }
+
+  get connectionStringUrl(): ConnectionString {
+    return new ConnectionString(this.connectionString);
   }
 
   get serverVersion(): string {


### PR DESCRIPTION
Instead of only providing the string through a getter, also provide the `ConnectionString` object from `mongodb-connection-string-url`.

This is helpful for consumers which need to modify the connection string before connecting to the spawned cluster.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  Use `feat`, `fix` for user facing changes that should be part of release notes.

  # Semantic Versioning:

  Package versions will be bumped automatically according to the PR title:

  - The words `BREAKING CHANGE` in the title will cause a **major** bump to all the packages changed in the PR. All dependants will also have a major bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - A subject starting with `feat` will cause a **minor** bump to all the packages changed in the PR. All dependants will also have a minor bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - Any other change to any package will cause a `patch` bump to the package and all its dependants.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Checklist
- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
