### PR TITLE
chore: copy ts and mocha configs from compass MONGOSH-1509 MONGOSH-1510

### DIFF
--- a/configs/eslint-config-devtools/README.md
+++ b/configs/eslint-config-devtools/README.md
@@ -1,5 +1,5 @@
 # @mongodb-js/eslint-config-devtools
 
-> Shared [eslint][eslint] configuration for Compass packages.
+> Shared [eslint][eslint] configuration for Devtools packages.
 
 [eslint]: https://eslint.org/

--- a/configs/mocha-config-devtools/.prettierrc.json
+++ b/configs/mocha-config-devtools/.prettierrc.json
@@ -1,0 +1,1 @@
+"@mongodb-js/prettier-config-devtools"

--- a/configs/mocha-config-devtools/README.md
+++ b/configs/mocha-config-devtools/README.md
@@ -1,0 +1,25 @@
+# @mongodb-js/mocha-config-devtools
+
+> Shared [mocha][mocha] configuration for Devtools packages.
+
+## Usage
+
+For general-purpose packages install as dependency and add the following configuration file
+
+```js
+// file:<package>/.mocharc.js
+module.exports = require('@mongodb-js/mocha-config-devtools');
+```
+
+This configuration activates the colors and sets default timeout to 15 seconds (helpful for CI runs). It also registers `ts-node` so that you can run tests written in typescript without compiling them first
+
+For packages that are intended for the browser use the following configuration file
+
+```js
+// file:<package>/.mocharc.js
+module.exports = require('@mongodb-js/mocha-config-devtools/react');
+```
+
+This configuration extends on the general-purpose one, but also adds `jsdom` to the environment and registers `chai-dom` helpers (if you don't have chai-dom types installed already you should add them with `npm i -D @types/chai-dom`)
+
+[mocha]: https://mochajs.org/#configuring-mocha-nodejs

--- a/configs/mocha-config-devtools/index.js
+++ b/configs/mocha-config-devtools/index.js
@@ -1,0 +1,33 @@
+'use strict';
+const path = require('path');
+const specs = process.argv.slice(2).filter((arg) => !arg.startsWith('-'));
+
+// This can be written as `{src,test}/**/*.{spec,test}.*`, but this causes
+// issues for mocha on some version. It will try to parse every string in the
+// array by splitting on commas causing a wrong spec pattern to be applied. It
+// is fixed in latest, but as we are still in the process of updating
+// everything to the same version and working around the issue helps with
+// migration (this can be removed when mocha is not in depalignrc anymore)
+const defaultSpecs = [
+  'src/**/*.spec.*',
+  'src/**/*.test.*',
+  'test/**/*.spec.*',
+  'test/**/*.test.*',
+];
+
+module.exports = {
+  colors: true,
+  timeout: 15000,
+  require: [
+    path.resolve(__dirname, 'register', 'why-node-running.js'),
+    path.resolve(__dirname, 'register', 'assets-import-register.js'),
+    path.resolve(__dirname, 'register', 'tsnode-register.js'),
+    path.resolve(__dirname, 'register', 'sinon-chai-register.js'),
+    path.resolve(__dirname, 'register', 'unhandled-rejections.js'),
+    path.resolve(__dirname, 'register', 'dns-config-register.js'),
+  ],
+  // Allows to run tests against a particular set of specs instead of all of them
+  spec: specs.length > 0 ? specs : defaultSpecs,
+  extension: ['js', 'ts', 'cjs', 'mjs', 'jsx', 'tsx'],
+  watchFiles: ['test/**/*', 'src/**/*'],
+};

--- a/configs/mocha-config-devtools/package.json
+++ b/configs/mocha-config-devtools/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@mongodb-js/mocha-config-devtools",
+  "version": "1.0.0",
+  "description": "Shared mocha mocha configuration for Devtools packages",
+  "license": "SSPL",
+  "main": "index.js",
+  "devDependencies": {
+    "@mongodb-js/prettier-config-devtools": "^1.0.0",
+    "prettier": "^2.3.2"
+  },
+  "scripts": {
+    "prettier": "prettier",
+    "lint": "npm run prettier --  --check .",
+    "check": "npm run lint",
+    "check-ci": "npm run lint",
+    "reformat": "npm run prettier -- --write ."
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mongodb-js/devtools-shared.git"
+  },
+  "homepage": "https://github.com/mongodb-js/devtools-shared",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@wojtekmaj/enzyme-adapter-react-17": "^0.8.0",
+    "chai": "^4.3.4",
+    "chai-dom": "^1.9.0",
+    "chai-enzyme": "^1.0.0-beta.1",
+    "enzyme": "^3.11.0",
+    "global-jsdom": "^8.3.0",
+    "jsdom": "^21.1.0",
+    "identity-obj-proxy": "^3.0.0",
+    "react-16-node-hanging-test-fix": "^1.0.0",
+    "sinon-chai": "^3.7.0",
+    "ts-node": "^10.9.1",
+    "why-is-node-running": "^2.2.2"
+  }
+}

--- a/configs/mocha-config-devtools/react.js
+++ b/configs/mocha-config-devtools/react.js
@@ -1,0 +1,27 @@
+'use strict';
+const path = require('path');
+const base = require('.');
+
+const pkgJson = require(path.join(process.cwd(), 'package.json'));
+
+const isEnzyme = !!pkgJson.devDependencies.enzyme;
+
+module.exports = {
+  ...base,
+  require: [
+    // There is a bug with React tests not exiting due to how React uses
+    // MessageChannel. The bug is fixed in react@17.1.0, but in the meantime we
+    // have to have this script around and it needs to be the absolute first
+    // import
+    // https://github.com/facebook/react/issues/20756#issuecomment-780927519
+    require.resolve('react-16-node-hanging-test-fix'),
+    ...base.require,
+    path.resolve(__dirname, 'register', 'jsdom-global-register.js'),
+    path.resolve(__dirname, 'register', 'chai-dom-register.js'),
+    path.resolve(__dirname, 'register', 'css-import-register.js'),
+    // We want to move new components/plugins to use testing-library, but for
+    // compat reasons will register and activate enzyme with adapters if
+    // plugin is using it
+    isEnzyme && path.resolve(__dirname, 'register', 'enzyme-register.js'),
+  ].filter(Boolean),
+};

--- a/configs/mocha-config-devtools/register/assets-import-register.js
+++ b/configs/mocha-config-devtools/register/assets-import-register.js
@@ -1,0 +1,15 @@
+'use strict';
+const filepathExports = (module, filepath) => {
+  module.exports = require('path').relative(module.parent.path, filepath);
+};
+
+require.extensions['.jpg'] = filepathExports;
+require.extensions['.jpeg'] = filepathExports;
+require.extensions['.png'] = filepathExports;
+require.extensions['.svg'] = filepathExports;
+require.extensions['.gif'] = filepathExports;
+require.extensions['.ico'] = filepathExports;
+require.extensions['.woff'] = filepathExports;
+require.extensions['.woff2'] = filepathExports;
+require.extensions['.ttf'] = filepathExports;
+require.extensions['.eot'] = filepathExports;

--- a/configs/mocha-config-devtools/register/chai-dom-register.js
+++ b/configs/mocha-config-devtools/register/chai-dom-register.js
@@ -1,0 +1,5 @@
+'use strict';
+const chai = require('chai');
+const chaiDom = require('chai-dom');
+
+chai.use(chaiDom);

--- a/configs/mocha-config-devtools/register/css-import-register.js
+++ b/configs/mocha-config-devtools/register/css-import-register.js
@@ -1,0 +1,9 @@
+'use strict';
+const identityObjProxy = require('identity-obj-proxy');
+
+const identityProxyExports = (module) => {
+  module.exports = identityObjProxy;
+};
+
+require.extensions['.css'] = identityProxyExports;
+require.extensions['.less'] = identityProxyExports;

--- a/configs/mocha-config-devtools/register/dns-config-register.js
+++ b/configs/mocha-config-devtools/register/dns-config-register.js
@@ -1,0 +1,6 @@
+const dns = require('dns');
+
+// https://github.com/nodejs/node/issues/40537
+// TODO(NODE-4926): This is so that tests that try and connect to localhost will
+// connect to 127.0.0.1 in node v18 and later.
+dns.setDefaultResultOrder('ipv4first');

--- a/configs/mocha-config-devtools/register/enzyme-register.js
+++ b/configs/mocha-config-devtools/register/enzyme-register.js
@@ -1,0 +1,8 @@
+'use strict';
+const chai = require('chai');
+const Enzyme = require('enzyme');
+const Adapter = require('@wojtekmaj/enzyme-adapter-react-17');
+
+Enzyme.configure({ adapter: new Adapter() });
+
+chai.use(require('chai-enzyme')());

