### PR TITLE
chore(saslprep): skip codepoint generation in CI

### DIFF
--- a/packages/saslprep/package.json
+++ b/packages/saslprep/package.json
@@ -42,7 +42,6 @@
     "gen-code-points": "ts-node src/generate-code-points.ts src/code-points-data.ts",
     "bootstrap": "npm run compile",
     "prepublishOnly": "npm run compile",
-    "//": "TODO(COMPASS-7555): fix codepoint generation",
     "compile": "npm run gen-code-points && tsc -p tsconfig.json && gen-esm-wrapper . ./dist/.esm-wrapper.mjs",
     "typecheck": "tsc --noEmit",
     "eslint": "eslint",

--- a/packages/saslprep/package.json
+++ b/packages/saslprep/package.json
@@ -42,7 +42,7 @@
     "gen-code-points": "ts-node src/generate-code-points.ts src/code-points-data.ts",
     "bootstrap": "npm run compile",
     "prepublishOnly": "npm run compile",
-    "//": "TODO(..): fix codepoint generation",
+    "//": "TODO(COMPASS-7555): fix codepoint generation",
     "compile": "SKIP_GENERATE_CODEPOINTS=true npm run gen-code-points && tsc -p tsconfig.json && gen-esm-wrapper . ./dist/.esm-wrapper.mjs",
     "typecheck": "tsc --noEmit",
     "eslint": "eslint",

--- a/packages/saslprep/package.json
+++ b/packages/saslprep/package.json
@@ -43,7 +43,7 @@
     "bootstrap": "npm run compile",
     "prepublishOnly": "npm run compile",
     "//": "TODO(COMPASS-7555): fix codepoint generation",
-    "compile": "SKIP_GENERATE_CODEPOINTS=true npm run gen-code-points && tsc -p tsconfig.json && gen-esm-wrapper . ./dist/.esm-wrapper.mjs",
+    "compile": "npm run gen-code-points && tsc -p tsconfig.json && gen-esm-wrapper . ./dist/.esm-wrapper.mjs",
     "typecheck": "tsc --noEmit",
     "eslint": "eslint",
     "prettier": "prettier",

--- a/packages/saslprep/package.json
+++ b/packages/saslprep/package.json
@@ -39,10 +39,11 @@
   },
   "types": "./dist/index.d.ts",
   "scripts": {
-    "gen-code-points": "ts-node src/generate-code-points.ts > src/code-points-data.ts",
+    "gen-code-points": "ts-node src/generate-code-points.ts src/code-points-data.ts",
     "bootstrap": "npm run compile",
     "prepublishOnly": "npm run compile",
-    "compile": "npm run gen-code-points && tsc -p tsconfig.json && gen-esm-wrapper . ./dist/.esm-wrapper.mjs",
+    "//": "TODO(..): fix codepoint generation",
+    "compile": "SKIP_GENERATE_CODEPOINTS=true npm run gen-code-points && tsc -p tsconfig.json && gen-esm-wrapper . ./dist/.esm-wrapper.mjs",
     "typecheck": "tsc --noEmit",
     "eslint": "eslint",
     "prettier": "prettier",

--- a/packages/saslprep/src/generate-code-points.ts
+++ b/packages/saslprep/src/generate-code-points.ts
@@ -3,6 +3,11 @@ import bitfield from 'sparse-bitfield';
 import * as codePoints from './code-points-src';
 import { createWriteStream } from 'fs';
 
+if (!process.env.GENERATE_CODE_POINTS) {
+  process.exitCode = 0;
+  process.exit();
+}
+
 const unassigned_code_points = bitfield();
 const commonly_mapped_to_nothing = bitfield();
 const non_ascii_space_characters = bitfield();
@@ -41,12 +46,7 @@ memory.push(
   traverse(bidirectional_l, codePoints.bidirectional_l)
 );
 
-if (process.env.SKIP_GENERATE_CODEPOINTS) {
-  process.exitCode = 0;
-  process.exit();
-}
-
-const fsStream = createWriteStream(process.argv[1]);
+const fsStream = createWriteStream(process.argv[2]);
 fsStream.write(
   `import { gunzipSync } from 'zlib';
 

--- a/packages/saslprep/src/generate-code-points.ts
+++ b/packages/saslprep/src/generate-code-points.ts
@@ -4,6 +4,7 @@ import * as codePoints from './code-points-src';
 import { createWriteStream } from 'fs';
 
 if (!process.env.GENERATE_CODE_POINTS) {
+  // TODO(COMPASS-7555): fix codepoint generation=
   process.exitCode = 0;
   process.exit();
 }

--- a/packages/saslprep/src/generate-code-points.ts
+++ b/packages/saslprep/src/generate-code-points.ts
@@ -1,6 +1,7 @@
 import { gzipSync } from 'zlib';
 import bitfield from 'sparse-bitfield';
 import * as codePoints from './code-points-src';
+import { createWriteStream } from 'fs';
 
 const unassigned_code_points = bitfield();
 const commonly_mapped_to_nothing = bitfield();
@@ -40,7 +41,13 @@ memory.push(
   traverse(bidirectional_l, codePoints.bidirectional_l)
 );
 
-process.stdout.write(
+if (process.env.SKIP_GENERATE_CODEPOINTS) {
+  process.exitCode = 0;
+  process.exit();
+}
+
+const fsStream = createWriteStream(process.argv[1]);
+fsStream.write(
   `import { gunzipSync } from 'zlib';
 
 export default gunzipSync(


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  Use `feat`, `fix` for user facing changes that should be part of release notes.

  # Semantic Versioning:

  Package versions will be bumped automatically according to the PR title:

  - The words `BREAKING CHANGE` in the title will cause a **major** bump to all the packages changed in the PR. All dependants will also have a major bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - A subject starting with `feat` will cause a **minor** bump to all the packages changed in the PR. All dependants will also have a minor bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - Any other change to any package will cause a `patch` bump to the package and all its dependants.
-->

## Description
This PR skips the codepoint generation temporarily to unblock the Github release action from releasing other packages.

https://jira.mongodb.org/browse/COMPASS-7555 is filed to fix codepoint generation.

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Checklist
- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
