### PR TITLE
feat: add monorepo-tools bin as lerna replacement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3996,6 +3996,15 @@
       "integrity": "sha512-Y3Faje1Gi/l+tSjAo52Lpm3fLnpQtQLfYcmpInikSoHBxckOFKl1uGWVfRyI3LnX2+brcRUDox7T08eJ60UQlQ==",
       "dev": true
     },
+    "node_modules/@types/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-rwV0tC3XGQvQ8zdeYDZ+dLn4CJLKnYPBrSU8dRXvzMVLUPMsYTsy3/ZbE4OlejsT2D7MTGP8ePk05C98xl2seQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/ssri": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/ssri/-/ssri-7.1.1.tgz",
@@ -5844,6 +5853,81 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/color-prefix-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/color-prefix-stream/-/color-prefix-stream-1.0.0.tgz",
+      "integrity": "sha512-jT3fTJOdTpgWIpruSUn+IFpENWy6QSzaMRQ6565YeUWuaZVCyPUQxzWGcsqTg7UkPK7aWEBQJtsU+L891JNzhg==",
+      "dependencies": {
+        "chalk": "^1.1.3",
+        "split2": "^2.1.0"
+      }
+    },
+    "node_modules/color-prefix-stream/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/color-prefix-stream/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/color-prefix-stream/node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/color-prefix-stream/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/color-prefix-stream/node_modules/split2": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "dependencies": {
+        "through2": "^2.0.2"
+      }
+    },
+    "node_modules/color-prefix-stream/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/color-prefix-stream/node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
@@ -6719,6 +6803,11 @@
       "resolved": "https://registry.npmjs.org/deps-regex/-/deps-regex-0.1.4.tgz",
       "integrity": "sha512-3tzwGYogSJi8HoG93R5x9NrdefZQOXgHgGih/7eivloOq6yC6O+yoFxZnkgP661twvfILONfoKRdF9GQOGx2RA==",
       "dev": true
+    },
+    "node_modules/depth-first": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/depth-first/-/depth-first-4.0.0.tgz",
+      "integrity": "sha512-m8mFxY5EetjSFUNqmkPdcTotaEku1QAJJIeI0wxFkEsL7i2hWEfgfYrGtzQ6gAL9eu6QFpjLNVecyVURfQb+qQ=="
     },
     "node_modules/detect-indent": {
       "version": "5.0.0",
@@ -8562,6 +8651,25 @@
       },
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-ansi/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/has-bigints": {
@@ -17857,7 +17965,9 @@
       "version": "1.1.9",
       "license": "SSPL",
       "dependencies": {
-        "chalk": "^4.1.1",
+        "chalk": "^4.1.2",
+        "color-prefix-stream": "^1.0.0",
+        "depth-first": "^4.0.0",
         "find-up": "^4.1.0",
         "git-log-parser": "^1.2.0",
         "glob": "^10.2.7",
@@ -17866,7 +17976,9 @@
         "pacote": "^11.3.5",
         "pkg-up": "^3.1.0",
         "semver": "^7.5.4",
-        "toposort": "^2.0.2"
+        "split2": "^4.2.0",
+        "toposort": "^2.0.2",
+        "yargs": "^17.7.2"
       },
       "bin": {
         "bump-monorepo-packages": "bin/bump-packages.js",
@@ -17882,6 +17994,7 @@
         "@types/mocha": "^9.0.0",
         "@types/node": "^17.0.35",
         "@types/pacote": "^11.1.5",
+        "@types/split2": "^4.2.0",
         "@types/toposort": "^2.0.3",
         "depcheck": "^1.4.1",
         "eslint": "^7.25.0",
@@ -17899,6 +18012,19 @@
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "packages/monorepo-tools/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "packages/monorepo-tools/node_modules/find-up": {
@@ -18032,6 +18158,14 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "packages/monorepo-tools/node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "packages/monorepo-tools/node_modules/typescript": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
@@ -18043,6 +18177,31 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "packages/monorepo-tools/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/monorepo-tools/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "packages/oidc-mock-provider": {
@@ -20589,9 +20748,12 @@
         "@types/mocha": "^9.0.0",
         "@types/node": "^17.0.35",
         "@types/pacote": "^11.1.5",
+        "@types/split2": "*",
         "@types/toposort": "^2.0.3",
-        "chalk": "^4.1.1",
+        "chalk": "^4.1.2",
+        "color-prefix-stream": "^1.0.0",
         "depcheck": "^1.4.1",
+        "depth-first": "^4.0.0",
         "eslint": "^7.25.0",
         "find-up": "^4.1.0",
         "gen-esm-wrapper": "^1.1.0",
@@ -20606,8 +20768,10 @@
         "prettier": "2.3.2",
         "semver": "^7.5.4",
         "sinon": "^9.2.3",
+        "split2": "^4.2.0",
         "toposort": "^2.0.2",
-        "typescript": "^5.0.4"
+        "typescript": "^5.0.4",
+        "yargs": "^17.7.2"
       },
       "dependencies": {
         "brace-expansion": {
@@ -20616,6 +20780,16 @@
           "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
           "requires": {
             "balanced-match": "^1.0.0"
+          }
+        },
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
           }
         },
         "find-up": {
@@ -20698,11 +20872,35 @@
           "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
           "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q=="
         },