--- a/configs/mocha-config-devtools/register/jsdom-global-register.js
+++ b/configs/mocha-config-devtools/register/jsdom-global-register.js
@@ -1,0 +1,64 @@
+'use strict';
+if (typeof window === 'undefined') {
+  require('global-jsdom')(undefined, { pretendToBeVisual: true });
+}
+
+if (!globalThis.DOMRectReadOnly) {
+  globalThis.DOMRectReadOnly = class DOMRectReadOnly {
+    x = 0;
+    y = 0;
+    width = 0;
+    height = 0;
+    top = 0;
+    right = 0;
+    bottom = 0;
+    left = 0;
+  };
+}
+
+if (!globalThis.ResizeObserver) {
+  globalThis.ResizeObserver = window.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+// We always mock clipboard because it doesn't exist in jsdom and it doesn't
+// work when running tests programmatically in "hidden" electron renderer
+// window (it needs an actual, user-initiated focus)
+class Clipboard {
+  #text = '';
+  async writeText(str) {
+    this.#text = str;
+  }
+  async readText() {
+    return this.#text;
+  }
+}
+const clipboard = new Clipboard();
+Object.defineProperty(globalThis.navigator, 'clipboard', {
+  get() {
+    return clipboard;
+  },
+});
+
+if (!globalThis.IntersectionObserver) {
+  globalThis.IntersectionObserver =
+    window.IntersectionObserver = class IntersectionObserver {
+      constructor() {}
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+}
+
+// jsdom doesn't override classes that already exist in global scope
+// https://github.com/jsdom/jsdom/issues/3331
+globalThis.EventTarget = window.EventTarget;
+
+Range.prototype.getClientRects = function () {
+  return [];
+};
+
+Element.prototype.scrollIntoView = () => {};

--- a/configs/mocha-config-devtools/register/sinon-chai-register.js
+++ b/configs/mocha-config-devtools/register/sinon-chai-register.js
@@ -1,0 +1,5 @@
+'use strict';
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+
+chai.use(sinonChai);

--- a/configs/mocha-config-devtools/register/tsnode-register.js
+++ b/configs/mocha-config-devtools/register/tsnode-register.js
@@ -1,0 +1,29 @@
+'use strict';
+require('ts-node').register({
+  files: true,
+  transpileOnly: true,
+  compilerOptions: {
+    allowJs: true,
+    jsx: 'react',
+  },
+});
+
+// XXX: @cspotcode/source-map-support library used by ts-node internally causes
+// issues when running tests in electron renderer environment due to webassembly
+// module registering that it's trying to run going out of allowed size boundary
+// for the sync compilation resulting in the following error:
+//
+//   Uncaught RangeError: WebAssembly.Compile is disallowed on the main thread,
+//   if the buffer size is larger than 4KB. Use WebAssembly.compile, or compile
+//   on a worker thread.
+//
+// There is no way to disable it through the library configuration so the only
+// thing we can do is to manually uninstall it after registering ts-node if we
+// can detect that we are in the electron renderer / web runtime
+if (
+  process.env.COMPASS_TEST_DISABLE_SOURCEMAPS === 'true' ||
+  typeof process === 'undefined' ||
+  process.type === 'renderer'
+) {
+  require('@cspotcode/source-map-support').uninstall();
+}

--- a/configs/mocha-config-devtools/register/unhandled-rejections.js
+++ b/configs/mocha-config-devtools/register/unhandled-rejections.js
@@ -1,0 +1,5 @@
+'use strict';
+// https://github.com/mochajs/mocha/issues/2640
+process.on('unhandledRejection', (reason) => {
+  throw reason;
+});

--- a/configs/mocha-config-devtools/register/why-node-running.js
+++ b/configs/mocha-config-devtools/register/why-node-running.js
@@ -1,0 +1,16 @@
+'use strict';
+require('why-is-node-running/include');
+exports.mochaHooks = {
+  afterAll() {
+    if (process.argv.includes('--watch')) {
+      return;
+    }
+    const timeout = setTimeout(() => {
+      console.log(
+        "if the process still running, run kill -SIGINFO %s to see what's keeping it",
+        process.pid
+      );
+    }, 10000);
+    timeout.unref?.();
+  },
+};

--- a/configs/tsconfig-devtools/.gitignore
+++ b/configs/tsconfig-devtools/.gitignore
@@ -1,0 +1,6 @@
+.nyc_output
+node_modules
+package-lock.json
+coverage
+lib
+.DS_Store

--- a/configs/tsconfig-devtools/.prettierrc.json
+++ b/configs/tsconfig-devtools/.prettierrc.json
@@ -1,0 +1,1 @@
+"@mongodb-js/prettier-config-devtools"

--- a/configs/tsconfig-devtools/README.md
+++ b/configs/tsconfig-devtools/README.md
@@ -1,0 +1,3 @@
+# @mongodb-js/tsconfig-devtools
+
+> Shared TypeScript base configurations for Devtools packages.

--- a/configs/tsconfig-devtools/package.json
+++ b/configs/tsconfig-devtools/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@mongodb-js/tsconfig-devtools",
+  "version": "1.0.0",
+  "description": "Shared Devtools Typescript configuration",
+  "license": "SSPL",
+  "files": [
+    "tsconfig.common.json",
+    "tsconfig.react.json"
+  ],
+  "peerDependencies": {
+    "typescript": "^5.0.4"
+  },
+  "devDependencies": {
+    "@mongodb-js/prettier-config-devtools": "^1.0.1",
+    "prettier": "^2.3.2"
+  },
+  "scripts": {
+    "check": "npm run lint",
+    "lint": "prettier --check .",
+    "reformat": "prettier --write ."
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mongodb-js/devtools.git"
+  },
+  "homepage": "https://github.com/mongodb-js/devtools",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/configs/tsconfig-devtools/tsconfig.common.json
+++ b/configs/tsconfig-devtools/tsconfig.common.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "allowJs": false,
+    "esModuleInterop": true,
+    "downlevelIteration": true,
+    "declaration": true,
+    "declarationMap": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["dom", "ES2021"],
+    "module": "commonjs",
+    "removeComments": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "ES2021"
+  }
+}

--- a/configs/tsconfig-devtools/tsconfig.react.json
+++ b/configs/tsconfig-devtools/tsconfig.react.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.common.json",
+  "compilerOptions": {
+    // "exactOptionalPropertyTypes": true,
+    "jsx": "react"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,43 @@
         "eslint": "^7.25.0"
       }
     },
+    "configs/mocha-config-devtools": {
+      "version": "1.0.0",
+      "license": "SSPL",
+      "dependencies": {
+        "@wojtekmaj/enzyme-adapter-react-17": "^0.8.0",
+        "chai": "^4.3.4",
+        "chai-dom": "^1.9.0",
+        "chai-enzyme": "^1.0.0-beta.1",
+        "enzyme": "^3.11.0",
+        "global-jsdom": "^8.3.0",
+        "identity-obj-proxy": "^3.0.0",
+        "jsdom": "^21.1.0",
+        "react-16-node-hanging-test-fix": "^1.0.0",
+        "sinon-chai": "^3.7.0",
+        "ts-node": "^10.9.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "devDependencies": {
+        "@mongodb-js/prettier-config-devtools": "^1.0.0",
+        "prettier": "^2.7.1"
+      }
+    },
+    "configs/mocha-config-devtools/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "configs/prettier-config-devtools": {
       "name": "@mongodb-js/prettier-config-devtools",
       "version": "1.0.1",
@@ -64,6 +101,32 @@
       }
     },
     "configs/prettier-config-devtools/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "configs/tsconfig-devtools": {
+      "version": "1.0.0",
+      "license": "SSPL",
+      "devDependencies": {
+        "@mongodb-js/prettier-config-devtools": "^1.0.1",
+        "prettier": "^2.7.1"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.4"
+      }
+    },
+    "configs/tsconfig-devtools/node_modules/prettier": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
@@ -1847,7 +1910,6 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -1859,7 +1921,6 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -2827,22 +2888,9 @@
       "resolved": "packages/get-os-info",
       "link": true
     },
-    "node_modules/@mongodb-js/mocha-config-compass": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/mocha-config-compass/-/mocha-config-compass-0.10.0.tgz",
-      "integrity": "sha512-jJn0l61kcjHY5/GRUdHd/xoBj+FBcLvLq7EJRMhTvZGOPEpyV2pcVmwVVefWy2KgQFTW5PfgYxKzSGyJmG6XWg==",
-      "dev": true,
-      "dependencies": {
-        "chai": "^4.3.4",
-        "chai-dom": "^1.9.0",
-        "chai-enzyme": "^1.0.0-beta.1",
-        "enzyme": "^3.11.0",
-        "enzyme-adapter-react-16": "^1.15.6",
-        "global-jsdom": "^8.3.0",
-        "identity-obj-proxy": "^3.0.0",
-        "sinon-chai": "^3.7.0",
-        "ts-node": "^10.4.0"
-      }
+    "node_modules/@mongodb-js/mocha-config-devtools": {
+      "resolved": "configs/mocha-config-devtools",
+      "link": true
     },
     "node_modules/@mongodb-js/mongodb-constants": {
       "resolved": "packages/mongodb-constants",
@@ -2868,14 +2916,9 @@
       "resolved": "packages/sbom-tools",
       "link": true
     },
-    "node_modules/@mongodb-js/tsconfig-compass": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/tsconfig-compass/-/tsconfig-compass-0.6.0.tgz",
-      "integrity": "sha512-T0e+ho6u20dQem2zZXvrLuYllYgoLPuK9W7JUJtWaGxCLsPlCZR6hujuPXN/mKdtAA505MDZwKzVD1RcpHmLJw==",
-      "dev": true,
-      "peerDependencies": {
-        "typescript": "^4.3.5"
-      }
+    "node_modules/@mongodb-js/tsconfig-devtools": {
+      "resolved": "configs/tsconfig-devtools",
+      "link": true
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -3634,26 +3677,22 @@
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "dev": true
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-      "dev": true
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
     },
     "node_modules/@tufjs/canonical-json": {
       "version": "1.0.0",
@@ -4288,15 +4327,6 @@
         "source-map": "^0.6.1"
       }
     },
