### PR TITLE
chore(dl-center): relax HTTP status code expectation for invalid config

### DIFF
--- a/packages/dl-center/src/download-center.spec.ts
+++ b/packages/dl-center/src/download-center.spec.ts
@@ -129,10 +129,11 @@ describe('download center client', function () {
       const error = await downloadCenter
         .uploadConfig('prefix/compass.json', invalidConfig)
         .catch((e) => e);
-
-      expect(error.message).equal(
-        'Download center urls broken:\n' +
-          '- http://example.com/non-existing-url -> 404'
+      expect(error.message).to.match(
+        new RegExp(
+          'Download center urls broken:\n' +
+            '- http://example.com/non-existing-url -> [45][0-9][0-9]'
+        )
       );
     });
   });


### PR DESCRIPTION
This seems to have started resulting in 500 rather than 404 errors (which may be a server-side bug, but nothing that affects our package's functional correctness).

<!--