### PR TITLE
fix(saslprep): run code point generation as part of package bumping NODE-6064

### DIFF
--- a/.github/workflows/bump-packages.yaml
+++ b/.github/workflows/bump-packages.yaml
@@ -38,7 +38,8 @@ jobs:
           npm -v
           npm ci
           # make sure precommit.js is compiled
-          npm run bootstrap-ci -- --scope @mongodb-js/monorepo-tools --stream --include-dependencies
+          # make sure saslprep is compiled on Linux (same as the publish step), see NODE-6064
+          npm run bootstrap-ci -- --scope @mongodb-js/monorepo-tools --scope @mongodb-js/saslprep --stream --include-dependencies
 
       - name: Bump packages
         run: |


### PR DESCRIPTION
This is necessary to unblock publishing packages from `main` since we merged 417d35affb2 without further following up on it.