-    "node_modules/@vue/compiler-core/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/@vue/compiler-dom": {
       "version": "3.2.37",
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.37.tgz",
@@ -4323,15 +4353,6 @@
         "magic-string": "^0.25.7",
         "postcss": "^8.1.10",
         "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/@vue/compiler-sfc/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/@vue/compiler-ssr": {
@@ -4509,6 +4530,72 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "node_modules/@wojtekmaj/enzyme-adapter-react-17": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/enzyme-adapter-react-17/-/enzyme-adapter-react-17-0.8.0.tgz",
+      "integrity": "sha512-zeUGfQRziXW7R7skzNuJyi01ZwuKCH8WiBNnTgUJwdS/CURrJwAhWsfW7nG7E30ak8Pu3ZwD9PlK9skBfAoOBw==",
+      "dependencies": {
+        "@wojtekmaj/enzyme-adapter-utils": "^0.2.0",
+        "enzyme-shallow-equal": "^1.0.0",
+        "has": "^1.0.0",
+        "prop-types": "^15.7.0",
+        "react-is": "^17.0.0",
+        "react-test-renderer": "^17.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/enzyme-adapter-react-17?sponsor=1"
+      },
+      "peerDependencies": {
+        "enzyme": "^3.0.0",
+        "react": "^17.0.0-0",
+        "react-dom": "^17.0.0-0"
+      }
+    },
+    "node_modules/@wojtekmaj/enzyme-adapter-react-17/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/@wojtekmaj/enzyme-adapter-react-17/node_modules/react-test-renderer": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
+      "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "react-is": "^17.0.2",
+        "react-shallow-renderer": "^16.13.1",
+        "scheduler": "^0.20.2"
+      },
+      "peerDependencies": {
+        "react": "17.0.2"
+      }
+    },
+    "node_modules/@wojtekmaj/enzyme-adapter-react-17/node_modules/scheduler": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "node_modules/@wojtekmaj/enzyme-adapter-utils": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/enzyme-adapter-utils/-/enzyme-adapter-utils-0.2.0.tgz",
+      "integrity": "sha512-ZvZm9kZxZEKAbw+M1/Q3iDuqQndVoN8uLnxZ8bzxm7KgGTBejrGRoJAp8f1EN8eoO3iAjBNEQnTDW/H4Ekb0FQ==",
+      "dependencies": {
+        "function.prototype.name": "^1.1.0",
+        "has": "^1.0.0",
+        "object.fromentries": "^2.0.0",
+        "prop-types": "^15.7.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/enzyme-adapter-utils?sponsor=1"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0-0"
+      }
+    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -4564,6 +4651,11 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
+    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -4574,6 +4666,26 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-globals": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
+      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+      "dependencies": {
+        "acorn": "^8.1.0",
+        "acorn-walk": "^8.0.2"
+      }
+    },
+    "node_modules/acorn-globals/node_modules/acorn": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4603,7 +4715,6 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4648,29 +4759,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/airbnb-prop-types": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.16.0.tgz",
-      "integrity": "sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==",
-      "dev": true,
-      "dependencies": {
-        "array.prototype.find": "^2.1.1",
-        "function.prototype.name": "^1.1.2",
-        "is-regex": "^1.1.0",
-        "object-is": "^1.1.2",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.1.2",
-        "prop-types": "^15.7.2",
-        "prop-types-exact": "^1.2.0",
-        "react-is": "^16.13.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      },
-      "peerDependencies": {
-        "react": "^0.14 || ^15.0.0 || ^16.0.0-alpha"
       }
     },
     "node_modules/ajv": {
@@ -4811,8 +4899,7 @@
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -4892,7 +4979,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.1.tgz",
       "integrity": "sha512-Dk3Ty7N42Odk7PjU/Ci3zT4pLj20YvuVnneG/58ICM6bt4Ij5kZaJTVQ9TSaWaIECX2sFyz4KItkVZqHNnciqw==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -4907,26 +4993,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array.prototype.find": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.2.0.tgz",
-      "integrity": "sha512-sn40qmUiLYAcRb/1HsIQjTTZ1kCy8II8VtZJpMn2Aoen9twULhbWXisfh3HimGqMlHGUul0/TfKCnXg42LuPpQ==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.4",
-        "es-shim-unscopables": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/array.prototype.flat": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
       "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -4996,7 +5066,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -5186,8 +5255,7 @@
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "dev": true
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -5307,8 +5375,7 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/builtins": {
       "version": "1.0.3",
@@ -5493,7 +5560,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
       "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
-      "dev": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
@@ -5511,7 +5577,6 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/chai-dom/-/chai-dom-1.11.0.tgz",
       "integrity": "sha512-ZzGlEfk1UhHH5+N0t9bDqstOxPEXmn3EyXvtsok5rfXVDOFDJbHVy12rED6ZwkJAUDs2w7/Da4Hlq2LB63kltg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.12.0"
       },
@@ -5524,7 +5589,6 @@
       "version": "1.0.0-beta.1",
       "resolved": "https://registry.npmjs.org/chai-enzyme/-/chai-enzyme-1.0.0-beta.1.tgz",
       "integrity": "sha512-vWT101M7qjq6kM/29G4vHrgLM4Mj1gCnKuvOSF03s8pFVsqol4B6USoGM/aYRKqaaIHs8/AxmHjWGFplQWhIQw==",
-      "dev": true,
       "dependencies": {
         "html": "^1.0.0"
       },
@@ -5561,7 +5625,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
-      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -5570,7 +5633,6 @@
       "version": "1.0.0-rc.12",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
       "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
-      "dev": true,
       "dependencies": {
         "cheerio-select": "^2.1.0",
         "dom-serializer": "^2.0.0",
@@ -5591,7 +5653,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
       "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-      "dev": true,
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-select": "^5.1.0",
@@ -5859,7 +5920,6 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
       "engines": [
         "node >= 0.8"
       ],
@@ -6127,8 +6187,7 @@
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -6147,7 +6206,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
       "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-      "dev": true,
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-what": "^6.1.0",
@@ -6163,12 +6221,22 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
       "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-3.0.0.tgz",
+      "integrity": "sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==",
+      "dependencies": {
+        "rrweb-cssom": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/damerau-levenshtein": {
@@ -6194,6 +6262,42 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-4.0.0.tgz",
+      "integrity": "sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "dependencies": {
+        "punycode": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
+      "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
+      "dependencies": {
+        "tr46": "^4.1.1",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/dateformat": {
@@ -6254,6 +6358,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
@@ -6500,7 +6609,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-      "dev": true,
       "dependencies": {
         "type-detect": "^4.0.0"
       },
@@ -6704,8 +6812,7 @@
     "node_modules/discontinuous-range": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
-      "dev": true
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -6723,7 +6830,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
       "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dev": true,
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
@@ -6737,7 +6843,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6745,11 +6850,21 @@
         }
       ]
     },
+    "node_modules/domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "dependencies": {
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/domhandler": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
       "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "dev": true,
       "dependencies": {
         "domelementtype": "^2.3.0"
       },
@@ -6764,7 +6879,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
       "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-      "dev": true,
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -7142,10 +7256,9 @@
       }
     },
     "node_modules/entities": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
-      "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==",
-      "dev": true,
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "engines": {
         "node": ">=0.12"
       },
@@ -7177,7 +7290,6 @@
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
       "integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
-      "dev": true,
       "dependencies": {
         "array.prototype.flat": "^1.2.3",
         "cheerio": "^1.0.0-rc.3",
@@ -7206,75 +7318,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/enzyme-adapter-react-16": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.6.tgz",
-      "integrity": "sha512-yFlVJCXh8T+mcQo8M6my9sPgeGzj85HSHi6Apgf1Cvq/7EL/J9+1JoJmJsRxZgyTvPMAqOEpRSu/Ii/ZpyOk0g==",
-      "dev": true,
-      "dependencies": {
-        "enzyme-adapter-utils": "^1.14.0",
-        "enzyme-shallow-equal": "^1.0.4",
-        "has": "^1.0.3",
-        "object.assign": "^4.1.2",
-        "object.values": "^1.1.2",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.13.1",
-        "react-test-renderer": "^16.0.0-0",
-        "semver": "^5.7.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      },
-      "peerDependencies": {
-        "enzyme": "^3.0.0",
-        "react": "^16.0.0-0",
-        "react-dom": "^16.0.0-0"
-      }
-    },
-    "node_modules/enzyme-adapter-react-16/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/enzyme-adapter-utils": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.14.0.tgz",
-      "integrity": "sha512-F/z/7SeLt+reKFcb7597IThpDp0bmzcH1E9Oabqv+o01cID2/YInlqHbFl7HzWBl4h3OdZYedtwNDOmSKkk0bg==",
-      "dev": true,
-      "dependencies": {
-        "airbnb-prop-types": "^2.16.0",
-        "function.prototype.name": "^1.1.3",
-        "has": "^1.0.3",
-        "object.assign": "^4.1.2",
-        "object.fromentries": "^2.0.3",
-        "prop-types": "^15.7.2",
-        "semver": "^5.7.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      },
-      "peerDependencies": {
-        "react": "0.13.x || 0.14.x || ^15.0.0-0 || ^16.0.0-0"
-      }
-    },
-    "node_modules/enzyme-adapter-utils/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/enzyme-shallow-equal": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.4.tgz",
       "integrity": "sha512-MttIwB8kKxypwHvRynuC3ahyNc+cFbR8mjVIltnmzQ0uKGqmsfO4bfBuLxb0beLNPhjblUEYvEbsg+VSygvF1Q==",
-      "dev": true,
       "dependencies": {
         "has": "^1.0.3",
         "object-is": "^1.1.2"
@@ -7344,8 +7391,7 @@
     "node_modules/es-array-method-boxes-properly": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-      "dev": true
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA=="
     },
     "node_modules/es-module-lexer": {
       "version": "1.2.1",
@@ -7401,6 +7447,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/eslint": {
@@ -8380,7 +8454,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
-      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -8631,7 +8704,6 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/global-jsdom/-/global-jsdom-8.5.0.tgz",
       "integrity": "sha512-ZuV3KygW6sVnEp/zYWscLhi/EJakk0z6kwoBL2/P3VPJW2wxvB+e4mcrUkazx6zC0JinceB0r6uMi8kZS97uzg==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -8730,15 +8802,6 @@
         "uglify-js": "^3.1.4"
       }
     },
-    "node_modules/handlebars/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -8772,8 +8835,7 @@
     "node_modules/harmony-reflect": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
-      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
-      "dev": true
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g=="
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -8911,7 +8973,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/html/-/html-1.0.0.tgz",
       "integrity": "sha512-lw/7YsdKiP3kk5PnR1INY17iJuzdAtJewxr14ozKJWbbR97znovZ0mh+WEMZ8rjc3lgTK+ID/htTjuyGKB52Kw==",
-      "dev": true,
       "dependencies": {
         "concat-stream": "^1.4.7"
       },
@@ -8923,13 +8984,23 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.3.1.tgz",
       "integrity": "sha512-6XMlxrAFX4UEEGxctfFnmrFaaZFNf9i5fNuV5wZ3WWQ4FVaNP1aX1LkX9j2mfEx1NpjeE/rL3nmgEn23GdFmrg==",
-      "dev": true,
       "dependencies": {
         "array.prototype.filter": "^1.0.0",
         "call-bind": "^1.0.2"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/html-escaper": {
@@ -8942,7 +9013,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
       "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
-      "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -9072,7 +9142,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
       "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
-      "dev": true,
       "dependencies": {
         "harmony-reflect": "^1.4.6"
       },
@@ -9571,6 +9640,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+    },
     "node_modules/is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -9643,8 +9717,7 @@
     "node_modules/is-subset": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-      "integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
