### PR TITLE
fix(oidc-mock-provider): move skipIdToken to callback response

### DIFF
--- a/packages/oidc-mock-provider/src/index.ts
+++ b/packages/oidc-mock-provider/src/index.ts
@@ -34,9 +34,7 @@ export interface OIDCMockProviderConfig {
    *
    * skipIdToken: Exclude ID Token
    */
-  getTokenPayload(
-    metadata: TokenMetadata
-  ): MaybePromise<{
+  getTokenPayload(metadata: TokenMetadata): MaybePromise<{
     expires_in: number;
     payload: Record<string, unknown>;
     skipIdToken?: boolean;


### PR DESCRIPTION

## Description
Actually, what I did before made no sense, because `getTokenPayload` is defined out of the plugin and called from within 🤦 
https://github.com/mongodb-js/oidc-plugin/pull/187/files