### PR TITLE
fix(signing-utils): migrate to new Windows signing cert DEVPROD-13200

### DIFF
--- a/packages/signing-utils/src/garasign.sh
+++ b/packages/signing-utils/src/garasign.sh
@@ -57,7 +57,7 @@ jsign_sign() {
     -v $directory:$directory \
     -w $directory \
     ${ARTIFACTORY_HOST}/release-tools-container-registry-local/garasign-jsign \
-    /bin/bash -c "jsign -t 'http://timestamp.digicert.com' -a 'mongo-authenticode-2021' '$file'"
+    /bin/bash -c "jsign -t 'http://timestamp.digicert.com' -a 'mongo-authenticode-2024' '$file'"
 }
 
 rpm_gpg_sign() {


### PR DESCRIPTION
## Description
This commit updates the certificate we use to sign to our new one for the next three years. Ideally we would also update this to be parameterized, but given that there are a few projects that depend on this script, I think it's safer to make this update as-is now and decide on templating later.