-      "dev": true
+      "integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw=="
     },
     "node_modules/is-symbol": {
       "version": "1.0.4",
@@ -9846,15 +9919,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/istanbul-reports": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
@@ -9989,6 +10053,140 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+    },
+    "node_modules/jsdom": {
+      "version": "21.1.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-21.1.2.tgz",
+      "integrity": "sha512-sCpFmK2jv+1sjff4u7fzft+pUh2KSUbUrEHYHyfSIbGTIcmnjyp83qg6qLwdJ/I3LpTXx33ACxeRL7Lsyc6lGQ==",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "acorn": "^8.8.2",
+        "acorn-globals": "^7.0.0",
+        "cssstyle": "^3.0.0",
+        "data-urls": "^4.0.0",
+        "decimal.js": "^10.4.3",
+        "domexception": "^4.0.0",
+        "escodegen": "^2.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.4",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.6.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^12.0.1",
+        "ws": "^8.13.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/jsdom/node_modules/acorn": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jsdom/node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jsdom/node_modules/tough-cookie": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "dependencies": {
+        "punycode": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/jsdom/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
+      "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
+      "dependencies": {
+        "tr46": "^4.1.1",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
@@ -11516,14 +11714,12 @@
     "node_modules/lodash.escape": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-      "integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==",
-      "dev": true
+      "integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw=="
     },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
-      "dev": true
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ=="
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
@@ -11534,8 +11730,7 @@
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "dev": true
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
@@ -11582,7 +11777,6 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
       "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
-      "dev": true,
       "dependencies": {
         "get-func-name": "^2.0.0"
       }
@@ -11633,8 +11827,7 @@
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "node_modules/make-fetch-happen": {
       "version": "11.1.1",
@@ -12503,8 +12696,7 @@
     "node_modules/moo": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
-      "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==",
-      "dev": true
+      "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w=="
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -12572,7 +12764,6 @@
       "version": "2.20.1",
       "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
       "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-      "dev": true,
       "dependencies": {
         "commander": "^2.19.0",
         "moo": "^0.5.0",
@@ -13129,7 +13320,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
       "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "dev": true,
       "dependencies": {
         "boolbase": "^1.0.0"
       },
@@ -13144,6 +13334,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
+      "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ=="
     },
     "node_modules/nx": {
       "version": "16.3.2",
@@ -13578,7 +13773,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
       "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -14096,12 +14290,11 @@
       }
     },
     "node_modules/parse5": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
-      "integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
-      "dev": true,
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
       "dependencies": {
-        "entities": "^4.3.0"
+        "entities": "^4.4.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -14111,7 +14304,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
       "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
-      "dev": true,
       "dependencies": {
         "domhandler": "^5.0.2",
         "parse5": "^7.0.0"
@@ -14207,7 +14399,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -14603,17 +14794,6 @@
         "react-is": "^16.13.1"
       }
     },
-    "node_modules/prop-types-exact": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
-      "integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
-      "dev": true,
-      "dependencies": {
-        "has": "^1.0.3",
-        "object.assign": "^4.1.0",
-        "reflect.ownkeys": "^0.2.0"
-      }
-    },
     "node_modules/propagate": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
@@ -14650,9 +14830,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "engines": {
         "node": ">=6"
       }
@@ -14678,6 +14858,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -14711,7 +14896,6 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dev": true,
       "dependencies": {
         "performance-now": "^2.1.0"
       }
@@ -14719,8 +14903,7 @@
     "node_modules/railroad-diagrams": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
-      "dev": true
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="
     },
     "node_modules/ramda": {
       "version": "0.27.2",
@@ -14731,7 +14914,6 @@
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
       "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-      "dev": true,
       "dependencies": {
         "discontinuous-range": "1.0.0",
         "ret": "~0.1.10"
@@ -14749,24 +14931,43 @@
         "safe-buffer": "^5.1.0"
       }
     },
+    "node_modules/react-16-node-hanging-test-fix": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/react-16-node-hanging-test-fix/-/react-16-node-hanging-test-fix-1.0.0.tgz",
+      "integrity": "sha512-D22iNNa+0MuMPA49nZ5ILBHiJ7h9PTeUUuZee38pFSEWlHOYnHEWzUjOlYjEo6Ji+axHrRnT+y1QRIJOcIcj4w==",
+      "dependencies": {
+        "semver": "^7.3.4"
+      }
+    },
+    "node_modules/react-16-node-hanging-test-fix/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
-    "node_modules/react-test-renderer": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
-      "integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
-      "dev": true,
+    "node_modules/react-shallow-renderer": {
+      "version": "16.15.0",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
       "dependencies": {
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.8.6",
-        "scheduler": "^0.19.1"
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
       },
       "peerDependencies": {
-        "react": "^16.14.0"
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/read": {
@@ -15196,12 +15397,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/reflect.ownkeys": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
-      "integrity": "sha512-qOLsBKHCpSOFKK1NUOCGC5VyeufB6lEsFe92AL2bhIJsacZS1qdoOZSbPk3MYKuT2cFlRDnulKXuuElIrMjGUg==",
-      "dev": true
-    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -15383,6 +15578,11 @@
       "integrity": "sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q==",
       "dev": true
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
     "node_modules/resolve": {
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -15461,7 +15661,6 @@
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-      "dev": true,
       "engines": {
         "node": ">=0.12"
       }
@@ -15497,11 +15696,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw=="
+    },
     "node_modules/rst-selector-parser": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
       "integrity": "sha512-nDG1rZeP6oFTLN6yNDV/uiAvs1+FS/KlrEwh7+y7dpuApDBy6bI2HTBcc0/V8lv9OTqfyD34eF7au2pm8aBbhA==",
-      "dev": true,
       "dependencies": {
         "lodash.flattendeep": "^4.4.0",
         "nearley": "^2.7.10"
@@ -15592,14 +15795,15 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "dev": true,
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/schema-utils": {
@@ -15716,6 +15920,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -15761,7 +15970,6 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
       "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
-      "dev": true,
       "peerDependencies": {
         "chai": "^4.0.0",
         "sinon": ">=4.0.0"
@@ -15945,6 +16153,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
@@ -15962,15 +16179,6 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/sourcemap-codec": {
@@ -16124,6 +16332,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="
+    },
     "node_modules/stackframe": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
@@ -16203,7 +16416,6 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.6.tgz",
       "integrity": "sha512-8lMR2m+U0VJTPp6JjvJTtGyc4FIGq9CdRt7O9p6T0e6K4vjU+OP+SQJpbe/SBmRcCUIvNUnjsbmY6lnMp8MhsQ==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -16372,6 +16584,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "node_modules/table": {
       "version": "6.8.0",
@@ -16700,7 +16917,6 @@
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -16743,7 +16959,6 @@
       "version": "8.8.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
       "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -16755,7 +16970,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -16848,7 +17062,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -16868,8 +17081,7 @@
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "dev": true
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
@@ -17043,6 +17255,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/url-parse-lax": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
@@ -17100,8 +17321,7 @@
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -17138,6 +17358,17 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "dependencies": {
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/watchpack": {
       "version": "2.4.0",
@@ -17236,6 +17467,36 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/whatwg-url": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
@@ -17282,6 +17543,21 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
       "dev": true
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.2.2.tgz",
+      "integrity": "sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/wide-align": {
       "version": "1.1.3",
@@ -17483,6 +17759,39 @@
         "node": ">=6"
       }
     },
+    "node_modules/ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -17587,7 +17896,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -17638,9 +17946,9 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@mongodb-js/eslint-config-devtools": "0.9.9",
-        "@mongodb-js/mocha-config-compass": "^0.10.0",
+        "@mongodb-js/mocha-config-devtools": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
-        "@mongodb-js/tsconfig-compass": "^0.6.0",
+        "@mongodb-js/tsconfig-devtools": "^1.0.0",
         "@types/chai": "^4.2.21",
         "@types/mocha": "^9.0.0",
         "@types/node": "^17.0.35",
@@ -17678,9 +17986,9 @@
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-devtools": "0.9.9",
-        "@mongodb-js/mocha-config-compass": "^0.10.0",
+        "@mongodb-js/mocha-config-devtools": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
-        "@mongodb-js/tsconfig-compass": "^0.6.0",
+        "@mongodb-js/tsconfig-devtools": "^1.0.0",
         "@types/chai": "^4.2.21",
         "@types/mocha": "^9.0.0",
         "@types/semver": "^7.5.0",
@@ -17749,9 +18057,9 @@
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-devtools": "0.9.9",
-        "@mongodb-js/mocha-config-compass": "^0.10.0",
+        "@mongodb-js/mocha-config-devtools": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
-        "@mongodb-js/tsconfig-compass": "^0.6.0",
+        "@mongodb-js/tsconfig-devtools": "^1.0.0",
         "@types/debug": "^4.1.8",
         "@types/download": "^8.0.2",
         "@types/mocha": "^9.0.0",
@@ -17855,9 +18163,9 @@
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-devtools": "0.9.9",
-        "@mongodb-js/mocha-config-compass": "^0.10.0",
+        "@mongodb-js/mocha-config-devtools": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
-        "@mongodb-js/tsconfig-compass": "^0.6.0",
+        "@mongodb-js/tsconfig-devtools": "^1.0.0",
         "@types/chai": "^4.2.21",
         "@types/debug": "^4.1.8",
         "@types/mocha": "^9.0.0",
@@ -17950,9 +18258,9 @@
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-devtools": "0.9.9",
-        "@mongodb-js/mocha-config-compass": "^0.10.0",
+        "@mongodb-js/mocha-config-devtools": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
-        "@mongodb-js/tsconfig-compass": "^0.6.0",
+        "@mongodb-js/tsconfig-devtools": "^1.0.0",
         "@types/mocha": "^9.0.0",
         "@types/node": "^17.0.35",
         "@types/pacote": "^11.1.5",
@@ -18131,9 +18439,9 @@
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-devtools": "0.9.9",
-        "@mongodb-js/mocha-config-compass": "^0.10.0",
+        "@mongodb-js/mocha-config-devtools": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
-        "@mongodb-js/tsconfig-compass": "^0.6.0",
+        "@mongodb-js/tsconfig-devtools": "^1.0.0",
         "@types/chai": "^4.2.21",
         "@types/mocha": "^9.0.0",
         "@types/node": "^17.0.35",
@@ -18220,9 +18528,9 @@
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-devtools": "0.9.9",
-        "@mongodb-js/mocha-config-compass": "^0.10.0",
+        "@mongodb-js/mocha-config-devtools": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
-        "@mongodb-js/tsconfig-compass": "^0.6.0",
+        "@mongodb-js/tsconfig-devtools": "^1.0.0",
         "@types/chai": "^4.2.21",
         "@types/lodash": "^4.14.194",
         "@types/mocha": "^9.0.0",
@@ -19670,7 +19978,6 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -19679,7 +19986,6 @@
           "version": "0.3.9",
           "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
           "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-          "dev": true,
           "requires": {
             "@jridgewell/resolve-uri": "^3.0.3",
             "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -20436,9 +20742,9 @@
       "version": "file:packages/get-os-info",
       "requires": {
         "@mongodb-js/eslint-config-devtools": "0.9.9",
-        "@mongodb-js/mocha-config-compass": "^0.10.0",
+        "@mongodb-js/mocha-config-devtools": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
-        "@mongodb-js/tsconfig-compass": "^0.6.0",
+        "@mongodb-js/tsconfig-devtools": "^1.0.0",
         "@types/chai": "^4.2.21",
         "@types/mocha": "^9.0.0",
         "@types/node": "^17.0.35",
@@ -20462,30 +20768,40 @@
         }
       }
     },
-    "@mongodb-js/mocha-config-compass": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/mocha-config-compass/-/mocha-config-compass-0.10.0.tgz",
-      "integrity": "sha512-jJn0l61kcjHY5/GRUdHd/xoBj+FBcLvLq7EJRMhTvZGOPEpyV2pcVmwVVefWy2KgQFTW5PfgYxKzSGyJmG6XWg==",
-      "dev": true,
+    "@mongodb-js/mocha-config-devtools": {
+      "version": "file:configs/mocha-config-devtools",
       "requires": {
+        "@mongodb-js/prettier-config-devtools": "^1.0.0",
+        "@wojtekmaj/enzyme-adapter-react-17": "^0.8.0",
         "chai": "^4.3.4",
         "chai-dom": "^1.9.0",
         "chai-enzyme": "^1.0.0-beta.1",
         "enzyme": "^3.11.0",
-        "enzyme-adapter-react-16": "^1.15.6",
         "global-jsdom": "^8.3.0",
         "identity-obj-proxy": "^3.0.0",
+        "jsdom": "^21.1.0",
+        "prettier": "^2.7.1",
+        "react-16-node-hanging-test-fix": "^1.0.0",
         "sinon-chai": "^3.7.0",
-        "ts-node": "^10.4.0"
+        "ts-node": "^10.9.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "dependencies": {
+        "prettier": {
+          "version": "2.8.8",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+          "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+          "dev": true
+        }
       }
     },
     "@mongodb-js/mongodb-constants": {
       "version": "file:packages/mongodb-constants",
       "requires": {
         "@mongodb-js/eslint-config-devtools": "0.9.9",
-        "@mongodb-js/mocha-config-compass": "^0.10.0",
+        "@mongodb-js/mocha-config-devtools": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
-        "@mongodb-js/tsconfig-compass": "^0.6.0",
+        "@mongodb-js/tsconfig-devtools": "^1.0.0",
         "@types/chai": "^4.2.21",
         "@types/mocha": "^9.0.0",
         "@types/semver": "^7.5.0",
@@ -20529,9 +20845,9 @@
       "version": "file:packages/mongodb-downloader",
       "requires": {
         "@mongodb-js/eslint-config-devtools": "0.9.9",
-        "@mongodb-js/mocha-config-compass": "^0.10.0",
+        "@mongodb-js/mocha-config-devtools": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
-        "@mongodb-js/tsconfig-compass": "^0.6.0",
+        "@mongodb-js/tsconfig-devtools": "^1.0.0",
         "@types/debug": "^4.1.8",
         "@types/download": "^8.0.2",
         "@types/mocha": "^9.0.0",
@@ -20608,9 +20924,9 @@
       "version": "file:packages/monorepo-tools",
       "requires": {
         "@mongodb-js/eslint-config-devtools": "0.9.9",
-        "@mongodb-js/mocha-config-compass": "^0.10.0",
+        "@mongodb-js/mocha-config-devtools": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
-        "@mongodb-js/tsconfig-compass": "^0.6.0",
+        "@mongodb-js/tsconfig-devtools": "^1.0.0",
         "@types/mocha": "^9.0.0",
         "@types/node": "^17.0.35",
         "@types/pacote": "^11.1.5",
@@ -20735,9 +21051,9 @@
       "version": "file:packages/oidc-mock-provider",
       "requires": {
         "@mongodb-js/eslint-config-devtools": "0.9.9",
-        "@mongodb-js/mocha-config-compass": "^0.10.0",
+        "@mongodb-js/mocha-config-devtools": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
-        "@mongodb-js/tsconfig-compass": "^0.6.0",
+        "@mongodb-js/tsconfig-devtools": "^1.0.0",
         "@types/chai": "^4.2.21",
         "@types/mocha": "^9.0.0",
         "@types/node": "^17.0.35",
@@ -20809,9 +21125,9 @@
       "version": "file:packages/sbom-tools",
       "requires": {
         "@mongodb-js/eslint-config-devtools": "0.9.9",
-        "@mongodb-js/mocha-config-compass": "^0.10.0",
+        "@mongodb-js/mocha-config-devtools": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
-        "@mongodb-js/tsconfig-compass": "^0.6.0",
+        "@mongodb-js/tsconfig-devtools": "^1.0.0",
         "@pkgjs/nv": "^0.2.1",
         "@types/chai": "^4.2.21",
         "@types/lodash": "^4.14.194",
@@ -20958,11 +21274,20 @@
         }
       }
     },
-    "@mongodb-js/tsconfig-compass": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/tsconfig-compass/-/tsconfig-compass-0.6.0.tgz",
-      "integrity": "sha512-T0e+ho6u20dQem2zZXvrLuYllYgoLPuK9W7JUJtWaGxCLsPlCZR6hujuPXN/mKdtAA505MDZwKzVD1RcpHmLJw==",
-      "dev": true
+    "@mongodb-js/tsconfig-devtools": {
+      "version": "file:configs/tsconfig-devtools",
+      "requires": {
+        "@mongodb-js/prettier-config-devtools": "^1.0.1",
+        "prettier": "^2.7.1"
+      },
+      "dependencies": {
+        "prettier": {
+          "version": "2.8.8",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+          "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+          "dev": true
+        }
+      }
     },
     "@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -21503,26 +21828,22 @@
     "@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "dev": true
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
     },
     "@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
     },
     "@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
     },
     "@tsconfig/node16": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-      "dev": true
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
     },
     "@tufjs/canonical-json": {
       "version": "1.0.0",
@@ -22037,14 +22358,6 @@
         "@vue/shared": "3.2.37",
         "estree-walker": "^2.0.2",
         "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "@vue/compiler-dom": {
@@ -22073,14 +22386,6 @@
         "magic-string": "^0.25.7",
         "postcss": "^8.1.10",
         "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "@vue/compiler-ssr": {
@@ -22258,6 +22563,57 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@wojtekmaj/enzyme-adapter-react-17": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/enzyme-adapter-react-17/-/enzyme-adapter-react-17-0.8.0.tgz",
+      "integrity": "sha512-zeUGfQRziXW7R7skzNuJyi01ZwuKCH8WiBNnTgUJwdS/CURrJwAhWsfW7nG7E30ak8Pu3ZwD9PlK9skBfAoOBw==",
+      "requires": {
+        "@wojtekmaj/enzyme-adapter-utils": "^0.2.0",
+        "enzyme-shallow-equal": "^1.0.0",
+        "has": "^1.0.0",
+        "prop-types": "^15.7.0",
+        "react-is": "^17.0.0",
+        "react-test-renderer": "^17.0.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+        },
+        "react-test-renderer": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
+          "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
+          "requires": {
+            "object-assign": "^4.1.1",
+            "react-is": "^17.0.2",
+            "react-shallow-renderer": "^16.13.1",
+            "scheduler": "^0.20.2"
+          }
+        },
+        "scheduler": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+          "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
+      }
+    },
+    "@wojtekmaj/enzyme-adapter-utils": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/enzyme-adapter-utils/-/enzyme-adapter-utils-0.2.0.tgz",
+      "integrity": "sha512-ZvZm9kZxZEKAbw+M1/Q3iDuqQndVoN8uLnxZ8bzxm7KgGTBejrGRoJAp8f1EN8eoO3iAjBNEQnTDW/H4Ekb0FQ==",
+      "requires": {
+        "function.prototype.name": "^1.1.0",
+        "has": "^1.0.0",
+        "object.fromentries": "^2.0.0",
+        "prop-types": "^15.7.0"
+      }
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -22311,6 +22667,11 @@
         }
       }
     },
