### PR TITLE
WIP feat!(mongodb-log-writer): add ability to disable logging MONGOSH-1988

### DIFF
--- a/packages/devtools-connect/src/log-hook.spec.ts
+++ b/packages/devtools-connect/src/log-hook.spec.ts
@@ -1,5 +1,5 @@
-import { hookLogger } from '../';
-import type { ConnectLogEmitter } from '../';
+import { hookLogger } from './';
+import type { ConnectLogEmitter } from './';
 import { EventEmitter } from 'events';
 import { MongoLogWriter } from 'mongodb-log-writer';
 import { redactConnectionString } from 'mongodb-connection-string-url';
@@ -9,12 +9,12 @@ import { expect } from 'chai';
 describe('Logging setup', function () {
   it('logs events', async function () {
     const pt = new PassThrough();
-    const log = new MongoLogWriter(
-      'logid',
-      null,
-      pt,
-      () => new Date('2021-12-16T14:35:08.763Z')
-    );
+    const log = new MongoLogWriter({
+      logId: 'logid',
+      logFilePath: null,
+      target: pt,
+      now: () => new Date('2021-12-16T14:35:08.763Z'),
+    });
     const emitter: ConnectLogEmitter = new EventEmitter();
 
     hookLogger(emitter, log, 'prefix', redactConnectionString);

--- a/packages/mongodb-log-writer/package.json
+++ b/packages/mongodb-log-writer/package.json
@@ -56,6 +56,7 @@
     "lint": "eslint src/**/*.ts",
     "test-only": "nyc mocha --colors -r ts-node/register src/**.spec.ts",
     "test": "npm run lint && npm run build && npm run test-only",
+    "test-ci": "npm run test",
     "build": "npm run compile-ts && gen-esm-wrapper . ./.esm-wrapper.mjs",
     "prepack": "npm run build",
     "compile-ts": "tsc -p tsconfig.json"

--- a/packages/mongodb-log-writer/src/mongo-log-manager.spec.ts
+++ b/packages/mongodb-log-writer/src/mongo-log-manager.spec.ts
@@ -213,4 +213,17 @@ describe('MongoLogManager', function () {
     writer.end();
     await once(writer, 'finish');
   });
+
+  it('can create a disabled writer', async function () {
+    const manager = new MongoLogManager({
+      directory,
+      retentionDays,
+      onwarn,
+      onerror,
+      gzip: true,
+    });
+    const logWriter = await manager.createLogWriter({ isDisabled: true });
+
+    expect(logWriter.isDisabled).is.true;
+  });
 });

--- a/packages/mongodb-log-writer/src/mongo-log-manager.spec.ts
+++ b/packages/mongodb-log-writer/src/mongo-log-manager.spec.ts
@@ -222,8 +222,11 @@ describe('MongoLogManager', function () {
       onerror,
       gzip: true,
     });
-    const logWriter = await manager.createLogWriter({ isDisabled: true });
+    const writer = await manager.createLogWriter({ isDisabled: true });
 
-    expect(logWriter.isDisabled).is.true;
+    expect(writer.isDisabled).is.true;
+
+    writer.end();
+    await once(writer, 'finish');
   });
 });

--- a/packages/mongodb-log-writer/src/mongo-log-manager.ts
+++ b/packages/mongodb-log-writer/src/mongo-log-manager.ts
@@ -143,7 +143,12 @@ export class MongoLogManager {
       });
     }
     if (!logWriter) {
-      logWriter = new MongoLogWriter({ logId, logFilePath, target: stream });
+      logWriter = new MongoLogWriter({
+        ...writerOptions,
+        logId,
+        logFilePath,
+        target: stream,
+      });
     }
 
     // We use 'log-finish' to give consumers an event that they can

--- a/packages/mongodb-log-writer/src/mongo-log-writer.spec.ts
+++ b/packages/mongodb-log-writer/src/mongo-log-writer.spec.ts
@@ -2,6 +2,7 @@ import type { MongoLogEntry } from '.';
 import { MongoLogWriter, mongoLogId } from '.';
 import { EJSON } from 'bson';
 import stream from 'stream';
+import { once } from 'events';
 import { inspect } from 'util';
 import chai, { expect } from 'chai';
 import sinonChai from 'sinon-chai';
@@ -37,7 +38,9 @@ describe('MongoLogWriter', function () {
       writeSpy = sinon.spy(writer, 'write');
     });
 
