### PR TITLE
feat(query-parser): allow falsy indentation, default to 2 space in toJSString, deprecate stringify

### DIFF
--- a/packages/query-parser/src/index.spec.ts
+++ b/packages/query-parser/src/index.spec.ts
@@ -357,6 +357,22 @@ pineapple}
 }`
       );
     });
+
+    it('retains double spaces and new lines in strings', function () {
+      assert.equal(
+        toJSString(
+          {
+            a: {
+              name: `multi-line with s  p    a   c
+        
+e  s`,
+            },
+          },
+          0
+        ),
+        "{a:{name:'multi-line with s  p    a   c\\n        \\ne  s'}}"
+      );
+    });
   });
 
   describe('stringify', function () {
@@ -367,6 +383,20 @@ pineapple}
     });
     it('should not added extra space when nesting', function () {
       assert.equal(stringify({ a: { $exists: true } }), '{a: {$exists: true}}');
+    });
+
+    // stringify is now deprecated as a result of this.
+    it('changes multi-space values', function () {
+      assert.equal(
+        stringify({
+          a: {
+            name: `multi-line with s  p    a   c
+        
+e  s`,
+          },
+        }),
+        "{a: {name: 'multi-line with s p a c\\n \\ne s'}}"
+      );
     });
 
     context('when providing a long', function () {

--- a/packages/query-parser/src/index.spec.ts
+++ b/packages/query-parser/src/index.spec.ts
@@ -16,6 +16,7 @@ import {
   parseProject,
   parseSort,
   stringify,
+  toJSString,
   DEFAULT_LIMIT,
   DEFAULT_MAX_TIME_MS,
   DEFAULT_SKIP,
@@ -324,6 +325,37 @@ describe('mongodb-query-parser', function () {
           assert.equal(parsed, false);
         });
       });
+    });
+  });
+
+  describe('toJSString', function () {
+    it('should default to two spaces', function () {
+      assert.equal(
+        toJSString({ a: { $exists: true } }),
+        `{
+  a: {
+    $exists: true
+  }
+}`
+      );
+    });
+
+    it('should allow falsy indentation', function () {
+      assert.equal(
+        toJSString({ a: { $exists: true } }, 0),
+        '{a:{$exists:true}}'
+      );
+    });
+
+    it('allows passing custom indent', function () {
+      assert.equal(
+        toJSString({ a: { $exists: true } }, 'pineapple'),
+        `{
+pineapplea: {
+pineapplepineapple$exists: true
+pineapple}
+}`
+      );
     });
   });
 

--- a/packages/query-parser/src/stringify.ts
+++ b/packages/query-parser/src/stringify.ts
@@ -139,7 +139,7 @@ const BSON_TO_JS_STRING = {
 /** @public */
 export function toJSString(
   obj: unknown,
-  ind?: Parameters<typeof JSON.stringify>[2]
+  ind: Parameters<typeof JSON.stringify>[2] = 2
 ): string | undefined {
   return toJavascriptString(
     obj,
@@ -151,13 +151,18 @@ export function toJSString(
       }
       return toJs(value);
     },
-    ind || ' '
+    ind
   );
 }
 
-/** @public */
+/**
+ * @public
+ * @deprecated
+ * This function is deprecated and not recommended as it replaces
+ * double spaces, newline values, and indents with only one space.
+ **/
 export function stringify(obj: unknown): string | undefined {
-  return toJSString(obj)
+  return toJSString(obj, 1)
     ?.replace(/ ?\n ? ?/g, '')
     .replace(/ {2,}/g, ' ');
 }


### PR DESCRIPTION
As part of https://jira.mongodb.org/browse/COMPASS-6980 we need to make Compass not use `stringify` for query parsing so that we can retain multi-spaces in values. We also want to have more flexibility over how we indent those places. This pr adds that flexibility and a deprecated notice on `stringify` so hopefully we can avoid using it in future.

To see a quick example of the bug `stringify` usage causes in Compass, run a query with the following:
```javascript
{
 name: 'te    st'
}
```
And then click on it in query history and observe the multiple spaces in `te   st` are replaced by one space.