### PR TITLE
fix(devtools-connect): give application code for custom OIDC HTTP options precedence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18150,9 +18150,9 @@
       }
     },
     "node_modules/mongodb-log-writer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/mongodb-log-writer/-/mongodb-log-writer-1.4.0.tgz",
-      "integrity": "sha512-hQrn8Xu58Z9uLmd2oncvu/b5KNxxKaW6MUrVRI/xObz/yzYNVWF3V4rgK9Ort72nOCmMD3PWOS+ZoZBtxgKibA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/mongodb-log-writer/-/mongodb-log-writer-1.4.2.tgz",
+      "integrity": "sha512-ZQYBgW1IZtuRWsv9hF0mjpfDg6usMawkkWKnFb/goXosbW0YyxVA9OHt32TJfppGK/U2p7jQx4V9DxRFsFmmKw==",
       "dev": true,
       "dependencies": {
         "bson": "^4.5.1 || ^5.0.0 || ^6.0.0",
@@ -24541,7 +24541,7 @@
         "gen-esm-wrapper": "^1.1.0",
         "mocha": "^8.4.0",
         "mongodb": "^5.8.1 || ^6.0.0",
-        "mongodb-log-writer": "^1.2.0",
+        "mongodb-log-writer": "^1.4.2",
         "nyc": "^15.1.0",
         "os-dns-native": "^1.2.0",
         "resolve-mongodb-srv": "^1.1.1",
@@ -24559,7 +24559,7 @@
       "peerDependencies": {
         "@mongodb-js/oidc-plugin": "^0.4.0",
         "mongodb": "^5.8.1 || ^6.0.0",
-        "mongodb-log-writer": "^1.2.0"
+        "mongodb-log-writer": "^1.4.2"
       }
     },
     "packages/devtools-connect/node_modules/@eslint/eslintrc": {
@@ -30885,7 +30885,7 @@
         "mongodb": "^5.8.1 || ^6.0.0",
         "mongodb-client-encryption": "^6.0.0",
         "mongodb-connection-string-url": "^3.0.0",
-        "mongodb-log-writer": "^1.2.0",
+        "mongodb-log-writer": "^1.4.2",
         "nyc": "^15.1.0",
         "os-dns-native": "^1.2.0",
         "resolve-mongodb-srv": "^1.1.1",
@@ -41552,9 +41552,9 @@
       }
     },
     "mongodb-log-writer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/mongodb-log-writer/-/mongodb-log-writer-1.4.0.tgz",
-      "integrity": "sha512-hQrn8Xu58Z9uLmd2oncvu/b5KNxxKaW6MUrVRI/xObz/yzYNVWF3V4rgK9Ort72nOCmMD3PWOS+ZoZBtxgKibA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/mongodb-log-writer/-/mongodb-log-writer-1.4.2.tgz",
+      "integrity": "sha512-ZQYBgW1IZtuRWsv9hF0mjpfDg6usMawkkWKnFb/goXosbW0YyxVA9OHt32TJfppGK/U2p7jQx4V9DxRFsFmmKw==",
       "dev": true,
       "requires": {
         "bson": "^4.5.1 || ^5.0.0 || ^6.0.0",

--- a/packages/devtools-connect/package.json
+++ b/packages/devtools-connect/package.json
@@ -56,7 +56,7 @@
   "peerDependencies": {
     "@mongodb-js/oidc-plugin": "^0.4.0",
     "mongodb": "^5.8.1 || ^6.0.0",
-    "mongodb-log-writer": "^1.2.0"
+    "mongodb-log-writer": "^1.4.2"
   },
   "devDependencies": {
     "@mongodb-js/oidc-plugin": "^0.4.0",
@@ -76,7 +76,7 @@
     "gen-esm-wrapper": "^1.1.0",
     "mocha": "^8.4.0",
     "mongodb": "^5.8.1 || ^6.0.0",
-    "mongodb-log-writer": "^1.2.0",
+    "mongodb-log-writer": "^1.4.2",
     "nyc": "^15.1.0",
     "os-dns-native": "^1.2.0",
     "resolve-mongodb-srv": "^1.1.1",

--- a/packages/devtools-connect/src/connect.ts
+++ b/packages/devtools-connect/src/connect.ts
@@ -536,10 +536,8 @@ function addCAToOIDCPluginHttpOptions(
   const existingCustomOptions = existingOIDCPluginOptions?.customHttpOptions;
   if (typeof existingCustomOptions === 'function') {
     return {
-      customHttpOptions: (...args) => ({
-        ...existingCustomOptions(...args),
-        ca,
-      }),
+      customHttpOptions: (url, options, ...restArgs) =>
+        existingCustomOptions(url, { ...options, ca }, ...restArgs),
     };
   }
   return { customHttpOptions: { ...existingCustomOptions, ca } };


### PR DESCRIPTION
Instead of using the application callback first and then potentially transforming the result with options computed by devtools-connect, do the reverse. This gives the application using devtools-connect more flexibility about how exactly to modify OIDC HTTP options.

The goal here is to enable usage of HTTP proxies in conjunction with `useSystemCA` and explicit `tlsCAFile` settings; devtools-connect correctly passes the former to the OIDC plugin, but after this change, the application can also pass it to the proxy agent, if it creates one.

None of our team's applications currently make use of the function variant of this options, so this will not affect existing code in any way.