+    "abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -22321,6 +22682,22 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true
+    },
+    "acorn-globals": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
+      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+      "requires": {
+        "acorn": "^8.1.0",
+        "acorn-walk": "^8.0.2"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.10.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+          "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw=="
+        }
+      }
     },
     "acorn-import-assertions": {
       "version": "1.8.0",
@@ -22337,8 +22714,7 @@
     "acorn-walk": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "dev": true
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
     },
     "add-stream": {
       "version": "1.0.0",
@@ -22371,23 +22747,6 @@
       "requires": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
-      }
-    },
-    "airbnb-prop-types": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.16.0.tgz",
-      "integrity": "sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==",
-      "dev": true,
-      "requires": {
-        "array.prototype.find": "^2.1.1",
-        "function.prototype.name": "^1.1.2",
-        "is-regex": "^1.1.0",
-        "object-is": "^1.1.2",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.1.2",
-        "prop-types": "^15.7.2",
-        "prop-types-exact": "^1.2.0",
-        "react-is": "^16.13.1"
       }
     },
     "ajv": {
@@ -22493,8 +22852,7 @@
     "arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "argparse": {
       "version": "1.0.10",
@@ -22556,7 +22914,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.1.tgz",
       "integrity": "sha512-Dk3Ty7N42Odk7PjU/Ci3zT4pLj20YvuVnneG/58ICM6bt4Ij5kZaJTVQ9TSaWaIECX2sFyz4KItkVZqHNnciqw==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -22565,23 +22922,10 @@
         "is-string": "^1.0.7"
       }
     },
