### PR TITLE
fix(devtools-connect): bump `mongodb` to latest and fix OIDC option check MONGOSH-1831

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8767,9 +8767,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.2.0.tgz",
-      "integrity": "sha512-ID1cI+7bazPDyL9wYy9GaQ8gEEohWvcUl/Yf0dIdutJxnmInEEyCsb4awy/OiBfall7zBA179Pahi3vCdFze3Q==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.8.0.tgz",
+      "integrity": "sha512-iOJg8pr7wq2tg/zSlCCHMi3hMm5JTOxLTagf3zxhcenHsFp+c6uOs6K7W5UE7A4QIJGtqh/ZovFNMP4mOPJynQ==",
       "engines": {
         "node": ">=16.20.1"
       }
@@ -18008,12 +18008,12 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.3.0.tgz",
-      "integrity": "sha512-tt0KuGjGtLUhLoU263+xvQmPHEGTw5LbcNC73EoFRYgSHwZt5tsoJC110hDyO1kjQzpgNrpdcSza9PknWN4LrA==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.8.0.tgz",
+      "integrity": "sha512-HGQ9NWDle5WvwMnrvUxsFYPd3JEbqD3RgABHBQRuoCEND0qzhsd0iH5ypHsf1eJ+sXmvmyKpP+FLOKY8Il7jMw==",
       "dependencies": {
-        "@mongodb-js/saslprep": "^1.1.0",
-        "bson": "^6.2.0",
+        "@mongodb-js/saslprep": "^1.1.5",
+        "bson": "^6.7.0",
         "mongodb-connection-string-url": "^3.0.0"
       },
       "engines": {
@@ -24498,7 +24498,7 @@
         "eslint-plugin-promise": "^6.1.1",
         "gen-esm-wrapper": "^1.1.0",
         "mocha": "^8.4.0",
-        "mongodb": "^5.8.1 || ^6.0.0",
+        "mongodb": "^6.8.0",
         "mongodb-log-writer": "^1.4.2",
         "nyc": "^15.1.0",
         "os-dns-native": "^1.2.0",
@@ -24516,7 +24516,7 @@
       },
       "peerDependencies": {
         "@mongodb-js/oidc-plugin": "^1.0.0",
-        "mongodb": "^5.8.1 || ^6.0.0",
+        "mongodb": "^6.8.0",
         "mongodb-log-writer": "^1.4.2"
       }
     },
@@ -25568,7 +25568,7 @@
         "@mongodb-js/mongodb-downloader": "^0.3.2",
         "@mongodb-js/saslprep": "^1.1.7",
         "debug": "^4.3.4",
-        "mongodb": "^6.3.0",
+        "mongodb": "^6.8.0",
         "mongodb-connection-string-url": "^3.0.0",
         "yargs": "^17.7.2"
       },
@@ -31114,7 +31114,7 @@
         "kerberos": "^2.1.0",
         "lodash.merge": "^4.6.2",
         "mocha": "^8.4.0",
-        "mongodb": "^5.8.1 || ^6.0.0",
+        "mongodb": "^6.8.0",
         "mongodb-client-encryption": "^6.0.0",
         "mongodb-connection-string-url": "^3.0.0",
         "mongodb-log-writer": "^1.4.2",
@@ -34812,9 +34812,9 @@
       }
     },
     "bson": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.2.0.tgz",
-      "integrity": "sha512-ID1cI+7bazPDyL9wYy9GaQ8gEEohWvcUl/Yf0dIdutJxnmInEEyCsb4awy/OiBfall7zBA179Pahi3vCdFze3Q=="
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.8.0.tgz",
+      "integrity": "sha512-iOJg8pr7wq2tg/zSlCCHMi3hMm5JTOxLTagf3zxhcenHsFp+c6uOs6K7W5UE7A4QIJGtqh/ZovFNMP4mOPJynQ=="
     },
     "buffer": {
       "version": "5.7.1",
@@ -41814,12 +41814,12 @@
       "dev": true
     },
     "mongodb": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.3.0.tgz",
