### PR TITLE
feat: add azure to the ADL $out description & comment COMPASS-7419

### DIFF
--- a/packages/mongodb-constants/src/stage-operators.ts
+++ b/packages/mongodb-constants/src/stage-operators.ts
@@ -681,7 +681,7 @@ const STAGE_OPERATORS = [
     apiVersions: [1],
     namespaces: [...ANY_NAMESPACE],
     description:
-      'Writes the result of a pipeline to an Atlas cluster or S3 bucket.',
+      'Writes the result of a pipeline to an Atlas cluster, S3 bucket or Azure Blob Storage.',
     comment: `/**
  * Use any one of the following:
  * s3: Parameters to save the data to S3.
@@ -692,6 +692,22 @@ const STAGE_OPERATORS = [
  *     coll: 'string',
  *     projectId: 'string',
  *     clusterName: 'string'
+ *   }
+ * },
+ * azure: Parameters to save the data to Azure. Example:
+ * {
+ *   azure: {
+ *     serviceURL: 'string',
+ *     containerName: 'string',
+ *     region: 'string,
+ *     filename: 'string',
+ *     format: {
+ *       name: 'string',
+ *       maxFileSize: 'string',
+ *       maxRowGroupSize: 'string',
+ *       columnCompression: 'string'
+ *     },
+ *     errorMode: 'string'
  *   }
  * }
  */

--- a/packages/mongodb-constants/src/stage-operators.ts
+++ b/packages/mongodb-constants/src/stage-operators.ts
@@ -681,7 +681,7 @@ const STAGE_OPERATORS = [
     apiVersions: [1],
     namespaces: [...ANY_NAMESPACE],
     description:
-      'Writes the result of a pipeline to an Atlas cluster, S3 bucket or Azure Blob Storage.',
+      'Writes the result of a pipeline to an Atlas cluster, S3 bucket, or Azure Blob Storage.',
     comment: `/**
  * Use any one of the following:
  * s3: Parameters to save the data to S3.


### PR DESCRIPTION
https://jira.mongodb.org/browse/COMPASS-7419

The suggested snippet seemed to have it as the new snippet either in addition to or in place of s3, but our established pattern seems to be to have one option in the snippet and the others documented in the comment so I stuck with that.