### PR TITLE
fix(mongodb-query-parser): missing `bson` peer dependency

### DIFF
--- a/packages/query-parser/package.json
+++ b/packages/query-parser/package.json
@@ -69,5 +69,8 @@
     "prettier": "^2.3.2",
     "sinon": "^9.2.3",
     "typescript": "^5.0.4"
+  },
+  "peerDependencies": {
+    "bson": "^4.6.3 || ^5 || ^6"
   }
 }


### PR DESCRIPTION
Fix #471

## Checklist
- [x] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [x] New tests and/or benchmarks are included
- [x] Documentation is changed or added