### PR TITLE
chore(oidc-mock-provider): allow binding to all ips while keeping a specific hostname for the issuer

### DIFF
--- a/packages/oidc-mock-provider/bin/oidc-mock-provider.js
+++ b/packages/oidc-mock-provider/bin/oidc-mock-provider.js
@@ -6,6 +6,7 @@ const { OIDCMockProvider } = require('..');
 
 const DEFAULT_PORT = 28200;
 const DEFAULT_HOST = 'localhost';
+const DEFAULT_BIND_IP_ALL = false;
 
 const argv = require('yargs')
   .option('port', {
@@ -17,6 +18,10 @@ const argv = require('yargs')
     alias: 'h',
     type: 'string',
     desc: 'Hostname for the server to listen upon. Defaults to localhost.',
+  })
+  .option('bind_ip_all', {
+    type: 'boolean',
+    desc: 'Bind to all IPv4 and IPv6 addresses',
   })
   .example(
     '$0 -p 28200',
@@ -41,6 +46,7 @@ const DEFAULT_TOKEN_PAYLOAD = {
     },
     port: argv.port ?? DEFAULT_PORT,
     hostname: argv.host ?? DEFAULT_HOST,
+    bindIpAll: argv.bind_ip_all ?? DEFAULT_BIND_IP_ALL,
   };
   const mockIdentityProvider = await OIDCMockProvider.create(
     oidcMockProviderConfig

--- a/packages/oidc-mock-provider/src/index.ts
+++ b/packages/oidc-mock-provider/src/index.ts
@@ -61,6 +61,11 @@ export interface OIDCMockProviderConfig {
   hostname?: string;
 
   /**
+   * Optional bind to all IPv4 and IPv6 addresses.
+   */
+  bindIpAll?: boolean;
+
+  /**
    * Optional additional fields to be returned when the OIDC configuration is accessed.
    */
   additionalIssuerMetadata?: () => Record<string, unknown>;
@@ -102,7 +107,10 @@ export class OIDCMockProvider {
   }
 
   private async init(): Promise<this> {
-    this.httpServer.listen(this.config.port ?? 0, this.config.hostname);
+    this.httpServer.listen(
+      this.config.port ?? 0,
+      this.config.bindIpAll ? '::,0.0.0.0' : this.config.hostname
+    );
     await once(this.httpServer, 'listening');
     const { port } = this.httpServer.address() as AddressInfo;
     this.issuer = `${

--- a/packages/oidc-mock-provider/src/index.ts
+++ b/packages/oidc-mock-provider/src/index.ts
@@ -109,7 +109,7 @@ export class OIDCMockProvider {
   private async init(): Promise<this> {
     this.httpServer.listen(
       this.config.port ?? 0,
-      this.config.bindIpAll ? '::,0.0.0.0' : this.config.hostname
+      this.config.bindIpAll ? '::' : this.config.hostname
     );
     await once(this.httpServer, 'listening');
     const { port } = this.httpServer.address() as AddressInfo;


### PR DESCRIPTION
`--bind_ip_all` and `bindIpAll` chosen to match the [server's config](https://www.mongodb.com/docs/manual/core/security-mongodb-configuration/).

This helps with docker host networking so that the mongodb server in docker can get to the oidc server you run on the host or another docker container while the issuer remains just localhost.