### PR TITLE
chore: add a github action for setting up the bot app

### DIFF
--- a/actions/setup-bot-token/action.yml
+++ b/actions/setup-bot-token/action.yml
@@ -1,10 +1,10 @@
 name: Setup app bot
 description: Gets a github app token and configures git with the app's user
 inputs:
-  app_id:
+  app-id:
     description: The app id
     required: true
-  app_private_key:
+  private-key:
     description: The app private key
     required: true
 outputs:
@@ -17,8 +17,8 @@ runs:
     - uses: actions/create-github-app-token@v1
       id: app-token
       with:
-        app-id: ${{ inputs.app_id }}
-        private-key: ${{ inputs.app_private_key }}
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.private-key }}
 
     - name: Get GitHub App User ID
       id: get-user-id

--- a/actions/setup-bot-token/action.yml
+++ b/actions/setup-bot-token/action.yml
@@ -1,0 +1,34 @@
+name: Setup app bot
+description: Gets a github app token and configures git with the app's user
+inputs:
+  app_id:
+    description: The app id
+    required: true
+  app_private_key:
+    description: The app private key
+    required: true
+outputs:
+  token:
+    description: The token to use for the GitHub App
+    value: ${{ steps.app-token.outputs.token }}
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/create-github-app-token@v1
+      id: app-token
+      with:
+        app-id: ${{ inputs.app_id }}
+        private-key: ${{ inputs.app_private_key }}
+
+    - name: Get GitHub App User ID
+      id: get-user-id
+      run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+      shell: bash
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+    - name: Set up Git
+      run: |
+        git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+        git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>'
+      shell: bash


### PR DESCRIPTION
## Description
Creates a trivial wrapper around actions/create-github-app-token to also setup git in addition to getting the token. Since we use the app tokens exclusively in workflows where we want to commit code, this saves us from copy-pasting it in every workflow. It's also provides a centralized place for updating the workflow without having to go and find all usages
