### PR TITLE
fix(devtools-proxy-support): handle special characters in SSH URL correctly COMPASS-8254

### DIFF
--- a/packages/devtools-proxy-support/src/ssh.spec.ts
+++ b/packages/devtools-proxy-support/src/ssh.spec.ts
@@ -41,6 +41,19 @@ describe('SSHAgent', function () {
     expect(setup.authHandler).to.have.been.calledOnceWith('foo', 'bar');
   });
 
+  it('handles special characters in username and password', async function () {
+    setup.authHandler = sinon.stub().returns(true);
+    agent = new SSHAgent({
+      proxy: `ssh://foo%5E:ba%26r@127.0.0.1:${setup.sshProxyPort}/`,
+    });
+    const fetch = createFetch(agent);
+    await Promise.all([
+      fetch('http://example.com/hello'),
+      fetch('http://example.com/hello'),
+    ]);
+    expect(setup.authHandler).to.have.been.calledOnceWith('foo^', 'ba&r');
+  });
+
   it('allows explicitly initializing the connection', async function () {
     setup.authHandler = sinon.stub().returns(true);
     agent = new SSHAgent({

--- a/packages/devtools-proxy-support/src/ssh.ts
+++ b/packages/devtools-proxy-support/src/ssh.ts
@@ -78,10 +78,10 @@ export class SSHAgent extends AgentBase implements AgentWithInitialize {
     const sshConnectConfig: ConnectConfig = {
       readyTimeout: 20000,
       keepaliveInterval: 20000,
-      host: this.url.hostname,
+      host: decodeURIComponent(this.url.hostname),
       port: +this.url.port || 22,
-      username: this.url.username || undefined,
-      password: this.url.password || undefined,
+      username: decodeURIComponent(this.url.username) || undefined,
+      password: decodeURIComponent(this.url.password) || undefined,
       privateKey: this.proxyOptions.sshOptions?.identityKeyFile
         ? await fs.readFile(this.proxyOptions.sshOptions.identityKeyFile)
         : undefined,
@@ -92,7 +92,7 @@ export class SSHAgent extends AgentBase implements AgentWithInitialize {
     this.logger.emit('ssh:establishing-conection', {
       host: sshConnectConfig.host,
       port: sshConnectConfig.port,
-      password: !!sshConnectConfig.passphrase,
+      password: !!sshConnectConfig.password,
       privateKey: !!sshConnectConfig.privateKey,
       passphrase: !!sshConnectConfig.passphrase,
     });


### PR DESCRIPTION
This is unfortunately very obvious in retrospect 😞 