+        "split2": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+          "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="
+        },
         "typescript": {
           "version": "5.1.6",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
           "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
           "dev": true
+        },
+        "yargs": {
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
         }
       }
     },
@@ -21820,6 +22018,15 @@
       "resolved": "https://registry.npmjs.org/@types/spdx-satisfies/-/spdx-satisfies-0.1.0.tgz",
       "integrity": "sha512-Y3Faje1Gi/l+tSjAo52Lpm3fLnpQtQLfYcmpInikSoHBxckOFKl1uGWVfRyI3LnX2+brcRUDox7T08eJ60UQlQ==",
       "dev": true
+    },
+    "@types/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-rwV0tC3XGQvQ8zdeYDZ+dLn4CJLKnYPBrSU8dRXvzMVLUPMsYTsy3/ZbE4OlejsT2D7MTGP8ePk05C98xl2seQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/ssri": {
       "version": "7.1.1",
@@ -23211,6 +23418,65 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "color-prefix-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/color-prefix-stream/-/color-prefix-stream-1.0.0.tgz",
+      "integrity": "sha512-jT3fTJOdTpgWIpruSUn+IFpENWy6QSzaMRQ6565YeUWuaZVCyPUQxzWGcsqTg7UkPK7aWEBQJtsU+L891JNzhg==",
+      "requires": {
+        "chalk": "^1.1.3",
+        "split2": "^2.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA=="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+        },
+        "split2": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+          "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+          "requires": {
+            "through2": "^2.0.2"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g=="
+        }
+      }
+    },
     "color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
@@ -23886,6 +24152,11 @@
       "resolved": "https://registry.npmjs.org/deps-regex/-/deps-regex-0.1.4.tgz",
       "integrity": "sha512-3tzwGYogSJi8HoG93R5x9NrdefZQOXgHgGih/7eivloOq6yC6O+yoFxZnkgP661twvfILONfoKRdF9GQOGx2RA==",
       "dev": true
