### PR TITLE
fix(devtools-connect): re-try connection in case of TLS errors without system CA MONGOSH-1935

### DIFF
--- a/packages/devtools-connect/src/fast-failure-connect.ts
+++ b/packages/devtools-connect/src/fast-failure-connect.ts
@@ -1,7 +1,9 @@
 // It probably makes sense to put this into its own package/repository once
 // other tools start using it.
 
-export function isFastFailureConnectionError(error: Error): boolean {
+function isFastFailureConnectionSingleError(
+  error: Error & { code?: string }
+): boolean {
   switch (error.name) {
     case 'MongoNetworkError':
       return /\b(ECONNREFUSED|ENOTFOUND|ENETUNREACH|EINVAL)\b/.test(
@@ -10,6 +12,81 @@ export function isFastFailureConnectionError(error: Error): boolean {
     case 'MongoError':
       return /The apiVersion parameter is required/.test(error.message);
     default:
-      return false;
+      return (
+        ['ECONNREFUSED', 'ENOTFOUND', 'ENETUNREACH', 'EINVAL'].includes(
+          error.code ?? ''
+        ) || isPotentialTLSCertificateError(error)
+      );
   }
+}
+
+export const isFastFailureConnectionError = handleNestedErrors(
+  isFastFailureConnectionSingleError
+);
+
+function isPotentialTLSCertificateSingleError(
+  error: Error & { code?: string }
+): boolean {
+  // https://nodejs.org/api/tls.html#x509-certificate-error-codes
+  return [
+    'UNABLE_TO_GET_ISSUER_CERT',
+    'UNABLE_TO_GET_CRL',
+    'UNABLE_TO_DECRYPT_CERT_SIGNATURE',
+    'UNABLE_TO_DECRYPT_CRL_SIGNATURE',
+    'UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY',
+    'CERT_SIGNATURE_FAILURE',
+    'CRL_SIGNATURE_FAILURE',
+    'CERT_NOT_YET_VALID',
+    'CERT_HAS_EXPIRED',
+    'CRL_NOT_YET_VALID',
+    'CRL_HAS_EXPIRED',
+    'ERROR_IN_CERT_NOT_BEFORE_FIELD',
+    'ERROR_IN_CERT_NOT_AFTER_FIELD',
+    'ERROR_IN_CRL_LAST_UPDATE_FIELD',
+    'ERROR_IN_CRL_NEXT_UPDATE_FIELD',
+    'OUT_OF_MEM',
+    'DEPTH_ZERO_SELF_SIGNED_CERT',
+    'SELF_SIGNED_CERT_IN_CHAIN',
+    'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+    'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+    'CERT_CHAIN_TOO_LONG',
+    'CERT_REVOKED',
+    'INVALID_CA',
+    'PATH_LENGTH_EXCEEDED',
+    'INVALID_PURPOSE',
+    'CERT_UNTRUSTED',
+    'CERT_REJECTED',
+    'HOSTNAME_MISMATCH',
+  ].includes(error.code ?? '');
+}
+
+export const isPotentialTLSCertificateError = handleNestedErrors(
+  isPotentialTLSCertificateSingleError
+);
+
+// Convenience wrapper that ensures that the given error is an `Error` instance
+// and that handles nested errors (.cause/AggregateError) as well
+function handleNestedErrors(
+  fn: (err: Error & { code?: string }) => boolean
+): (err: unknown) => boolean {
+  const checker = (err: unknown): boolean => {
+    if (
+      Object.prototype.toString.call(err).toLowerCase() !== '[object error]'
+    ) {
+      return checker(new Error(String(err)));
+    }
+    if (!err || typeof err !== 'object') return false; // Make TS happy
+    if ('cause' in err && checker(err.cause)) {
+      return true; // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+    }
+    if (
+      'errors' in err &&
+      Array.isArray(err.errors) &&
+      err.errors.some((err) => checker(err))
+    ) {
+      return true; // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError
+    }
+    return fn(err as Error);
+  };
+  return checker;
 }

--- a/packages/devtools-connect/src/index.ts
+++ b/packages/devtools-connect/src/index.ts
@@ -5,6 +5,7 @@ export type {
   DevtoolsConnectionState,
   DevtoolsProxyOptions,
   AgentWithInitialize,
+  ConnectMongoClientResult,
 } from './connect';
 export { hookLogger } from './log-hook';
 export { oidcServerRequestHandler } from './oidc/handler';

--- a/packages/devtools-connect/src/log-hook.ts
+++ b/packages/devtools-connect/src/log-hook.ts
@@ -8,6 +8,7 @@ import type {
   ConnectMissingOptionalDependencyEvent,
   ConnectUsedSystemCAEvent,
   ConnectLogEmitter,
+  ConnectRetryAfterTLSErrorEvent,
 } from './types';
 
 import { hookLoggerToMongoLogWriter as oidcHookLogger } from '@mongodb-js/oidc-plugin';
@@ -170,6 +171,21 @@ export function hookLogger(
           asyncFallbackError: ev.asyncFallbackError?.message,
           systemCertsError: ev.systemCertsError?.message,
           messages: ev.messages,
+        }
+      );
+    }
+  );
+
+  emitter.on(
+    'devtools-connect:retry-after-tls-error',
+    function (ev: ConnectRetryAfterTLSErrorEvent) {
+      log.info(
+        'DEVTOOLS-CONNECT',
+        mongoLogId(1_000_000_054),
+        `${contextPrefix}-connect`,
+        'Restarting connection attempt after TLS error',
+        {
+          error: ev.error,
         }
       );
     }

--- a/packages/devtools-connect/src/types.ts
+++ b/packages/devtools-connect/src/types.ts
@@ -58,6 +58,10 @@ export interface ConnectUsedSystemCAEvent {
   messages: string[];
 }
 
+export interface ConnectRetryAfterTLSErrorEvent {
+  error: string;
+}
+
 export interface ConnectEventMap
   extends MongoDBOIDCLogEventsMap,
     ProxyEventMap {
@@ -93,6 +97,10 @@ export interface ConnectEventMap
   ) => void;
   /** Signals that the list of system certificates has been loaded and used for connecting. */
   'devtools-connect:used-system-ca': (ev: ConnectUsedSystemCAEvent) => void;
+  /** Signals that a connection attempt was restarted after a TLS error */
+  'devtools-connect:retry-after-tls-error': (
+    ev: ConnectRetryAfterTLSErrorEvent
+  ) => void;
 }
 
 export type ConnectEventArgs<K extends keyof ConnectEventMap> =


### PR DESCRIPTION
Recent user reports have made it clear that our attempts to solve TLS errors caused by adding system certificates haven't fully been resolved yet. To address this, we add a generic fallback that attempts to connect a second time without the system certificate store added.

This commit also adds TLS errors to the list of fail-fast errors, i.e. errors which should result in a quick connection end because they are unlikely to be resolved by the Node.js driver attempting to re-connect repeatedly on the level of individual connections. This should avoid situations in which timeouts make the connection attempt take twice as long for TLS errors.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  Use `feat`, `fix` for user facing changes that should be part of release notes.

  # Semantic Versioning:

  Package versions will be bumped automatically according to the PR title:

  - The words `BREAKING CHANGE` in the title will cause a **major** bump to all the packages changed in the PR. All dependants will also have a major bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - A subject starting with `feat` will cause a **minor** bump to all the packages changed in the PR. All dependants will also have a minor bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - Any other change to any package will cause a `patch` bump to the package and all its dependants.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Checklist
- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