-    "array.prototype.find": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.2.0.tgz",
-      "integrity": "sha512-sn40qmUiLYAcRb/1HsIQjTTZ1kCy8II8VtZJpMn2Aoen9twULhbWXisfh3HimGqMlHGUul0/TfKCnXg42LuPpQ==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.4",
-        "es-shim-unscopables": "^1.0.0"
-      }
-    },
     "array.prototype.flat": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
       "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -22632,8 +22976,7 @@
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
     },
     "ast-types-flow": {
       "version": "0.0.7",
@@ -22783,8 +23126,7 @@
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "dev": true
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -22861,8 +23203,7 @@
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "builtins": {
       "version": "1.0.3",
@@ -22995,7 +23336,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
       "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
-      "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
@@ -23009,14 +23349,12 @@
     "chai-dom": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/chai-dom/-/chai-dom-1.11.0.tgz",
-      "integrity": "sha512-ZzGlEfk1UhHH5+N0t9bDqstOxPEXmn3EyXvtsok5rfXVDOFDJbHVy12rED6ZwkJAUDs2w7/Da4Hlq2LB63kltg==",
-      "dev": true
+      "integrity": "sha512-ZzGlEfk1UhHH5+N0t9bDqstOxPEXmn3EyXvtsok5rfXVDOFDJbHVy12rED6ZwkJAUDs2w7/Da4Hlq2LB63kltg=="
     },
     "chai-enzyme": {
       "version": "1.0.0-beta.1",
       "resolved": "https://registry.npmjs.org/chai-enzyme/-/chai-enzyme-1.0.0-beta.1.tgz",
       "integrity": "sha512-vWT101M7qjq6kM/29G4vHrgLM4Mj1gCnKuvOSF03s8pFVsqol4B6USoGM/aYRKqaaIHs8/AxmHjWGFplQWhIQw==",
-      "dev": true,
       "requires": {
         "html": "^1.0.0"
       }
@@ -23039,14 +23377,12 @@
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
-      "dev": true
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA=="
     },
     "cheerio": {
       "version": "1.0.0-rc.12",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
       "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
-      "dev": true,
       "requires": {
         "cheerio-select": "^2.1.0",
         "dom-serializer": "^2.0.0",
@@ -23061,7 +23397,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
       "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-      "dev": true,
       "requires": {
         "boolbase": "^1.0.0",
         "css-select": "^5.1.0",
@@ -23262,7 +23597,6 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -23465,8 +23799,7 @@
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -23482,7 +23815,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
       "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-      "dev": true,
       "requires": {
         "boolbase": "^1.0.0",
         "css-what": "^6.1.0",
@@ -23494,8 +23826,15 @@
     "css-what": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-      "dev": true
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
+    },
+    "cssstyle": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-3.0.0.tgz",
+      "integrity": "sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==",
+      "requires": {
+        "rrweb-cssom": "^0.6.0"
+      }
     },
     "damerau-levenshtein": {
       "version": "1.0.8",
@@ -23514,6 +23853,35 @@
       "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
       "requires": {
         "assert-plus": "^1.0.0"
+      }
+    },
+    "data-urls": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-4.0.0.tgz",
+      "integrity": "sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==",
+      "requires": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^12.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+          "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+          "requires": {
+            "punycode": "^2.3.0"
+          }
+        },
+        "whatwg-url": {
+          "version": "12.0.1",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
+          "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
+          "requires": {
+            "tr46": "^4.1.1",
+            "webidl-conversions": "^7.0.0"
+          }
+        }
       }
     },
     "dateformat": {
@@ -23553,6 +23921,11 @@
           "dev": true
         }
       }
+    },
+    "decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "decode-uri-component": {
       "version": "0.2.2",
@@ -23744,7 +24117,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-      "dev": true,
       "requires": {
         "type-detect": "^4.0.0"
       }
@@ -23896,8 +24268,7 @@
     "discontinuous-range": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
-      "dev": true
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
     },
     "doctrine": {
       "version": "3.0.0",
@@ -23912,7 +24283,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
       "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dev": true,
       "requires": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
@@ -23922,14 +24292,20 @@
     "domelementtype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
+    },
+    "domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "requires": {
+        "webidl-conversions": "^7.0.0"
+      }
     },
     "domhandler": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
       "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "dev": true,
       "requires": {
         "domelementtype": "^2.3.0"
       }
@@ -23938,7 +24314,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
       "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-      "dev": true,
       "requires": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -24249,10 +24624,9 @@
       }
     },
     "entities": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
-      "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==",
-      "dev": true
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
     },
     "env-paths": {
       "version": "2.2.1",
@@ -24269,7 +24643,6 @@
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
       "integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
-      "dev": true,
       "requires": {
         "array.prototype.flat": "^1.2.3",
         "cheerio": "^1.0.0-rc.3",
@@ -24295,59 +24668,10 @@
         "string.prototype.trim": "^1.2.1"
       }
     },
-    "enzyme-adapter-react-16": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.6.tgz",
-      "integrity": "sha512-yFlVJCXh8T+mcQo8M6my9sPgeGzj85HSHi6Apgf1Cvq/7EL/J9+1JoJmJsRxZgyTvPMAqOEpRSu/Ii/ZpyOk0g==",
-      "dev": true,
-      "requires": {
-        "enzyme-adapter-utils": "^1.14.0",
-        "enzyme-shallow-equal": "^1.0.4",
-        "has": "^1.0.3",
-        "object.assign": "^4.1.2",
-        "object.values": "^1.1.2",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.13.1",
-        "react-test-renderer": "^16.0.0-0",
-        "semver": "^5.7.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
-      }
-    },
-    "enzyme-adapter-utils": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.14.0.tgz",
-      "integrity": "sha512-F/z/7SeLt+reKFcb7597IThpDp0bmzcH1E9Oabqv+o01cID2/YInlqHbFl7HzWBl4h3OdZYedtwNDOmSKkk0bg==",
-      "dev": true,
-      "requires": {
-        "airbnb-prop-types": "^2.16.0",
-        "function.prototype.name": "^1.1.3",
-        "has": "^1.0.3",
-        "object.assign": "^4.1.2",
-        "object.fromentries": "^2.0.3",
-        "prop-types": "^15.7.2",
-        "semver": "^5.7.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
-      }
-    },
     "enzyme-shallow-equal": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.4.tgz",
       "integrity": "sha512-MttIwB8kKxypwHvRynuC3ahyNc+cFbR8mjVIltnmzQ0uKGqmsfO4bfBuLxb0beLNPhjblUEYvEbsg+VSygvF1Q==",
-      "dev": true,
       "requires": {
         "has": "^1.0.3",
         "object-is": "^1.1.2"
@@ -24408,8 +24732,7 @@
     "es-array-method-boxes-properly": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-      "dev": true
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA=="
     },
     "es-module-lexer": {
       "version": "1.2.1",
@@ -24451,6 +24774,24 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true
+    },
+    "escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+        }
+      }
     },
     "eslint": {
       "version": "7.32.0",
@@ -25177,8 +25518,7 @@
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
-      "dev": true
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig=="
     },
     "get-intrinsic": {
       "version": "1.1.2",
@@ -25369,8 +25709,7 @@
     "global-jsdom": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/global-jsdom/-/global-jsdom-8.5.0.tgz",
-      "integrity": "sha512-ZuV3KygW6sVnEp/zYWscLhi/EJakk0z6kwoBL2/P3VPJW2wxvB+e4mcrUkazx6zC0JinceB0r6uMi8kZS97uzg==",
-      "dev": true
+      "integrity": "sha512-ZuV3KygW6sVnEp/zYWscLhi/EJakk0z6kwoBL2/P3VPJW2wxvB+e4mcrUkazx6zC0JinceB0r6uMi8kZS97uzg=="
     },
     "globals": {
       "version": "11.12.0",
@@ -25435,14 +25774,6 @@
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "har-schema": {
@@ -25468,8 +25799,7 @@
     "harmony-reflect": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
-      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
-      "dev": true
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g=="
     },
     "has": {
       "version": "1.0.3",
@@ -25564,7 +25894,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/html/-/html-1.0.0.tgz",
       "integrity": "sha512-lw/7YsdKiP3kk5PnR1INY17iJuzdAtJewxr14ozKJWbbR97znovZ0mh+WEMZ8rjc3lgTK+ID/htTjuyGKB52Kw==",
-      "dev": true,
       "requires": {
         "concat-stream": "^1.4.7"
       }
@@ -25573,10 +25902,17 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.3.1.tgz",
       "integrity": "sha512-6XMlxrAFX4UEEGxctfFnmrFaaZFNf9i5fNuV5wZ3WWQ4FVaNP1aX1LkX9j2mfEx1NpjeE/rL3nmgEn23GdFmrg==",
-      "dev": true,
       "requires": {
         "array.prototype.filter": "^1.0.0",
         "call-bind": "^1.0.2"
+      }
+    },
+    "html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "requires": {
+        "whatwg-encoding": "^2.0.0"
       }
     },
     "html-escaper": {
@@ -25589,7 +25925,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
       "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
-      "dev": true,
       "requires": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
@@ -25680,7 +26015,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
       "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
-      "dev": true,
       "requires": {
         "harmony-reflect": "^1.4.6"
       }
@@ -26034,6 +26368,11 @@
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "dev": true
     },
+    "is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+    },
     "is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -26082,8 +26421,7 @@
     "is-subset": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-      "integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
-      "dev": true
+      "integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw=="
     },
     "is-symbol": {
       "version": "1.0.4",
@@ -26237,14 +26575,6 @@
         "debug": "^4.1.1",
         "istanbul-lib-coverage": "^3.0.0",
         "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "istanbul-reports": {
@@ -26345,6 +26675,104 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+    },
+    "jsdom": {
+      "version": "21.1.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-21.1.2.tgz",
+      "integrity": "sha512-sCpFmK2jv+1sjff4u7fzft+pUh2KSUbUrEHYHyfSIbGTIcmnjyp83qg6qLwdJ/I3LpTXx33ACxeRL7Lsyc6lGQ==",
+      "requires": {
+        "abab": "^2.0.6",
+        "acorn": "^8.8.2",
+        "acorn-globals": "^7.0.0",
+        "cssstyle": "^3.0.0",
+        "data-urls": "^4.0.0",
+        "decimal.js": "^10.4.3",
+        "domexception": "^4.0.0",
+        "escodegen": "^2.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.4",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.6.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^12.0.1",
+        "ws": "^8.13.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "dependencies": {
+        "@tootallnate/once": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+          "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
+        },
+        "acorn": {
+          "version": "8.10.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+          "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw=="
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "http-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+          "requires": {
+            "@tootallnate/once": "2",
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
+        "tough-cookie": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+          "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+          "requires": {
+            "psl": "^1.1.33",
+            "punycode": "^2.1.1",
+            "universalify": "^0.2.0",
+            "url-parse": "^1.5.3"
+          }
+        },
+        "tr46": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+          "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+          "requires": {
+            "punycode": "^2.3.0"
+          }
+        },
+        "universalify": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+          "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="
+        },
+        "whatwg-url": {
+          "version": "12.0.1",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
+          "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
+          "requires": {
+            "tr46": "^4.1.1",
+            "webidl-conversions": "^7.0.0"
+          }
+        }
+      }
     },
     "jsesc": {
       "version": "2.5.2",
@@ -27544,14 +27972,12 @@
     "lodash.escape": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-      "integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==",
-      "dev": true
+      "integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw=="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
-      "dev": true
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ=="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -27562,8 +27988,7 @@
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "dev": true
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "lodash.ismatch": {
       "version": "4.4.0",
@@ -27604,7 +28029,6 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
       "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
-      "dev": true,
       "requires": {
         "get-func-name": "^2.0.0"
       }
@@ -27643,8 +28067,7 @@
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "make-fetch-happen": {
       "version": "11.1.1",
@@ -28278,10 +28701,10 @@
       "version": "file:packages/mongodb-runner",
       "requires": {
         "@mongodb-js/eslint-config-devtools": "0.9.9",
-        "@mongodb-js/mocha-config-compass": "^0.10.0",
+        "@mongodb-js/mocha-config-devtools": "^1.0.0",
         "@mongodb-js/mongodb-downloader": "^0.2.6",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
-        "@mongodb-js/tsconfig-compass": "^0.6.0",
+        "@mongodb-js/tsconfig-devtools": "^1.0.0",
         "@types/chai": "^4.2.21",
         "@types/debug": "^4.1.8",
         "@types/mocha": "^9.0.0",
@@ -28342,8 +28765,7 @@
     "moo": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
-      "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==",
-      "dev": true
+      "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w=="
     },
     "ms": {
       "version": "2.1.2",
@@ -28398,7 +28820,6 @@
       "version": "2.20.1",
       "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
       "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-      "dev": true,
       "requires": {
         "commander": "^2.19.0",
         "moo": "^0.5.0",
@@ -28826,7 +29247,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
       "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "dev": true,
       "requires": {
         "boolbase": "^1.0.0"
       }
@@ -28835,6 +29255,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ=="
+    },
+    "nwsapi": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
+      "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ=="
     },
     "nx": {
       "version": "16.3.2",
@@ -29173,7 +29598,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
       "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -29544,19 +29968,17 @@
       }
     },
     "parse5": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
-      "integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
-      "dev": true,
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
       "requires": {
-        "entities": "^4.3.0"
+        "entities": "^4.4.0"
       }
     },
     "parse5-htmlparser2-tree-adapter": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
       "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
-      "dev": true,
       "requires": {
         "domhandler": "^5.0.2",
         "parse5": "^7.0.0"
@@ -29628,8 +30050,7 @@
     "pathval": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ=="
     },
     "pend": {
       "version": "1.2.0",
@@ -29912,17 +30333,6 @@
         "react-is": "^16.13.1"
       }
     },
