### PR TITLE
fix(mongodb-constants): fix property name in types and filter function

### DIFF
--- a/packages/mongodb-constants/src/filter.spec.ts
+++ b/packages/mongodb-constants/src/filter.spec.ts
@@ -97,7 +97,7 @@ describe('completer', function () {
         version: '0.0.0',
         meta: 'stage',
         env: ['adl'],
-        namespace: ['database'],
+        namespaces: ['database'],
         apiVersions: [],
       },
       {
@@ -105,7 +105,7 @@ describe('completer', function () {
         version: '0.0.0',
         meta: 'stage',
         env: ['on-prem'],
-        namespace: ['collection'],
+        namespaces: ['collection'],
         apiVersions: [],
       },
       {
@@ -113,7 +113,7 @@ describe('completer', function () {
         version: '0.0.0',
         meta: 'stage',
         env: ['atlas'],
-        namespace: ['timeseries'],
+        namespaces: ['timeseries'],
         apiVersions: [1],
       },
     ];

--- a/packages/mongodb-constants/src/filter.ts
+++ b/packages/mongodb-constants/src/filter.ts
@@ -42,7 +42,7 @@ export type Completion = {
   snippet?: string;
   score?: number;
   env?: string[];
-  namespace?: string[];
+  namespaces?: string[];
   apiVersions?: number[];
   outputStage?: boolean;
   fullScan?: boolean;
@@ -127,11 +127,17 @@ export function createConstantFilter({
     // Fallback to default server version if provided version doesn't match
     // regex so that semver doesn't throw when checking
     DEFAULT_SERVER_VERSION;
-  return ({ version: minServerVersion, meta, env, namespace, apiVersions }) => {
+  return ({
+    version: minServerVersion,
+    meta,
+    env,
+    namespaces,
+    apiVersions,
+  }) => {
     return (
       satisfiesVersion(currentServerVersion, minServerVersion) &&
       isIn(filterStage.env, env) &&
-      isIn(filterStage.namespace, namespace) &&
+      isIn(filterStage.namespace, namespaces) &&
       isIn(filterStage.apiVersion, apiVersions) &&
       (!filterMeta || matchesMeta(filterMeta, meta))
     );


### PR DESCRIPTION
While the issue is that the variable name was misspelled, I feel like the root cause is that getting a generic type out of those completion constants is hard and so we had to just manually write a catch-all type for completions. If someone has ideas how to type this package better, please tell!