### PR TITLE
chore(mongodb-constants): fix constants type

### DIFF
--- a/packages/mongodb-constants/src/filter.ts
+++ b/packages/mongodb-constants/src/filter.ts
@@ -69,7 +69,7 @@ export type FilterOptions = {
   /**
    * Filter completions by completion category
    */
-  meta?: (Meta | 'field:*' | 'accumulator:*' | 'expr:*')[];
+  meta?: (Meta | 'field:*' | 'accumulator:*' | 'expr:*' | 'variable:*')[];
   /**
    * Stage-only filters
    */

--- a/packages/mongodb-constants/src/system-variables.ts
+++ b/packages/mongodb-constants/src/system-variables.ts
@@ -90,6 +90,6 @@ const SYSTEM_VARIABLES = [
     description:
       'A variable that stores the role names of the authenticated user running the command.',
   },
-];
+] as const;
 
 export { SYSTEM_VARIABLES };


### PR DESCRIPTION
Noticed when trying to do an update of the verison, the types are broken because a non-const value was added to the constants array, this in particular breaks meta type assertion with typescript