-    "prop-types-exact": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
-      "integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.3",
-        "object.assign": "^4.1.0",
-        "reflect.ownkeys": "^0.2.0"
-      }
-    },
     "propagate": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
@@ -29956,9 +30366,9 @@
       }
     },
     "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
     },
     "query-ast": {
       "version": "1.0.4",
@@ -29979,6 +30389,11 @@
         "strict-uri-encode": "^1.0.0"
       }
     },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -29994,7 +30409,6 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dev": true,
       "requires": {
         "performance-now": "^2.1.0"
       }
@@ -30002,8 +30416,7 @@
     "railroad-diagrams": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
-      "dev": true
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="
     },
     "ramda": {
       "version": "0.27.2",
@@ -30014,7 +30427,6 @@
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
       "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-      "dev": true,
       "requires": {
         "discontinuous-range": "1.0.0",
         "ret": "~0.1.10"
@@ -30029,21 +30441,36 @@
         "safe-buffer": "^5.1.0"
       }
     },
+    "react-16-node-hanging-test-fix": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/react-16-node-hanging-test-fix/-/react-16-node-hanging-test-fix-1.0.0.tgz",
+      "integrity": "sha512-D22iNNa+0MuMPA49nZ5ILBHiJ7h9PTeUUuZee38pFSEWlHOYnHEWzUjOlYjEo6Ji+axHrRnT+y1QRIJOcIcj4w==",
+      "requires": {
+        "semver": "^7.3.4"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
-    "react-test-renderer": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
-      "integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
-      "dev": true,
+    "react-shallow-renderer": {
+      "version": "16.15.0",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
       "requires": {
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.8.6",
-        "scheduler": "^0.19.1"
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "read": {
@@ -30369,12 +30796,6 @@
         "strip-indent": "^3.0.0"
       }
     },
-    "reflect.ownkeys": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
-      "integrity": "sha512-qOLsBKHCpSOFKK1NUOCGC5VyeufB6lEsFe92AL2bhIJsacZS1qdoOZSbPk3MYKuT2cFlRDnulKXuuElIrMjGUg==",
-      "dev": true
-    },
     "regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -30516,6 +30937,11 @@
       "integrity": "sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q==",
       "dev": true
     },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
     "resolve": {
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -30574,8 +31000,7 @@
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-      "dev": true
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
     "retry": {
       "version": "0.12.0",
@@ -30595,11 +31020,15 @@
         "glob": "^7.1.3"
       }
     },
+    "rrweb-cssom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw=="
+    },
     "rst-selector-parser": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
       "integrity": "sha512-nDG1rZeP6oFTLN6yNDV/uiAvs1+FS/KlrEwh7+y7dpuApDBy6bI2HTBcc0/V8lv9OTqfyD34eF7au2pm8aBbhA==",
-      "dev": true,
       "requires": {
         "lodash.flattendeep": "^4.4.0",
         "nearley": "^2.7.10"
@@ -30666,14 +31095,12 @@
         "source-map-js": ">=0.6.2 <2.0.0"
       }
     },
-    "scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "dev": true,
+    "saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "xmlchars": "^2.2.0"
       }
     },
     "schema-utils": {
@@ -30761,6 +31188,11 @@
         "object-inspect": "^1.9.0"
       }
     },
+    "siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="
+    },
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -30803,8 +31235,7 @@
     "sinon-chai": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
-      "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
-      "dev": true
+      "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g=="
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -30946,6 +31377,12 @@
         }
       }
     },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "devOptional": true
+    },
     "source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
@@ -30960,14 +31397,6 @@
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "sourcemap-codec": {
@@ -31104,6 +31533,11 @@
         "minipass": "^3.1.1"
       }
     },
+    "stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="
+    },
     "stackframe": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
@@ -31170,7 +31604,6 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.6.tgz",
       "integrity": "sha512-8lMR2m+U0VJTPp6JjvJTtGyc4FIGq9CdRt7O9p6T0e6K4vjU+OP+SQJpbe/SBmRcCUIvNUnjsbmY6lnMp8MhsQ==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -31286,6 +31719,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+    },
+    "symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "table": {
       "version": "6.8.0",
@@ -31536,7 +31974,6 @@
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "dev": true,
       "requires": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -31556,14 +31993,12 @@
         "acorn": {
           "version": "8.8.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-          "dev": true
+          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
         },
         "diff": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-          "dev": true
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
         }
       }
     },
@@ -31635,8 +32070,7 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-fest": {
       "version": "0.21.3",
@@ -31647,8 +32081,7 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "dev": true
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
@@ -31767,6 +32200,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "url-parse-lax": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
@@ -31817,8 +32259,7 @@
     "v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -31853,6 +32294,14 @@
           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
           "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
         }
+      }
+    },
+    "w3c-xmlserializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "requires": {
+        "xml-name-validator": "^4.0.0"
       }
     },
     "watchpack": {
@@ -31924,6 +32373,29 @@
       "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
       "dev": true
     },
+    "whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "requires": {
+        "iconv-lite": "0.6.3"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
+    },
+    "whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="
+    },
     "whatwg-url": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
@@ -31958,6 +32430,15 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
       "dev": true
+    },
+    "why-is-node-running": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.2.2.tgz",
+      "integrity": "sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==",
+      "requires": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      }
     },
     "wide-align": {
       "version": "1.1.3",
@@ -32119,6 +32600,21 @@
         }
       }
     },
+    "ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA=="
+    },
+    "xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw=="
+    },
+    "xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -32197,8 +32693,7 @@
     "yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/packages/get-os-info/.depcheckrc
+++ b/packages/get-os-info/.depcheckrc
@@ -1,6 +1,6 @@
 ignores:
  - '@mongodb-js/prettier-config-devtools'
- - '@mongodb-js/tsconfig-compass'
+ - '@mongodb-js/tsconfig-devtools'
  - '@types/chai'
  - '@types/sinon-chai'
  - 'sinon'

--- a/packages/get-os-info/.mocharc.js
+++ b/packages/get-os-info/.mocharc.js
@@ -1,1 +1,1 @@
-module.exports = require('@mongodb-js/mocha-config-compass');
+module.exports = require('@mongodb-js/mocha-config-devtools');

--- a/packages/get-os-info/package.json
+++ b/packages/get-os-info/package.json
@@ -47,9 +47,9 @@
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-devtools": "0.9.9",
-    "@mongodb-js/mocha-config-compass": "^0.10.0",
+    "@mongodb-js/mocha-config-devtools": "^1.0.0",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
-    "@mongodb-js/tsconfig-compass": "^0.6.0",
+    "@mongodb-js/tsconfig-devtools": "^1.0.0",
     "@types/chai": "^4.2.21",
     "@types/mocha": "^9.0.0",
     "@types/node": "^17.0.35",

--- a/packages/get-os-info/tsconfig.json
+++ b/packages/get-os-info/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@mongodb-js/tsconfig-compass/tsconfig.common.json",
+  "extends": "@mongodb-js/tsconfig-devtools/tsconfig.common.json",
   "compilerOptions": {
     "outDir": "dist"
   },

--- a/packages/mongodb-constants/.depcheckrc
+++ b/packages/mongodb-constants/.depcheckrc
@@ -1,6 +1,6 @@
 ignores:
  - '@mongodb-js/prettier-config-devtools'
- - '@mongodb-js/tsconfig-compass'
+ - '@mongodb-js/tsconfig-devtools'
  - '@types/chai'
  - '@types/sinon-chai'
  - 'sinon'

--- a/packages/mongodb-constants/.mocharc.js
+++ b/packages/mongodb-constants/.mocharc.js
@@ -1,1 +1,1 @@
-module.exports = require('@mongodb-js/mocha-config-compass');
+module.exports = require('@mongodb-js/mocha-config-devtools');

--- a/packages/mongodb-constants/package.json
+++ b/packages/mongodb-constants/package.json
@@ -47,9 +47,9 @@
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-devtools": "0.9.9",
-    "@mongodb-js/mocha-config-compass": "^0.10.0",
+    "@mongodb-js/mocha-config-devtools": "^1.0.0",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
-    "@mongodb-js/tsconfig-compass": "^0.6.0",
+    "@mongodb-js/tsconfig-devtools": "^1.0.0",
     "@types/chai": "^4.2.21",
     "@types/mocha": "^9.0.0",
     "@types/semver": "^7.5.0",

--- a/packages/mongodb-constants/tsconfig.json
+++ b/packages/mongodb-constants/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@mongodb-js/tsconfig-compass/tsconfig.common.json",
+  "extends": "@mongodb-js/tsconfig-devtools/tsconfig.common.json",
   "compilerOptions": {
     "outDir": "dist"
   },

