### PR TITLE
fix(mongodb-constants): fix regexp that picks valid part of semver version

### DIFF
--- a/packages/mongodb-constants/src/filter.spec.ts
+++ b/packages/mongodb-constants/src/filter.spec.ts
@@ -14,6 +14,16 @@ describe('completer', function () {
       version: '>=2.0.0 <3.0.0 || >=3.5.0',
       meta: 'expr:set',
     },
+    {
+      value: 'woof',
+      version: '>=0.200.300 <0.200.301',
+      meta: 'accumulator',
+    },
+    {
+      value: 'honk',
+      version: '999.999.999',
+      meta: 'variable:system',
+    },
   ];
 
   function getFilteredValues(
@@ -30,7 +40,13 @@ describe('completer', function () {
       'Foo',
       'bar',
     ]);
-    expect(getFilteredValues({ serverVersion: '0.0.1-alpha0' })).to.deep.eq([
+  });
+
+  it('should clean up version before comparing', function () {
+    expect(getFilteredValues({ serverVersion: '0.200.300-alpha0' })).to.deep.eq(
+      ['foo', 'Foo', 'woof']
+    );
+    expect(getFilteredValues({ serverVersion: '0.0.0---what???' })).to.deep.eq([
       'foo',
       'Foo',
     ]);
@@ -44,14 +60,18 @@ describe('completer', function () {
     );
   });
 
-  it('should ignore version when version is not valid', function () {
-    expect(getFilteredValues({ serverVersion: '1' })).to.deep.eq([
+  it('should use default version when provided version is not valid', function () {
+    expect(
+      getFilteredValues({ serverVersion: 'one dot one dot zero' })
+    ).to.deep.eq(['foo', 'Foo', 'bar', 'buz', 'barbar', 'meow', 'honk']);
+    expect(getFilteredValues({ serverVersion: '1.2' })).to.deep.eq([
       'foo',
       'Foo',
       'bar',
       'buz',
       'barbar',
       'meow',
+      'honk',
     ]);
   });
 

--- a/packages/mongodb-constants/src/filter.spec.ts
+++ b/packages/mongodb-constants/src/filter.spec.ts
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
 import type { Completion } from './filter';
-import { wrapField, getFilteredCompletions } from './filter';
+import { wrapField, getFilteredCompletions, ALL_CONSTANTS } from './filter';
+import semver from 'semver';
+import util from 'util';
 
 describe('completer', function () {
   const simpleConstants: Completion[] = [
@@ -188,6 +190,23 @@ describe('completer', function () {
       expect(wrapField('quotes"in"the"middle')).to.eq(
         '"quotes\\"in\\"the\\"middle"'
       );
+    });
+  });
+
+  describe('all completions', function () {
+    it('should have valid semver version or range specified', function () {
+      ALL_CONSTANTS.forEach(({ name, version }) => {
+        const errMessage = `Expected completion ${util.inspect({
+          name,
+          version,
+        })} to have valid version`;
+
+        try {
+          expect(semver.valid(version)).to.not.eq(null, errMessage);
+        } catch {
+          expect(semver.validRange(version)).to.not.eq(null, errMessage);
+        }
+      });
     });
   });
 });

--- a/packages/mongodb-constants/src/filter.ts
+++ b/packages/mongodb-constants/src/filter.ts
@@ -9,7 +9,7 @@ import { QUERY_OPERATORS } from './query-operators';
 import { STAGE_OPERATORS } from './stage-operators';
 import { SYSTEM_VARIABLES } from './system-variables';
 
-const ALL_CONSTANTS = [
+export const ALL_CONSTANTS = [
   ...ACCUMULATORS,
   ...BSON_TYPES,
   ...BSON_TYPE_ALIASES,

--- a/packages/mongodb-constants/src/filter.ts
+++ b/packages/mongodb-constants/src/filter.ts
@@ -111,7 +111,7 @@ function isIn<T extends string | number>(
  * @param v2 Either a single version number or a range to match against
  */
 function satisfiesVersion(v1: string, v2: string): boolean {
-  const isGTECheck = /^\d+?\.\d+?\.\d+?$/.test(v2);
+  const isGTECheck = /^\d+\.\d+\.\d+$/.test(v2);
   return satisfies(v1, isGTECheck ? `>=${v2}` : v2);
 }
 
@@ -123,7 +123,7 @@ export function createConstantFilter({
   completion: Completion
 ) => boolean {
   const currentServerVersion =
-    /^(?<version>\d+?\.\d+?\.\d+?)/.exec(serverVersion)?.groups?.version ??
+    /^(?<version>\d+\.\d+\.\d+)/.exec(serverVersion)?.groups?.version ??
     // Fallback to default server version if provided version doesn't match
     // regex so that semver doesn't throw when checking
     DEFAULT_SERVER_VERSION;


### PR DESCRIPTION
The regex that we used to clean up current server version was only picking up a single number from the patch version because of the unnecessary `?` usage. Seems like we had this bug for awhile now, even before we moved all this logic to this package, just never noticed or got reports before, I noticed this only now when testing `$vectorSearch` stage

Also @mcasimir asked to add tests for version as we specify it in constants, added it in the same patch as a drive-by