### PR TITLE
chore(signing-utils): add ssh2 types and don't override file with gpg signing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4118,10 +4118,9 @@
       "dev": true
     },
     "node_modules/@types/ssh2": {
-      "version": "1.11.18",
-      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.11.18.tgz",
-      "integrity": "sha512-7eH4ppQMFlzvn//zhwD54MWaITR1aSc1oFBye9vb76GZ2Y9PSFYdwVIwOlxRXWs5+1hifntXyt+8a6SUbOD7Hg==",
-      "dev": true,
+      "version": "1.11.19",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.11.19.tgz",
+      "integrity": "sha512-ydbQAqEcdNVy2t1w7dMh6eWMr+iOgtEkqM/3K9RMijMaok/ER7L8GW6PwsOypHCN++M+c8S/UR9SgMqNIFstbA==",
       "dependencies": {
         "@types/node": "^18.11.18"
       }
@@ -4130,7 +4129,6 @@
       "version": "18.19.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.4.tgz",
       "integrity": "sha512-xNzlUhzoHotIsnFoXmJB+yWmBvFZgKCI9TtPIEdYIMM1KWfwuY8zh7wvc1u1OAXlC7dlf6mZVx/s+Y5KfFz19A==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -18023,8 +18021,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -19902,6 +19899,7 @@
       "version": "0.2.3",
       "license": "SSPL",
       "dependencies": {
+        "@types/ssh2": "^1.11.19",
         "debug": "^4.3.4",
         "ssh2": "^1.15.0"
       },
@@ -19914,7 +19912,6 @@
         "@types/mocha": "^9.1.1",
         "@types/node": "^17.0.35",
         "@types/sinon-chai": "^3.2.5",
-        "@types/ssh2": "^1.11.18",
         "chai": "^4.3.6",
         "depcheck": "^1.4.1",
         "eslint": "^7.25.0",
@@ -22603,7 +22600,7 @@
         "@types/mocha": "^9.1.1",
         "@types/node": "^17.0.35",
         "@types/sinon-chai": "^3.2.5",
-        "@types/ssh2": "^1.11.18",
+        "@types/ssh2": "^1.11.19",
         "chai": "^4.3.6",
         "debug": "^4.3.4",
         "depcheck": "^1.4.1",
@@ -23507,10 +23504,9 @@
       "dev": true
     },
     "@types/ssh2": {
-      "version": "1.11.18",
-      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.11.18.tgz",
-      "integrity": "sha512-7eH4ppQMFlzvn//zhwD54MWaITR1aSc1oFBye9vb76GZ2Y9PSFYdwVIwOlxRXWs5+1hifntXyt+8a6SUbOD7Hg==",
-      "dev": true,
+      "version": "1.11.19",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.11.19.tgz",
+      "integrity": "sha512-ydbQAqEcdNVy2t1w7dMh6eWMr+iOgtEkqM/3K9RMijMaok/ER7L8GW6PwsOypHCN++M+c8S/UR9SgMqNIFstbA==",
       "requires": {
         "@types/node": "^18.11.18"
       },
@@ -23519,7 +23515,6 @@
           "version": "18.19.4",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.4.tgz",
           "integrity": "sha512-xNzlUhzoHotIsnFoXmJB+yWmBvFZgKCI9TtPIEdYIMM1KWfwuY8zh7wvc1u1OAXlC7dlf6mZVx/s+Y5KfFz19A==",
-          "dev": true,
           "requires": {
             "undici-types": "~5.26.4"
           }
@@ -34158,8 +34153,7 @@
     "undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/packages/signing-utils/package.json
+++ b/packages/signing-utils/package.json
@@ -55,7 +55,6 @@
     "@types/mocha": "^9.1.1",
     "@types/node": "^17.0.35",
     "@types/sinon-chai": "^3.2.5",
-    "@types/ssh2": "^1.11.18",
     "chai": "^4.3.6",
     "depcheck": "^1.4.1",
     "eslint": "^7.25.0",
@@ -68,6 +67,7 @@
   },
   "dependencies": {
     "debug": "^4.3.4",
-    "ssh2": "^1.15.0"
+    "ssh2": "^1.15.0",
+    "@types/ssh2": "^1.11.19"
   }
 }

--- a/packages/signing-utils/src/signing-clients/remote-signing-client.spec.ts
+++ b/packages/signing-utils/src/signing-clients/remote-signing-client.spec.ts
@@ -46,7 +46,7 @@ describe('RemoteSigningClient', function () {
     const remoteSigningClient = new RemoteSigningClient(getMockedSSHClient(), {
       workingDirectory: workingDirectoryPath,
       signingScript: signingScript,
-      signingMethod: 'gpg',
+      signingMethod: 'jsign',
     });
 
     await remoteSigningClient.sign(fileToSign);

--- a/packages/signing-utils/src/signing-clients/remote-signing-client.ts
+++ b/packages/signing-utils/src/signing-clients/remote-signing-client.ts
@@ -69,8 +69,10 @@ export class RemoteSigningClient implements SigningClient {
       await this.signRemoteFile(path.basename(remotePath));
       debug(`SFTP: Signed file ${file}`);
 
-      await this.sshClient.downloadFile(remotePath, file);
-      debug(`SFTP: Downloaded signed file to ${file}`);
+      if (this.options.signingMethod === 'jsign') {
+        await this.sshClient.downloadFile(remotePath, file);
+        debug(`SFTP: Downloaded signed file to ${file}`);
+      }
 
       // For signing using gpg, `.sig` file is created along side the file being signed.
       // We also have to download it back and put it in the same path as original file.


### PR DESCRIPTION
Two misc fixes:

- @types/ssh2 is now a prod dependency.  I thought this was already the case, but apparently not.  
- with gpg signing, we don't override the original file when signing remotely.  This isn't necessary because gpg doesn't sign in place, and was causing issues in Mongosh's CI.

  # Semantic Versioning:

  Package versions will be bumped automatically according to the PR title:

  - The words `BREAKING CHANGE` in the title will cause a **major** bump to all the packages changed in the PR. All dependants will also have a major bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - A subject starting with `feat` will cause a **minor** bump to all the packages changed in the PR. All dependants will also have a minor bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - Any other change to any package will cause a `patch` bump to the package and all its dependants.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Checklist
- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