--- a/packages/mongodb-downloader/.depcheckrc
+++ b/packages/mongodb-downloader/.depcheckrc
@@ -1,6 +1,6 @@
 ignores:
  - '@mongodb-js/prettier-config-devtools'
- - '@mongodb-js/tsconfig-compass'
+ - '@mongodb-js/tsconfig-devtools'
  - '@types/chai'
  - '@types/sinon-chai'
  - 'sinon'

--- a/packages/mongodb-downloader/.mocharc.js
+++ b/packages/mongodb-downloader/.mocharc.js
@@ -1,1 +1,1 @@
-module.exports = require('@mongodb-js/mocha-config-compass');
+module.exports = require('@mongodb-js/mocha-config-devtools');

--- a/packages/mongodb-downloader/package.json
+++ b/packages/mongodb-downloader/package.json
@@ -54,9 +54,9 @@
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-devtools": "0.9.9",
-    "@mongodb-js/mocha-config-compass": "^0.10.0",
+    "@mongodb-js/mocha-config-devtools": "^1.0.0",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
-    "@mongodb-js/tsconfig-compass": "^0.6.0",
+    "@mongodb-js/tsconfig-devtools": "^1.0.0",
     "@types/debug": "^4.1.8",
     "@types/download": "^8.0.2",
     "@types/mocha": "^9.0.0",

--- a/packages/mongodb-downloader/tsconfig.json
+++ b/packages/mongodb-downloader/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@mongodb-js/tsconfig-compass/tsconfig.common.json",
+  "extends": "@mongodb-js/tsconfig-devtools/tsconfig.common.json",
   "compilerOptions": {
     "outDir": "dist",
     "allowJs": true

--- a/packages/mongodb-runner/.depcheckrc
+++ b/packages/mongodb-runner/.depcheckrc
@@ -1,6 +1,6 @@
 ignores:
  - '@mongodb-js/prettier-config-devtools'
- - '@mongodb-js/tsconfig-compass'
+ - '@mongodb-js/tsconfig-devtools'
  - '@types/chai'
  - '@types/sinon-chai'
  - 'sinon'

--- a/packages/mongodb-runner/.mocharc.js
+++ b/packages/mongodb-runner/.mocharc.js
@@ -1,1 +1,1 @@
-module.exports = require('@mongodb-js/mocha-config-compass');
+module.exports = require('@mongodb-js/mocha-config-devtools');

--- a/packages/mongodb-runner/package.json
+++ b/packages/mongodb-runner/package.json
@@ -57,9 +57,9 @@
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-devtools": "0.9.9",
-    "@mongodb-js/mocha-config-compass": "^0.10.0",
+    "@mongodb-js/mocha-config-devtools": "^1.0.0",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
-    "@mongodb-js/tsconfig-compass": "^0.6.0",
+    "@mongodb-js/tsconfig-devtools": "^1.0.0",
     "@types/chai": "^4.2.21",
     "@types/debug": "^4.1.8",
     "@types/mocha": "^9.0.0",

--- a/packages/mongodb-runner/tsconfig.json
+++ b/packages/mongodb-runner/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@mongodb-js/tsconfig-compass/tsconfig.common.json",
+  "extends": "@mongodb-js/tsconfig-devtools/tsconfig.common.json",
   "compilerOptions": {
     "outDir": "dist",
     "allowJs": true

--- a/packages/monorepo-tools/.depcheckrc
+++ b/packages/monorepo-tools/.depcheckrc
@@ -1,6 +1,6 @@
 ignores:
  - '@mongodb-js/prettier-config-devtools'
- - '@mongodb-js/tsconfig-compass'
+ - '@mongodb-js/tsconfig-devtools'
  - '@types/chai'
  - '@types/sinon-chai'
  - 'sinon'

--- a/packages/monorepo-tools/.mocharc.js
+++ b/packages/monorepo-tools/.mocharc.js
@@ -1,1 +1,1 @@
-module.exports = require('@mongodb-js/mocha-config-compass');
+module.exports = require('@mongodb-js/mocha-config-devtools');

--- a/packages/monorepo-tools/package.json
+++ b/packages/monorepo-tools/package.json
@@ -48,9 +48,9 @@
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-devtools": "0.9.9",
-    "@mongodb-js/mocha-config-compass": "^0.10.0",
+    "@mongodb-js/mocha-config-devtools": "^1.0.0",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
-    "@mongodb-js/tsconfig-compass": "^0.6.0",
+    "@mongodb-js/tsconfig-devtools": "^1.0.0",
     "@types/mocha": "^9.0.0",
     "@types/node": "^17.0.35",
     "@types/pacote": "^11.1.5",

--- a/packages/monorepo-tools/tsconfig.json
+++ b/packages/monorepo-tools/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@mongodb-js/tsconfig-compass/tsconfig.common.json",
+  "extends": "@mongodb-js/tsconfig-devtools/tsconfig.common.json",
   "compilerOptions": {
     "outDir": "dist",
     "allowJs": true

--- a/packages/oidc-mock-provider/.depcheckrc
+++ b/packages/oidc-mock-provider/.depcheckrc
@@ -1,6 +1,6 @@
 ignores:
  - '@mongodb-js/prettier-config-devtools'
- - '@mongodb-js/tsconfig-compass'
+ - '@mongodb-js/tsconfig-devtools'
  - '@types/chai'
  - '@types/sinon-chai'
  - 'sinon'

--- a/packages/oidc-mock-provider/.mocharc.js
+++ b/packages/oidc-mock-provider/.mocharc.js
@@ -1,1 +1,1 @@
-module.exports = require('@mongodb-js/mocha-config-compass');
+module.exports = require('@mongodb-js/mocha-config-devtools');

--- a/packages/oidc-mock-provider/package.json
+++ b/packages/oidc-mock-provider/package.json
@@ -55,9 +55,9 @@
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-devtools": "0.9.9",
-    "@mongodb-js/mocha-config-compass": "^0.10.0",
+    "@mongodb-js/mocha-config-devtools": "^1.0.0",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
-    "@mongodb-js/tsconfig-compass": "^0.6.0",
+    "@mongodb-js/tsconfig-devtools": "^1.0.0",
     "@types/chai": "^4.2.21",
     "@types/mocha": "^9.0.0",
     "@types/node": "^17.0.35",

--- a/packages/oidc-mock-provider/tsconfig.json
+++ b/packages/oidc-mock-provider/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@mongodb-js/tsconfig-compass/tsconfig.common.json",
+  "extends": "@mongodb-js/tsconfig-devtools/tsconfig.common.json",
   "compilerOptions": {
     "outDir": "dist",
     "allowJs": true

--- a/packages/sbom-tools/.depcheckrc
+++ b/packages/sbom-tools/.depcheckrc
@@ -1,6 +1,6 @@
 ignores:
  - '@mongodb-js/prettier-config-devtools'
- - '@mongodb-js/tsconfig-compass'
+ - '@mongodb-js/tsconfig-devtools'
  - '@types/chai'
  - '@types/sinon-chai'
  - 'sinon'

--- a/packages/sbom-tools/.mocharc.js
+++ b/packages/sbom-tools/.mocharc.js
@@ -1,1 +1,1 @@
-module.exports = require('@mongodb-js/mocha-config-compass');
+module.exports = require('@mongodb-js/mocha-config-devtools');

--- a/packages/sbom-tools/package.json
+++ b/packages/sbom-tools/package.json
@@ -50,9 +50,9 @@
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-devtools": "0.9.9",
-    "@mongodb-js/mocha-config-compass": "^0.10.0",
+    "@mongodb-js/mocha-config-devtools": "^1.0.0",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
-    "@mongodb-js/tsconfig-compass": "^0.6.0",
+    "@mongodb-js/tsconfig-devtools": "^1.0.0",
     "@types/chai": "^4.2.21",
     "@types/lodash": "^4.14.194",
     "@types/mocha": "^9.0.0",

--- a/packages/sbom-tools/tsconfig.json
+++ b/packages/sbom-tools/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@mongodb-js/tsconfig-compass/tsconfig.common.json",
+  "extends": "@mongodb-js/tsconfig-devtools/tsconfig.common.json",
   "compilerOptions": {
     "outDir": "dist",
     "allowJs": true

--- a/scripts/src/create-workspace.js
+++ b/scripts/src/create-workspace.js
@@ -194,9 +194,9 @@ async function main(argv) {
     },
     devDependencies: {
       '@mongodb-js/eslint-config-devtools': '*',
-      '@mongodb-js/mocha-config-compass': '*',
+      '@mongodb-js/mocha-config-devtools': '*',
       '@mongodb-js/prettier-config-devtools': '*',
-      '@mongodb-js/tsconfig-compass': '*',
+      '@mongodb-js/tsconfig-devtools': '*',
       '@types/chai': '*',
       '@types/mocha': '*',
       '@types/node': '*',
@@ -231,7 +231,7 @@ async function main(argv) {
   const depcheckrcPath = path.join(packagePath, '.depcheckrc');
   const ignores = [
     '@mongodb-js/prettier-config-devtools',
-    '@mongodb-js/tsconfig-compass',
+    '@mongodb-js/tsconfig-devtools',
     '@types/chai',
     '@types/sinon-chai',
     'sinon',
@@ -251,7 +251,7 @@ async function main(argv) {
   const tsconfigPath = path.join(packagePath, 'tsconfig.json');
   const tsconfigContent = JSON.stringify(
     {
-      extends: '@mongodb-js/tsconfig-compass/tsconfig.common.json',
+      extends: '@mongodb-js/tsconfig-devtools/tsconfig.common.json',
       compilerOptions: {
         outDir: 'dist',
         allowJs: true,
@@ -288,7 +288,7 @@ module.exports = {
   const eslintIgnorePath = path.join(packagePath, '.eslintignore');
   const eslintIgnoreContent = '.nyc-output\ndist\n';
   const mocharcPath = path.join(packagePath, '.mocharc.js');
-  const mocharcContent = `module.exports = require('@mongodb-js/mocha-config-compass');`;
+  const mocharcContent = `module.exports = require('@mongodb-js/mocha-config-devtools');`;
 
   const indexSrcDir = path.join(packagePath, 'src');
   const indexSrcPath = path.join(indexSrcDir, 'index.ts');


### PR DESCRIPTION
tsconfig-devtools is exactly the same as tsconfig-compass. mocha-config-devtools misses a few electron/compass-only bits we'll have to keep in compass when we switch to this:

* compass-plugin.js
* main-process.js
* window-config.json
* register/resolve-from-source-register.js (which will have to be loaded in index.js, react.js and compass-plugin.js)

