### PR TITLE
fix(devtools-proxy-support): remove ability to specify per-request CA

### DIFF
--- a/packages/devtools-proxy-support/src/agent.spec.ts
+++ b/packages/devtools-proxy-support/src/agent.spec.ts
@@ -21,7 +21,6 @@ describe('createAgent', function () {
       new URL(url).protocol === 'https:' ? httpsGet : httpGet;
     const options = {
       agent,
-      ca: setup.tlsOptions.ca,
       checkServerIdentity: () => undefined, // allow hostname mismatches
       ...customOptions,
     };
@@ -142,7 +141,10 @@ describe('createAgent', function () {
     it('can connect to an https proxy without auth', async function () {
       const res = await get(
         'https://example.com/hello',
-        createAgent({ proxy: `http://127.0.0.1:${setup.httpsProxyPort}` })
+        createAgent({
+          proxy: `http://127.0.0.1:${setup.httpsProxyPort}`,
+          ca: setup.tlsOptions.ca,
+        })
       );
       expect(res.body).to.equal('OK /hello');
       expect(setup.getRequestedUrls()).to.deep.equal([
@@ -157,6 +159,7 @@ describe('createAgent', function () {
         'https://example.com/hello',
         createAgent({
           proxy: `http://foo:bar@127.0.0.1:${setup.httpsProxyPort}`,
+          ca: setup.tlsOptions.ca,
         })
       );
       expect(res.body).to.equal('OK /hello');
@@ -173,6 +176,7 @@ describe('createAgent', function () {
         'https://example.com/hello',
         createAgent({
           proxy: `http://foo:bar@127.0.0.1:${setup.httpsProxyPort}`,
+          ca: setup.tlsOptions.ca,
         })
       );
       expect(res.statusCode).to.equal(407);
@@ -186,17 +190,6 @@ describe('createAgent', function () {
         resetSystemCACache();
       });
 
-      it('can connect using CA as part of the request options', async function () {
-        // get() helpfully sets the CA for us
-        const res = await get(
-          'https://example.com/hello',
-          createAgent({ proxy: `http://127.0.0.1:${setup.httpsProxyPort}` })
-        );
-        expect(res.body).to.equal('OK /hello');
-        expect(setup.getRequestedUrls()).to.deep.equal([
-          'http://example.com/hello',
-        ]);
-      });
       it('can connect using CA as part of the agent options (no explicit CA set)', async function () {
         const res = await get(
           'https://example.com/hello',

--- a/packages/devtools-proxy-support/src/agent.ts
+++ b/packages/devtools-proxy-support/src/agent.ts
@@ -49,13 +49,14 @@ class DevtoolsProxyAgent extends ProxyAgent implements AgentWithInitialize {
   private _reqLockResolve: (() => void) | undefined;
 
   constructor(proxyOptions: DevtoolsProxyOptions, logger: ProxyLogEmitter) {
-    // We remove .ca because the Node.js HTTP agent implementation overrides
-    // request options with agent options, but we want to merge them instead
+    // NB: The Node.js HTTP agent implementation overrides request options
+    // with agent options. Ideally, we'd want to merge them, but it seems like
+    // there is little we can do about it at this point.
+    // None of our products need the ability to specify per-request CA options
+    // currently anyway.
     // https://github.com/nodejs/node/blob/014dad5953a632f44e668f9527f546c6e1bb8b86/lib/_http_agent.js#L239
-    const { ca, ...proxyOptionsWithoutCA } = proxyOptions;
-    void ca;
     super({
-      ...proxyOptionsWithoutCA,
+      ...proxyOptions,
       getProxyForUrl: (url: string) => this._getProxyForUrl(url),
     });
 


### PR DESCRIPTION
This is currently not supported by `https-proxy-agent`. Instead of trying to work around this, let's just keep it simple for now and always stick to the CA option provided to the agent (i.e. typically on the application level).

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  Use `feat`, `fix` for user facing changes that should be part of release notes.

  # Semantic Versioning:

  Package versions will be bumped automatically according to the PR title:

  - The words `BREAKING CHANGE` in the title will cause a **major** bump to all the packages changed in the PR. All dependants will also have a major bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - A subject starting with `feat` will cause a **minor** bump to all the packages changed in the PR. All dependants will also have a minor bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - Any other change to any package will cause a `patch` bump to the package and all its dependants.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Checklist
- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