-      "integrity": "sha512-tt0KuGjGtLUhLoU263+xvQmPHEGTw5LbcNC73EoFRYgSHwZt5tsoJC110hDyO1kjQzpgNrpdcSza9PknWN4LrA==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.8.0.tgz",
+      "integrity": "sha512-HGQ9NWDle5WvwMnrvUxsFYPd3JEbqD3RgABHBQRuoCEND0qzhsd0iH5ypHsf1eJ+sXmvmyKpP+FLOKY8Il7jMw==",
       "requires": {
-        "@mongodb-js/saslprep": "^1.1.0",
-        "bson": "^6.2.0",
+        "@mongodb-js/saslprep": "^1.1.5",
+        "bson": "^6.7.0",
         "mongodb-connection-string-url": "^3.0.0"
       }
     },
@@ -42003,7 +42003,7 @@
         "eslint": "^7.25.0",
         "gen-esm-wrapper": "^1.1.0",
         "mocha": "^8.4.0",
-        "mongodb": "^6.3.0",
+        "mongodb": "^6.8.0",
         "mongodb-connection-string-url": "^3.0.0",
         "nyc": "^15.1.0",
         "prettier": "2.3.2",

--- a/packages/devtools-connect/package.json
+++ b/packages/devtools-connect/package.json
@@ -55,7 +55,7 @@
   },
   "peerDependencies": {
     "@mongodb-js/oidc-plugin": "^1.0.0",
-    "mongodb": "^5.8.1 || ^6.0.0",
+    "mongodb": "^6.8.0",
     "mongodb-log-writer": "^1.4.2"
   },
   "devDependencies": {
@@ -75,7 +75,7 @@
     "eslint-plugin-promise": "^6.1.1",
     "gen-esm-wrapper": "^1.1.0",
     "mocha": "^8.4.0",
-    "mongodb": "^5.8.1 || ^6.0.0",
+    "mongodb": "^6.8.0",
     "mongodb-log-writer": "^1.4.2",
     "nyc": "^15.1.0",
     "os-dns-native": "^1.2.0",

--- a/packages/devtools-connect/src/connect.spec.ts
+++ b/packages/devtools-connect/src/connect.spec.ts
@@ -429,20 +429,20 @@ describe('devtools connect', function () {
       ).to.equal(true);
     });
 
-    it('returns false if the PROVIDER_NAME JS option is set', function () {
+    it('returns false if the ENVIRONMENT JS option is set', function () {
       expect(
         isHumanOidcFlow('mongodb://example/?authMechanism=MONGODB-OIDC', {
           authMechanismProperties: {
-            PROVIDER_NAME: 'aws',
+            ENVIRONMENT: 'azure',
           },
         })
       ).to.equal(false);
     });
 
-    it('returns false if the PROVIDER_NAME url option is set', function () {
+    it('returns false if the ENVIRONMENT url option is set', function () {
       expect(
         isHumanOidcFlow(
-          'mongodb://example/?authMechanism=MONGODB-OIDC&authMechanismProperties=PROVIDER_NAME:aws',
+          'mongodb://example/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:azure',
           {}
         )
       ).to.equal(false);

--- a/packages/devtools-connect/src/connect.ts
+++ b/packages/devtools-connect/src/connect.ts
@@ -471,7 +471,8 @@ export function isHumanOidcFlow(
   if (
     (clientOptions.authMechanism &&
       clientOptions.authMechanism !== 'MONGODB-OIDC') ||
-    clientOptions.authMechanismProperties?.PROVIDER_NAME
+    clientOptions.authMechanismProperties?.ENVIRONMENT ||
+    clientOptions.authMechanismProperties?.OIDC_CALLBACK
   ) {
     return false;
   }
@@ -487,7 +488,7 @@ export function isHumanOidcFlow(
   return (
     authMechanism === 'MONGODB-OIDC' &&
     !new CommaAndColonSeparatedRecord(sp.get('authMechanismProperties')).get(
-      'PROVIDER_NAME'
+      'ENVIRONMENT'
     )
   );
 }

--- a/packages/mongodb-runner/package.json
+++ b/packages/mongodb-runner/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@mongodb-js/mongodb-downloader": "^0.3.2",
     "debug": "^4.3.4",
-    "mongodb": "^6.3.0",
+    "mongodb": "^6.8.0",
     "@mongodb-js/saslprep": "^1.1.7",
     "mongodb-connection-string-url": "^3.0.0",
     "yargs": "^17.7.2"


### PR DESCRIPTION
Missed this option update in https://github.com/mongodb-js/devtools-shared/pull/347 because we didn't bump the driver (and therefore also not its types) in it