### PR TITLE
chore(mongodb-redact): remove lodash usage MONGOSH-1975

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26563,9 +26563,6 @@
     "packages/mongodb-redact": {
       "version": "1.1.4",
       "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
       "devDependencies": {
         "@mongodb-js/eslint-config-devtools": "0.9.10",
         "@mongodb-js/mocha-config-devtools": "^1.0.4",
@@ -43539,7 +43536,6 @@
         "depcheck": "^1.4.1",
         "eslint": "^7.25.0",
         "gen-esm-wrapper": "^1.1.0",
-        "lodash": "^4.17.21",
         "mocha": "^8.4.0",
         "nyc": "^15.1.0",
         "prettier": "^2.3.2",

--- a/packages/mongodb-redact/package.json
+++ b/packages/mongodb-redact/package.json
@@ -45,9 +45,6 @@
     "test-ci": "npm run test-cov",
     "reformat": "npm run prettier -- --write ."
   },
-  "dependencies": {
-    "lodash": "^4.17.21"
-  },
   "devDependencies": {
     "@mongodb-js/eslint-config-devtools": "0.9.10",
     "@mongodb-js/mocha-config-devtools": "^1.0.4",


### PR DESCRIPTION
Just ran into this while writing a test for mongosh that ensures that `shell-api` is really as runtime-independent as we expect.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  Use `feat`, `fix` for user facing changes that should be part of release notes.

  # Semantic Versioning:

  Package versions will be bumped automatically according to the PR title:

  - The words `BREAKING CHANGE` in the title will cause a **major** bump to all the packages changed in the PR. All dependants will also have a major bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - A subject starting with `feat` will cause a **minor** bump to all the packages changed in the PR. All dependants will also have a minor bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - Any other change to any package will cause a `patch` bump to the package and all its dependants.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Checklist
- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
