### PR TITLE
fix(shell-bson-parser): Support `valueOf` date method

### DIFF
--- a/packages/shell-bson-parser/src/index.spec.ts
+++ b/packages/shell-bson-parser/src/index.spec.ts
@@ -425,6 +425,7 @@ describe('@mongodb-js/shell-bson-parser', function () {
           setUTCSeconds: (${newDate}).setUTCSeconds(59),
           setYear: (${newDate}).setYear(96),
           toISOString: (${newDate}).toISOString(),
+          valueOf: (${newDate}.valueOf()),
        }`;
               expect(parse(input, options)).to.deep.equal({
                 getDate: new (Date as any)(...args).getDate(),
@@ -469,6 +470,7 @@ describe('@mongodb-js/shell-bson-parser', function () {
                 setUTCSeconds: new (Date as any)(...args).setUTCSeconds(59),
                 setYear: new (Date as any)(...args).setYear(96), // setYear is deprecated
                 toISOString: new (Date as any)(...args).toISOString(),
+                valueOf: new (Date as any)(...args).valueOf(),
               });
             });
 

--- a/packages/shell-bson-parser/src/scope.ts
+++ b/packages/shell-bson-parser/src/scope.ts
@@ -233,6 +233,7 @@ const ALLOWED_CLASS_EXPRESSIONS: ClassExpressions = lookupMap({
       setUTCSeconds: true,
       setYear: true,
       toISOString: true,
+      valueOf: true,
     }),
   }),
   ISODate: lookupMap({


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  Use `feat`, `fix` for user facing changes that should be part of release notes.

  # Semantic Versioning:

  Package versions will be bumped automatically according to the PR title:

  - The words `BREAKING CHANGE` in the title will cause a **major** bump to all the packages changed in the PR. All dependants will also have a major bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - A subject starting with `feat` will cause a **minor** bump to all the packages changed in the PR. All dependants will also have a minor bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - Any other change to any package will cause a `patch` bump to the package and all its dependants.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Adds support for the [`valueOf`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/valueOf) Date method to the `shell-bson-parser` package


## Checklist
- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
