### PR TITLE
chore(mongodb-constants): add 7.1/7.2 aggregation autocomplete updates

### DIFF
--- a/packages/mongodb-constants/src/expression-operators.ts
+++ b/packages/mongodb-constants/src/expression-operators.ts
@@ -677,6 +677,13 @@ const EXPRESSION_OPERATORS = [
     version: '3.4.0',
   },
   {
+    name: '$toHashedIndexKey',
+    value: '$toHashedIndexKey',
+    score: 1,
+    meta: 'expr:arith',
+    version: '4.2.24',
+  },
+  {
     name: '$toLower',
     value: '$toLower',
     score: 1,

--- a/packages/mongodb-constants/src/stage-operators.ts
+++ b/packages/mongodb-constants/src/stage-operators.ts
@@ -651,11 +651,21 @@ const STAGE_OPERATORS = [
     description:
       'Writes the result of a pipeline to a new or existing collection.',
     comment: `/**
- * Provide the name of the output collection.
+ * Provide the name of the output database and collection.
  */
 `,
     // eslint-disable-next-line quotes
-    snippet: `'\${1:string}'`,
+    snippet: `{
+  db: '\${1:string}',
+  coll: '\${2:string}',
+  /*
+  timeseries: {
+    timeField: '\${3:field}',
+    bucketMaxSpanSeconds: '\${4:number}',
+    granularity: '\${5:granularity}'
+  }
+  */
+}`,
   },
   {
     name: '$out',


### PR DESCRIPTION
- COMPASS-6592
- COMPASS-7601

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  Use `feat`, `fix` for user facing changes that should be part of release notes.

  # Semantic Versioning:

  Package versions will be bumped automatically according to the PR title:

  - The words `BREAKING CHANGE` in the title will cause a **major** bump to all the packages changed in the PR. All dependants will also have a major bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - A subject starting with `feat` will cause a **minor** bump to all the packages changed in the PR. All dependants will also have a minor bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - Any other change to any package will cause a `patch` bump to the package and all its dependants.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Checklist
- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
