### PR TITLE
specify ssh2 as dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
         "scripts"
       ],
       "dependencies": {
-        "@mongodb-js/monorepo-tools": "^1.1.0",
-        "@mongodb-js/signing-utils": "^0.1.0"
+        "@mongodb-js/monorepo-tools": "^1.1.0"
       },
       "devDependencies": {
         "@babel/core": "^7.22.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "scripts"
       ],
       "dependencies": {
-        "@mongodb-js/monorepo-tools": "^1.1.0"
+        "@mongodb-js/monorepo-tools": "^1.1.0",
+        "@mongodb-js/signing-utils": "^0.1.0"
       },
       "devDependencies": {
         "@babel/core": "^7.22.8",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "where": "node ./scripts/src/where.js"
   },
   "dependencies": {
-    "@mongodb-js/monorepo-tools": "^1.1.0",
-    "@mongodb-js/signing-utils": "^0.1.0"
+    "@mongodb-js/monorepo-tools": "^1.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.22.8",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "where": "node ./scripts/src/where.js"
   },
   "dependencies": {
-    "@mongodb-js/monorepo-tools": "^1.1.0"
+    "@mongodb-js/monorepo-tools": "^1.1.0",
+    "@mongodb-js/signing-utils": "^0.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.22.8",

--- a/packages/signing-utils/src/signing-clients/local-signing-client.ts
+++ b/packages/signing-utils/src/signing-clients/local-signing-client.ts
@@ -49,8 +49,6 @@ export class LocalSigningClient implements SigningClient {
         );
       }
       localClientDebug(`Signed file ${file}`);
-
-      return Promise.resolve();
     } catch (error) {
       localClientDebug({ error });
       throw error;

--- a/packages/signing-utils/src/signing-clients/local-signing-client.ts
+++ b/packages/signing-utils/src/signing-clients/local-signing-client.ts
@@ -2,7 +2,6 @@ import path from 'path';
 import { spawnSync } from 'child_process';
 import { debug, getEnv } from '../utils';
 import type { SigningClient, SigningClientOptions } from '.';
-import { inspect } from 'util';
 
 const localClientDebug = debug.extend('LocalSigningClient');
 
@@ -17,6 +16,9 @@ export class LocalSigningClient implements SigningClient {
     private options: Omit<SigningClientOptions, 'workingDirectory'>
   ) {}
 
+  // we want to wrap any errors in promise rejections, so even though there is no
+  // await statement, we use an `async` function
+  // eslint-disable-next-line @typescript-eslint/require-await
   async sign(file: string): Promise<void> {
     localClientDebug(`Signing ${file}`);
 

--- a/packages/signing-utils/src/ssh-client.ts
+++ b/packages/signing-utils/src/ssh-client.ts
@@ -79,7 +79,7 @@ export class SSHClient {
     return data;
   }
 
-  async getSftpConnection(): Promise<SFTPWrapper> {
+  private async getSftpConnection(): Promise<SFTPWrapper> {
     if (!this.connected) {
       throw new Error('Not connected to ssh server');
     }
@@ -88,5 +88,26 @@ export class SSHClient {
       this.sftpConnection ??
       (await promisify(this.sshConnection.sftp.bind(this.sshConnection))());
     return this.sftpConnection;
+  }
+
+  async copyFile(file: string, remotePath: string): Promise<void> {
+    const sftpConnection = await this.getSftpConnection();
+    return promisify(sftpConnection.fastPut.bind(sftpConnection))(
+      file,
+      remotePath
+    );
+  }
+
+  async downloadFile(remotePath: string, file: string): Promise<void> {
+    const sftpConnection = await this.getSftpConnection();
+    return promisify(sftpConnection.fastGet.bind(sftpConnection))(
+      remotePath,
+      file
+    );
+  }
+
+  async removeFile(remotePath: string): Promise<void> {
+    const sftpConnection = await this.getSftpConnection();
+    return promisify(sftpConnection.unlink.bind(sftpConnection))(remotePath);
   }
 }


### PR DESCRIPTION
This PR does three things

- the local signing client now looks at the exit code of the signing script and rejects if the exit code is non-zero
- moves all SFTP file operations from the remote signing client onto the ssh client (optional change)
- adds @types/ssh2 as a dependency.  this is necessary because currently the compiled TS exports classes which make use of these types.  if we don't specify this as a dependency, `@mongodb-js/signing-utils` fails to compile for users who do not have @types/ssh2 installed.



## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Checklist
- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