-    afterEach(function () {
+    afterEach(async function () {
+      writer.end();
+      await once(writer, 'finish');
       sinon.restore();
     });
 
@@ -58,6 +61,7 @@ describe('MongoLogWriter', function () {
         logFilePath: null,
         target,
         now: () => now,
+        isDisabled: true,
       });
 
       expect(disabledWriter.isDisabled).to.equal(true);

--- a/packages/mongodb-log-writer/src/mongo-log-writer.spec.ts
+++ b/packages/mongodb-log-writer/src/mongo-log-writer.spec.ts
@@ -28,7 +28,12 @@ describe('MongoLogWriter', function () {
 
     beforeEach(function () {
       target = new stream.PassThrough().setEncoding('utf8');
-      writer = new MongoLogWriter('logid', null, target, () => now);
+      writer = new MongoLogWriter({
+        logId: 'logid',
+        logFilePath: null,
+        target,
+        now: () => now,
+      });
       writeSpy = sinon.spy(writer, 'write');
     });
 
@@ -48,15 +53,12 @@ describe('MongoLogWriter', function () {
     });
 
     it('can be disabled on initialization', async function () {
-      const disabledWriter = new MongoLogWriter(
-        'logid',
-        null,
+      const disabledWriter = new MongoLogWriter({
+        logId: 'logid',
+        logFilePath: null,
         target,
-        () => now,
-        {
-          isDisabled: true,
-        }
-      );
+        now: () => now,
+      });
 
       expect(disabledWriter.isDisabled).to.equal(true);
       logAllSeverities(disabledWriter);
@@ -107,7 +109,12 @@ describe('MongoLogWriter', function () {
 
   it('allows writing log messages to a stream', async function () {
     const target = new stream.PassThrough().setEncoding('utf8');
-    const writer = new MongoLogWriter('logid', null, target, () => now);
+    const writer = new MongoLogWriter({
+      logId: 'logid',
+      logFilePath: null,
+      target,
+      now: () => now,
+    });
     const logEvents: MongoLogEntry[] = [];
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     writer.on('log', (entry) => logEvents.push(entry));
@@ -207,7 +214,12 @@ describe('MongoLogWriter', function () {
   it('can log error object as data as-is', async function () {
     const now = new Date(1628591965386);
     const target = new stream.PassThrough().setEncoding('utf8');
-    const writer = new MongoLogWriter('logid', null, target, () => now);
+    const writer = new MongoLogWriter({
+      logId: 'logid',
+      logFilePath: null,
+      target,
+      now: () => now,
+    });
     writer.error(
       'component',
       mongoLogId(12345),
@@ -233,7 +245,12 @@ describe('MongoLogWriter', function () {
   it('can log non-trivial data', async function () {
     const now = new Date(1628591965386);
     const target = new stream.PassThrough().setEncoding('utf8');
-    const writer = new MongoLogWriter('logid', null, target, () => now);
+    const writer = new MongoLogWriter({
+      logId: 'logid',
+      logFilePath: null,
+      target,
+      now: () => now,
+    });
 
     const cyclic: any = {};
     cyclic.cyclic = cyclic;
@@ -256,7 +273,11 @@ describe('MongoLogWriter', function () {
     const errors: Error[] = [];
     function tryWrite(input: any) {
       const target = new stream.PassThrough().setEncoding('utf8');
-      const writer = new MongoLogWriter('logid', null, target);
+      const writer = new MongoLogWriter({
+        logId: 'logid',
+        logFilePath: null,
+        target,
+      });
       writer.on('error', (err) => errors.push(err));
       writer.write(input);
     }

--- a/packages/mongodb-log-writer/src/mongo-log-writer.ts
+++ b/packages/mongodb-log-writer/src/mongo-log-writer.ts
@@ -65,6 +65,10 @@ function validateLogEntry(info: MongoLogEntry): Error | null {
 
 export type MongoLogWriterOptions = {
   isDisabled?: boolean;
+  logId: string;
+  logFilePath: string | null;
+  target: PlainWritable;
+  now?: () => Date;
 };
 
 /**
@@ -88,13 +92,13 @@ export class MongoLogWriter extends Writable {
    * @param target The Writable stream to write data to.
    * @param now An optional function that overrides computation of the current time. This is used for testing.
    */
-  constructor(
-    logId: string,
-    logFilePath: string | null,
-    target: PlainWritable,
-    now?: () => Date,
-    { isDisabled = false }: MongoLogWriterOptions = {}
-  ) {
+  constructor({
+    logId,
+    logFilePath,
+    target,
+    now,
+    isDisabled = false,
+  }: MongoLogWriterOptions) {
     super({ objectMode: true });
     this._logId = logId;
     this._logFilePath = logFilePath;


### PR DESCRIPTION
WIP - do not review

Adds a new `isDisabled` field to disable the writing of logs. This can be modified using the new `enable()` and `disable()` methods.

See: https://github.com/mongodb-js/mongosh/pull/2325