+    },
+    "depth-first": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/depth-first/-/depth-first-4.0.0.tgz",
+      "integrity": "sha512-m8mFxY5EetjSFUNqmkPdcTotaEku1QAJJIeI0wxFkEsL7i2hWEfgfYrGtzQ6gAL9eu6QFpjLNVecyVURfQb+qQ=="
     },
     "detect-indent": {
       "version": "5.0.0",
@@ -25267,6 +25538,21 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "requires": {
         "function-bind": "^1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+        }
       }
     },
     "has-bigints": {

--- a/packages/monorepo-tools/bin/monorepo-tools.js
+++ b/packages/monorepo-tools/bin/monorepo-tools.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+'use strict';
+require('../dist/monorepo-tools.js');

--- a/packages/monorepo-tools/package.json
+++ b/packages/monorepo-tools/package.json
@@ -26,6 +26,7 @@
     "precommit": "./bin/precommit.js",
     "depalign": "./bin/depalign.js",
     "monorepo-where": "./bin/where.js",
+    "monorepo-tools": "./bin/monorepo-tools.js",
     "bump-monorepo-packages": "./bin/bump-packages.js"
   },
   "scripts": {
@@ -54,6 +55,7 @@
     "@types/mocha": "^9.0.0",
     "@types/node": "^17.0.35",
     "@types/pacote": "^11.1.5",
+    "@types/split2": "^4.2.0",
     "@types/toposort": "^2.0.3",
     "depcheck": "^1.4.1",
     "eslint": "^7.25.0",
@@ -65,7 +67,9 @@
     "typescript": "^5.0.4"
   },
   "dependencies": {
-    "chalk": "^4.1.1",
+    "chalk": "^4.1.2",
+    "color-prefix-stream": "^1.0.0",
+    "depth-first": "^4.0.0",
     "find-up": "^4.1.0",
     "git-log-parser": "^1.2.0",
     "glob": "^10.2.7",
@@ -74,7 +78,9 @@
     "pacote": "^11.3.5",
     "pkg-up": "^3.1.0",
     "semver": "^7.5.4",
-    "toposort": "^2.0.2"
+    "split2": "^4.2.0",
+    "toposort": "^2.0.2",
+    "yargs": "^17.7.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/monorepo-tools/src/monorepo-tools.ts
+++ b/packages/monorepo-tools/src/monorepo-tools.ts
@@ -1,0 +1,321 @@
+/* eslint-disable no-console */
+import { spawn } from 'child_process';
+import split2 from 'split2';
+
+import { findMonorepoRoot } from './utils/find-monorepo-root';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import type { PackageInfo } from './utils/get-packages-in-topological-order';
+import { getPackagesInTopologicalOrder } from './utils/get-packages-in-topological-order';
+import chalk from 'chalk';
+
+type YargsCommand = ReturnType<typeof yargs>;
+type YargsOptionDefinition = Parameters<YargsCommand['options']>[0];
+type CommandOptions<T> = { _: string[] } & T;
+
+const getColorFn = (() => {
+  let i = 0;
+  const chalkColors = [
+    chalk.red,
+    chalk.green,
+    chalk.yellow,
+    chalk.blue,
+    chalk.magenta,
+    chalk.cyan,
+    chalk.white,
+    chalk.blackBright,
+    chalk.redBright,
+    chalk.greenBright,
+    chalk.yellowBright,
+    chalk.blueBright,
+    chalk.magentaBright,
+    chalk.cyanBright,
+    chalk.whiteBright,
+  ];
+
+  return () => {
+    i++;
+    if (i >= chalkColors.length) {
+      i = 0;
+    }
+
+    return chalkColors[i];
+  };
+})();
+
+const addPrefix = (
+  prefix: string,
+  colorFn: (l: string) => string = (line: string) => line
+) => split2((line) => colorFn(`[${prefix}]:`) + ` ${line}\n`);
+
+function spawnAsync(
+  file: string,
+  execFileArgs: string[],
+  options: {
+    cwd: string;
+    signal: AbortSignal;
+    prefix?: string;
+  }
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(file, execFileArgs, {
+      cwd: options.cwd,
+      signal: options.signal,
+      stdio: ['inherit', 'pipe', 'pipe'],
+    });
+
+    let childOut = child.stdout;
+    let childErr = child.stderr;
+
+    if (options.prefix) {
+      const colorFn = getColorFn();
+      childOut = childOut.pipe(addPrefix(options.prefix, colorFn));
+      childErr = childErr.pipe(addPrefix(`${options.prefix}!`, colorFn));
+    }
+
+    childOut.pipe(process.stdout);
+    childErr.pipe(process.stderr);
+
+    child.on('error', (error) => {
+      reject(error);
+    });
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${file} exited with code ${code ? code : '?'}`));
+      }
+    });
+  });
+}
+
+const filterOptions: YargsOptionDefinition = {
+  workspace: {
+    alias: ['w', 'scope'],
+    type: 'array',
+    describe: 'Packages to include, defaults to all packages',
+  },
+  ignore: {
+    type: 'array',
+    describe: 'Packages to exclude',
+  },
+  private: {
+    type: 'array',
+    default: true,
+    describe: 'Whether to include private packages',
+  },
+  'include-dependencies': {
+    type: 'boolean',
+    default: false,
+    describe: 'Whether to include dependencies',
+  },
+  'include-dependents': {
+    type: 'boolean',
+    default: false,
+    describe: 'Whether to include dependents',
+  },
+  where: {
+    type: 'string',
+    describe:
+      'Filter packages with an js expression that uses package.json properties as global variables. Example: --where="devDependencies[\'webpack\'].startsWith("^3")"',
+  },
+  since: {
+    type: 'string',
+    describe: 'Include only packages changed since a specific commit',
+  },
+};
+
+const execOptions: YargsOptionDefinition = {
+  bail: {
+    type: 'boolean',
+    default: true,
+    describe: 'Whether to bail on error',
+  },
+  parallel: {
+    type: 'boolean',
+    default: true,
+    describe: 'Whether to run in parallel',
+  },
+  prefix: {
+    type: 'boolean',
+    default: true,
+    describe: 'Whether to prefix the output with the package name',
+  },
+};
+
+type ExecOptions = {
+  bail: boolean;
+  parallel: boolean;
+  prefix: boolean;
+  script?: string;
+};
+
+type FilterOptions = {
+  workspace?: string[];
+  includeDependencies: boolean;
+  includeDependents: boolean;
+  where?: string;
+  since?: string;
+  ignore?: string[];
+  private: boolean;
+};
+
+async function handleExecCommand(
+  cliOptions: CommandOptions<FilterOptions & ExecOptions>
+) {
+  const spawnCommand = cliOptions._[0];
+  if (!spawnCommand || typeof spawnCommand !== 'string') {
+    throw new Error('no command provided');
+  }
+
+  const spawnArgs: string[] = cliOptions._.slice(1);
+
+  const monorepoRoot = await findMonorepoRoot();
+
+  const packages = await getPackagesInTopologicalOrder(monorepoRoot, {
+    include: cliOptions.workspace || [],
+    exclude: cliOptions.ignore || [],
+    excludePrivate: !cliOptions.private,
+    since: cliOptions.since,
+    includeDependencies: cliOptions.includeDependencies,
+    includeDependents: cliOptions.includeDependents,
+    where: cliOptions.where,
+  });
+
+  const abortController = new AbortController();
+
+  const execOnePackage = async (packageInfo: PackageInfo) => {
+    // only execute `run` scripts if present
+    if (
+      cliOptions.script &&
+      !(cliOptions.script in packageInfo.packageJson.scripts ?? {})
+    ) {
+      return;
+    }
+
+    return await spawnAsync(spawnCommand, spawnArgs, {
+      cwd: packageInfo.location,
+      signal: abortController.signal,
+      prefix: cliOptions.prefix ? packageInfo.name : undefined,
+    });
+  };
+
+  if (cliOptions.parallel) {
+    const promises = packages.map(execOnePackage);
+
+    if (cliOptions.bail) {
+      await Promise.all(promises).catch((e) => {
+        abortController.abort();
+        return Promise.reject(e);
+      });
+    } else {
+      const results = await Promise.allSettled(promises);
+      if (results.some((res) => res.status === 'rejected')) {
+        process.exit(1);
+      }
+    }
+  } else {
+    let failed = false;
+    for (const pkg of packages) {
+      try {
+        await execOnePackage(pkg);
+      } catch (e) {
+        failed = true;
+        if (cliOptions.bail) {
+          break;
+        }
+      }
+    }
+
+    if (failed) {
+      process.exit(1);
+    }
+  }
+}
+
+async function handleLsCommand(cliOptions: CommandOptions<FilterOptions>) {
+  const monorepoRoot = await findMonorepoRoot();
+
+  const packages = await getPackagesInTopologicalOrder(monorepoRoot, {
+    include: cliOptions.workspace || [],
+    exclude: cliOptions.ignore || [],
+    excludePrivate: !cliOptions.private,
+    since: cliOptions.since,
+    includeDependencies: cliOptions.includeDependencies,
+    includeDependents: cliOptions.includeDependents,
+    where: cliOptions.where,
+  });
+
+  for (const info of packages) {
+    console.info(info.name);
+  }
+}
+
+async function main() {
+  // strips the command name from the `_` array, converts any positional argument to a string
+  // and return the parsed options as CommandOptions type
+  const toCommandOptions = <T>(opts: { _: (string | number)[] }) => {
+    return {
+      ...opts,
+      _: opts._.slice(1).map((x) => `${x}`),
+    } as unknown as CommandOptions<T>;
+  };
+
+  await yargs(hideBin(process.argv))
+    .command('ls', 'List all the packages matching filters.', {
+      builder: (command: YargsCommand) => {
+        return command.options({ ...filterOptions, ...execOptions });
+      },
+      handler: (args) => handleLsCommand(toCommandOptions<FilterOptions>(args)),
+    })
+    .command(
+      'run <script>',
+      'Run an npm script in each package that contains that script. Pass any argument after --.',
+      {
+        builder: (command: YargsCommand) => {
+          return command.options({ ...filterOptions, ...execOptions });
+        },
+        handler: (args) => {
+          const commandOptions = toCommandOptions<
+            FilterOptions & ExecOptions & { script: string }
+          >(args);
+
+          return handleExecCommand({
+            ...commandOptions,
+            _: ['npm', 'run', commandOptions.script, ...commandOptions._],
+          });
+        },
+      }
+    )
+    .command(
+      'exec',
+      'Execute an arbitrary command in each package. Pass the command and any argument after --.',
+      {
+        builder: (command: YargsCommand) => {
+          return command.options({ ...filterOptions, ...execOptions });
+        },
+        handler: (args) =>
+          handleExecCommand(
+            toCommandOptions<FilterOptions & ExecOptions>(args)
+          ),
+      }
+    )
+    .strict()
+    .demandCommand(1)
+    .help()
+    .showHelpOnFail(false)
+    .parseAsync();
+}
+
+process.on('unhandledRejection', (err: Error) => {
+  console.error();
+  console.error(err?.stack || err?.message || err);
+  process.exitCode = 1;
+});
+
+main().catch((err) =>
+  process.nextTick(() => {
+    throw err;
+  })
+);

--- a/packages/monorepo-tools/src/utils/get-packages-in-topological-order.spec.ts
+++ b/packages/monorepo-tools/src/utils/get-packages-in-topological-order.spec.ts
@@ -1,0 +1,264 @@
+import { execFile as execFileCb } from 'child_process';
+import { promisify } from 'util';
+import path from 'path';
+import { promises as fs } from 'fs';
+import os from 'os';
+import { getPackagesInTopologicalOrder } from './get-packages-in-topological-order';
+import assert from 'assert';
+
+const execFile = promisify(execFileCb);
+
+describe('getPackagesInTopologicalOrder', function () {
+  let tempDir: string;
+  let remoteDir;
+  let repoPath: string;
+
+  const writeRepoFile = async (filePath: string, content: any) => {
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(
+      path.join(repoPath, filePath),
+      typeof content === 'string' ? content : JSON.stringify(content, null, 2)
+    );
+  };
+
+  beforeEach(async function () {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'monorepo-tests-'));
+
+    // create fake git remote:
+    remoteDir = path.resolve(tempDir, 'remote');
+    await fs.mkdir(remoteDir, { recursive: true });
+    process.chdir(remoteDir);
+    await execFile('git', ['init', '--bare']);
+    await execFile('git', ['config', '--local', 'user.name', 'user']);
+    await execFile('git', [
+      'config',
+      '--local',
+      'user.email',
+      'user@example.com',
+    ]);
+
+    // setup repo and package:
+    repoPath = path.resolve(tempDir, 'monorepo-test-repo');
+    await fs.mkdir(repoPath, { recursive: true });
+    process.chdir(repoPath);
+
+    await execFile('npm', ['init', '-y']);
+
+    const packageJsonPath = path.join(repoPath, 'package.json');
+    const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+
+    await fs.writeFile(
+      packageJsonPath,
+      JSON.stringify({ ...packageJson, workspaces: ['packages/*'] }, null, 2)
+    );
+
+    await writeRepoFile('packages/pkg1/package.json', {
+      name: 'pkg1',
+      version: '0.1.0',
+      dependencies: {
+        pkg2: '0.1.0',
+      },
+    });
+
+    await writeRepoFile('packages/pkg2/package.json', {
+      name: 'pkg2',
+      version: '0.1.0',
+      dependencies: {
+        pkg3: '0.1.0',
+      },
+      private: true,
+    });
+
+    await writeRepoFile('packages/pkg3/package.json', {
+      name: 'pkg3',
+      version: '0.1.0',
+    });
+
+    await execFile('npm', ['install']); // generates package-lock.json
+  });
+
+  // eslint-disable-next-line mocha/no-sibling-hooks
+  afterEach(async function () {
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    } catch (e) {
+      // windows fails to clean those up sometimes, let's just skip it and move
+      // forward with runnning the tests
+    }
+  });
+
+  it('returns packages toposorted', async function () {
+    const packages = await getPackagesInTopologicalOrder(repoPath);
+
+    assert.deepStrictEqual(
+      packages.map((p) => p.name),
+      ['pkg3', 'pkg2', 'pkg1']
+    );
+  });
+
+  it('include dependencies', async function () {
+    const packages = await getPackagesInTopologicalOrder(repoPath, {
+      include: ['pkg2'],
+      includeDependencies: true,
+    });
+
+    assert.deepStrictEqual(
+      packages.map((p) => p.name),
+      ['pkg3', 'pkg2']
+    );
+  });
+
+  it('include dependents', async function () {
+    const packages = await getPackagesInTopologicalOrder(repoPath, {
+      include: ['pkg2'],
+      includeDependents: true,
+    });
+
+    assert.deepStrictEqual(
+      packages.map((p) => p.name),
+      ['pkg2', 'pkg1']
+    );
+  });
+
+  it('ignore excluded packages', async function () {
+    const packages = await getPackagesInTopologicalOrder(repoPath, {
+      include: ['pkg2'],
+      exclude: ['pkg1'],
+      includeDependents: true,
+    });
+
+    assert.deepStrictEqual(
+      packages.map((p) => p.name),
+      ['pkg2']
+    );
+  });
+
+  it('ignore private packages with excludePrivate', async function () {
+    const packages = await getPackagesInTopologicalOrder(repoPath, {
+      include: ['pkg2'],
+      includeDependents: true,
+      excludePrivate: true,
+    });
+
+    assert.deepStrictEqual(
+      packages.map((p) => p.name),
+      ['pkg1']
+    );
+  });
+
+  it('filter packages with where', async function () {
+    const packages = await getPackagesInTopologicalOrder(repoPath, {
+      where: 'name === "pkg1"',
+    });
+
+    assert.deepStrictEqual(
+      packages.map((p) => p.name),
+      ['pkg1']
+    );
+  });
+
+  describe('since', function () {
+    beforeEach(async function () {
+      await execFile('git', ['init']);
+      await execFile('git', ['config', '--local', 'user.name', 'user']);
+      await execFile('git', [
+        'config',
+        '--local',
+        'user.email',
+        'user@example.com',
+      ]);
+      await execFile('git', ['checkout', '-b', 'main']);
+      await execFile('git', ['remote', 'add', 'origin', remoteDir]);
+      await execFile('git', ['add', '.']);
+      await execFile('git', ['commit', '-am', 'init']);
+      await execFile('git', ['push', '--set-upstream', 'origin', 'main']);
+    });
+    it('returns empty if nothing changed', async function () {
+      const packages = await getPackagesInTopologicalOrder(repoPath, {
+        since: 'HEAD',
+      });
+
+      assert.deepStrictEqual(
+        packages.map((p) => p.name),
+        []
+      );
+    });
+
+    it('returns packages with untracked files', async function () {
+      await writeRepoFile('packages/pkg1/index.js', '');
+
+      const packages = await getPackagesInTopologicalOrder(repoPath, {
+        since: 'HEAD',
+      });
+
+      assert.deepStrictEqual(
+        packages.map((p) => p.name),
+        ['pkg1']
+      );
+    });
+
+    it('returns packages with staged files', async function () {
+      await writeRepoFile('packages/pkg1/index.js', '');
+
+      await execFile('git', ['add', '.'], { cwd: repoPath });
+
+      const packages = await getPackagesInTopologicalOrder(repoPath, {
+        since: 'HEAD',
+      });
+
+      assert.deepStrictEqual(
+        packages.map((p) => p.name),
+        ['pkg1']
+      );
+    });
+
+    it('returns packages with committed files changed', async function () {
+      await writeRepoFile('packages/pkg1/index.js', '');
+
+      await execFile('git', ['add', '.'], { cwd: repoPath });
+      await execFile('git', ['commit', '-m', 'add one file'], {
+        cwd: repoPath,
+      });
+
+      const packages = await getPackagesInTopologicalOrder(repoPath, {
+        since: 'HEAD~1',
+      });
+
+      assert.deepStrictEqual(
+        packages.map((p) => p.name),
+        ['pkg1']
+      );
+    });
+
+    it('returns packages with staged changes', async function () {
+      await writeRepoFile('packages/pkg1/index.js', '');
+
+      await execFile('git', ['add', '.'], { cwd: repoPath });
+      await execFile('git', ['commit', '-m', 'add one file'], {
+        cwd: repoPath,
+      });
+
+      assert.deepStrictEqual(
+        (
+          await getPackagesInTopologicalOrder(repoPath, {
+            since: 'HEAD',
+          })
+        ).map((p) => p.name),
+        [] // HEAD should be 'add one file', so no changes
+      );
+
+      await writeRepoFile('packages/pkg1/index.js', 'change');
+
+      await execFile('git', ['add', '.'], { cwd: repoPath });
+
+      assert.deepStrictEqual(
+        (
+          await getPackagesInTopologicalOrder(repoPath, {
+            since: 'HEAD',
+          })
+        ).map((p) => p.name),
+        ['pkg1']
+      );
+    });
+  });
+});

--- a/packages/monorepo-tools/src/utils/get-packages-in-topological-order.ts
+++ b/packages/monorepo-tools/src/utils/get-packages-in-topological-order.ts
@@ -2,47 +2,241 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { glob } from 'glob';
 import toposort from 'toposort';
+import depthFirst from 'depth-first';
+import { runInContext, createContext } from 'vm';
 
-interface InternalPackageInfo {
-  name: string;
-  location: string;
-  packageJson: Record<string, any>;
-}
+import { execFile as execFileCb } from 'child_process';
+import { promisify } from 'util';
+const execFile = promisify(execFileCb);
 
 export interface PackageInfo {
   name: string;
   location: string;
   version: string;
   private: boolean;
+  rootDir: string;
+  packageJson: Record<string, any>;
+}
+
+function packageListArgAsSet(
+  list: string[] | undefined,
+  packageNames: Set<string>
+) {
+  list = list || [];
+  const unknown = list.filter((name) => !packageNames.has(name));
+
+  if (unknown.length) {
+    throw new Error(`Unknown workspaces: ${unknown.join(', ')}`);
+  }
+
+  return new Set(list);
 }
 
 export async function getPackagesInTopologicalOrder(
-  cwd: string
+  cwd: string,
+  options?: {
+    include?: string[];
+    exclude?: string[];
+    excludePrivate?: boolean;
+    since?: string;
+    includeDependencies?: boolean;
+    includeDependents?: boolean;
+    where?: string;
+  }
 ): Promise<PackageInfo[]> {
-  const patterns: string[] =
-    JSON.parse(await fs.readFile(path.join(cwd, `package.json`), 'utf8'))
-      .workspaces || [];
+  const internalPackages: PackageInfo[] = await getMonorepoPackages(cwd);
 
-  const packageJsonPaths = await glob(
-    patterns.map((pattern) => path.join(pattern, 'package.json'))
+  const allPackageNames = new Set(internalPackages.map((pkg) => pkg.name));
+  const includeSet = packageListArgAsSet(options?.include, allPackageNames);
+  const excludeSet = packageListArgAsSet(options?.exclude, allPackageNames);
+
+  // Scopes is a set of workspaces to include in the result.
+  // The scopes set is used to filter the toposorted array of packages, hence if a workspace
+  // is not present in the scopes it will not be included.
+  //
+  // The list of scopes is built starting from the workspaces specified as "include",
+  // or with all the workspaces if none has been passed.
+  //
+  // This list is then restricted to the packages matching the `where` expression if one is passed and
+  // then the changed workspaces if `since` is passed,
+  // and is then augmented with dependencies and dependents if includeDependencies and includeDependents
+  // are set.
+  // Finally excluded packages (and private packages if excludePrivate is true) are removed from the scopes.
+  //
+  // For example with {workspace: [A, B], since: 'HEAD', includeDependencies: true}, where A has changes since HEAD:
+  // It will start with [A, B], reduce the scopes to [A] and then include all the dependencies of A.
+  //
+  // This allows us to implement a command as such, which re-compiles `core-util` and all its dependents
+  // only if `core-util` has changed:
+  //
+  // monorepo run compile --workspace core-util --since HEAD --include-dependents
+  //
+  // NOTE: this mimics lerna behavior but with some key differences:
+  // - Same as lerna: dependents/dependencies of the packages included or found through `since` (and in this case also `where`) are always
+  // added to the result if includeDependencies and includeDependents are passed, so since doesn't apply to dependencies.
+  // - Difference 1: `includeDependents` must be set explicitly with `since`: an excludeDependents option is not necessary.
+  // - Difference 2: unlike lerna's `--ignore` excluded packages are always removed from the result set.
+  const scopes = includeSet.size ? includeSet : allPackageNames;
+
+  // if where is specified restrict the scopes to matching packages
+  if (options?.where) {
+    const matchingPackages = filterWhere(internalPackages, options?.where);
+    for (const scope of Array.from(scopes)) {
+      if (!matchingPackages.has(scope)) {
+        scopes.delete(scope);
+      }
+    }
+  }
+
+  // if since is specified restrict the scopes to changed packages
+  if (options?.since) {
+    const changedPackages = await filterSince(
+      cwd,
+      { since: options?.since },
+      internalPackages
+    );
+    for (const scope of Array.from(scopes)) {
+      if (!changedPackages.has(scope)) {
+        scopes.delete(scope);
+      }
+    }
+  }
+
+  const edges: [string, string][] = getEdgeList(internalPackages);
+
+  // if includeDependencies is specified augment the scopes with dependents
+  if (options?.includeDependencies) {
+    getDependencies(Array.from(scopes), edges).forEach((dep) =>
+      scopes.add(dep)
+    );
+  }
+
+  // if includeDependents is specified augment the scopes with dependencies
+  if (options?.includeDependents) {
+    getDependents(Array.from(scopes), edges).forEach((dep) => scopes.add(dep));
+  }
+
+  return (
+    // the result is constructed by filtering the toposorted list of packages
+    // so to return only the packages that are present in the scopes in topological order.
+    toposort(edges)
+      .slice(1) // remove .root
+      .reverse()
+      // filter scopes
+      .filter((packageName) => scopes.has(packageName))
+      // remove excluded
+      .filter((packageName) => !excludeSet.has(packageName))
+      .map((packageName) => {
+        const pkg = internalPackages.find((p) => p.name === packageName);
+
+        if (!pkg) {
+          // results are filtered with scopes and scopes are validated to be
+          // internalPackages, this situation should never occur.
+          throw new Error(
+            `Unexpected: could not find ${packageName} in results.`
+          );
+        }
+
+        return pkg;
+      })
+      // remove private packages if excludePrivate
+      .filter((packageInfo) => {
+        return options?.excludePrivate ? !packageInfo.private : true;
+      })
+      .filter(Boolean)
+  );
+}
+
+function isSubPath(parentPath: string, childPath: string) {
+  const relative = path.relative(parentPath, childPath);
+  return !!relative && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+async function filterSince(
+  monorepoRoot: string,
+  cliOptions: { since: string },
+  packages: PackageInfo[]
+): Promise<Set<string>> {
+  const execGit = (...args: string[]) =>
+    execFile('git', ['--no-pager', ...args], { cwd: monorepoRoot }).then(
+      ({ stdout }) => stdout
+    );
+
+  // changes up to the HEAD of the current branch
+  const changesTillHead = await execGit(
+    'log',
+    '--name-only',
+    '--pretty=', // remove commit info, so only file names are present in the output
+    `${cliOptions.since}..HEAD`
   );
 
-  const internalPackages: InternalPackageInfo[] = await Promise.all(
-    packageJsonPaths.map(async (packageJsonPath) => {
-      const packageJson = JSON.parse(
-        await fs.readFile(packageJsonPath, 'utf8')
-      );
-      return {
-        name: packageJson.name,
-        location: packageJsonPath,
-        packageJson,
-      };
-    })
+  // Anything that has changed since the HEAD of the current branch is always included:
+  const staged = await execGit('diff', '--name-only', '--cached');
+  const unstaged = await execGit('diff', '--name-only');
+  const untracked = await execGit('ls-files', '--others', '--exclude-standard');
+
+  const anyChange = Array.from(
+    new Set(
+      [changesTillHead, staged, unstaged, untracked]
+        .map((out) => out.split('\n'))
+        .flat()
+        .filter((line) => line)
+        .map((line) => line.trim())
+        .map((line) => path.resolve(monorepoRoot, line))
+    )
   );
 
-  const edges: [string, string][] = [];
+  const changedPackages = new Set<string>();
+
+  for (const change of anyChange) {
+    const changedPackage = packages.find((p) => {
+      return isSubPath(p.location, change);
+    });
+
+    if (changedPackage) {
+      changedPackages.add(changedPackage.name);
+    }
+  }
+
+  return changedPackages;
+}
+
+function filterWhere(packages: PackageInfo[], expression: string): Set<string> {
+  const filtered = new Set<string>();
+
+  for (const pkg of packages) {
+    try {
+      if (runInContext(expression, createContext(pkg.packageJson)))
+        filtered.add(pkg.name);
+    } catch {
+      /* skip */
+    }
+  }
+
+  return filtered;
+}
+
+function getDependents(
+  scopes: string[],
+  edges: PackagesTreeEdgeList
+): string[] {
+  return scopes
+    .map((scope) => depthFirst(edges, scope, { reverse: true }))
+    .flat();
+}
+
+function getDependencies(
+  scopes: string[],
+  edges: PackagesTreeEdgeList
+): string[] {
+  return scopes.map((scope) => depthFirst(edges, scope)).flat();
+}
+
+type PackagesTreeEdgeList = [string, string][];
+
+function getEdgeList(internalPackages: PackageInfo[]): PackagesTreeEdgeList {
   const packageNames = new Set(internalPackages.map((p) => p.name));
-
+  const edges: [string, string][] = [];
   for (const internalPackage of internalPackages) {
     const anyInternalDependency = Object.keys({
       ...(internalPackage.packageJson?.dependencies || {}),
@@ -59,20 +253,32 @@ export async function getPackagesInTopologicalOrder(
       }
     }
   }
+  return edges;
+}
 
-  const sorted = toposort(edges).slice(1).reverse();
+async function getMonorepoPackages(cwd: string) {
+  const patterns: string[] =
+    JSON.parse(await fs.readFile(path.join(cwd, `package.json`), 'utf8'))
+      .workspaces || [];
 
-  const result = sorted
-    .map((packageName) => internalPackages.find((p) => p.name === packageName))
-    .map((packageInfo) => {
-      if (!packageInfo) throw new Error('unreachable');
+  const packageJsonPaths = await glob(
+    patterns.map((pattern) => path.join(pattern, 'package.json'))
+  );
+
+  const info: PackageInfo[] = await Promise.all(
+    packageJsonPaths.map(async (packageJsonPath) => {
+      const packageJson = JSON.parse(
+        await fs.readFile(packageJsonPath, 'utf8')
+      );
       return {
-        name: packageInfo.name,
-        version: packageInfo.packageJson.version,
-        private: !!packageInfo.packageJson.private,
-        location: path.resolve(path.dirname(packageInfo.location)),
+        name: packageJson.name,
+        version: packageJson.version,
+        location: path.resolve(cwd, path.dirname(packageJsonPath)),
+        private: !!packageJson.private,
+        packageJson,
+        rootDir: cwd,
       };
-    });
-
-  return result;
+    })
+  );
+  return info;
 }

--- a/packages/monorepo-tools/src/utils/list-all-packages.ts
+++ b/packages/monorepo-tools/src/utils/list-all-packages.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import type { PackageInfo } from './get-packages-in-topological-order';
 import { getPackagesInTopologicalOrder } from './get-packages-in-topological-order';
 import { findMonorepoRoot } from './find-monorepo-root';
@@ -9,11 +8,6 @@ export async function* listAllPackages(): AsyncIterable<
   const monorepoRoot = await findMonorepoRoot();
   const packages = await getPackagesInTopologicalOrder(monorepoRoot);
   for (const packageInfo of packages) {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const packageJson = require(path.join(
-      packageInfo.location,
-      'package.json'
-    ));
-    yield { rootDir: monorepoRoot, packageJson, ...packageInfo };
+    yield packageInfo;
   }
 }


### PR DESCRIPTION
@lerouxb not sure if this is too much, the filter part in getPackagesByTopology is probably ok, since we are maintaining it already the added code + tests doesn't seem to be overwhelming, but do we want to have an actual lerna replacement? or something like  `monorepo-packages | xargs xargs -I{} npm run -w {}` (if it works everywhere)