### PR TITLE
chore(mongodb-constants): export types for filter function

### DIFF
--- a/packages/mongodb-constants/src/filter.ts
+++ b/packages/mongodb-constants/src/filter.ts
@@ -32,8 +32,6 @@ export type Meta =
  * Our completions are a mix of ace autocompleter types and some custom values
  * added on top, this interface provides a type definition for all required
  * properties that completer is using
- *
- * @internal
  */
 export type Completion = {
   value: string;

--- a/packages/mongodb-constants/src/index.ts
+++ b/packages/mongodb-constants/src/index.ts
@@ -10,3 +10,7 @@ export * from './query-operators';
 export * from './stage-operators';
 export * from './system-variables';
 export { getFilteredCompletions, wrapField } from './filter';
+export type {
+  Completion,
+  FilterOptions as CompletionFilterOptions,
+} from './filter';


### PR DESCRIPTION
Just so we can use them easier in Compass