### PR TITLE
fix(oidc-mock-provider): Include nonce in token if present in request MONGOSH-1905

### DIFF
--- a/packages/oidc-mock-provider/src/index.ts
+++ b/packages/oidc-mock-provider/src/index.ts
@@ -24,6 +24,7 @@ export interface TokenMetadata {
   // parameters that are defined this way.
   client_id: string;
   scope: string;
+  nonce?: string;
 }
 
 export type MaybePromise<T> = T | PromiseLike<T>;
@@ -205,6 +206,7 @@ export class OIDCMockProvider {
             code_challenge,
             code_challenge_method,
             state,
+            nonce,
           } = Object.fromEntries(url.searchParams);
           if (response_type !== 'code') {
             throw new Error(`unknown response_type ${response_type}`);
@@ -216,6 +218,7 @@ export class OIDCMockProvider {
               scope,
               code_challenge,
               code_challenge_method,
+              nonce,
             }),
             state,
           }).toString();
@@ -235,6 +238,7 @@ export class OIDCMockProvider {
             code_challenge,
             code_challenge_method,
             isDeviceCode,
+            nonce,
           } = this.retrieveFromStorage(device_code ?? code);
 
           if (!isDeviceCode) {
@@ -267,6 +271,7 @@ export class OIDCMockProvider {
           const { access_token, id_token, expires_in } = await this.issueToken({
             client_id,
             scope,
+            nonce,
           });
 
           // Issue a token response:
@@ -344,6 +349,7 @@ export class OIDCMockProvider {
       scope: metadata.scope,
       iss: this.issuer,
       aud: metadata.client_id,
+      nonce: metadata.nonce,
       ...payload,
     };
     const makeToken = (payload: Record<string, unknown>) => {


### PR DESCRIPTION
## Description
Update the mock oidc provider to pass the nonce down in the token claims.

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Checklist
- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
