### PR TITLE
feat(mongodb-constants): add vector search index template

### DIFF
--- a/packages/mongodb-constants/src/atlas-search-templates.ts
+++ b/packages/mongodb-constants/src/atlas-search-templates.ts
@@ -122,12 +122,12 @@ export const ATLAS_SEARCH_TEMPLATES: SearchTemplate[] = [
 export const ATLAS_VECTOR_SEARCH_TEMPLATE: SearchTemplate = {
   name: 'Vector Search default template',
   snippet: `{
-  "fields": [
+  "fields": [{
     "type": "vector",
     "path": "\${1:<field name to index>}",
     "numDimensions": \${2:<number of dimensions>},
     "similarity": "\${3:<euclidean | cosine | dotProduct>}"
-  ]
+  }]
 }`,
   version: '4.4.0',
 };

--- a/packages/mongodb-constants/src/atlas-search-templates.ts
+++ b/packages/mongodb-constants/src/atlas-search-templates.ts
@@ -118,3 +118,16 @@ export const ATLAS_SEARCH_TEMPLATES: SearchTemplate[] = [
     version: '4.4.0',
   },
 ];
+
+export const ATLAS_VECTOR_SEARCH_TEMPLATE: SearchTemplate = {
+  name: 'Vector Search default template',
+  snippet: `{
+  "fields": [
+    "type": "vector",
+    "path": "\${1:<field name to index>}",
+    "numDimensions": \${2:<number of dimensions>},
+    "similarity": "\${3:<euclidean | cosine | dotProduct>}"
+  ]
+}`,
+  version: '4.4.0',
+};

--- a/packages/mongodb-constants/src/index.spec.ts
+++ b/packages/mongodb-constants/src/index.spec.ts
@@ -30,6 +30,7 @@ describe('constants', function () {
       'REQUIRED_AS_FIRST_STAGE',
       'SYSTEM_VARIABLES',
       'ATLAS_SEARCH_TEMPLATES',
+      'ATLAS_VECTOR_SEARCH_TEMPLATE',
     ]);
   });
 });


### PR DESCRIPTION
https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type/

Initially this will be only used in Compass for creating vector search indexes in the ui.