### PR TITLE
feat(mongodb-log-writer): add ability to specify a prefix for log files

### DIFF
--- a/packages/mongodb-log-writer/src/mongo-log-manager.spec.ts
+++ b/packages/mongodb-log-writer/src/mongo-log-manager.spec.ts
@@ -31,6 +31,48 @@ describe('MongoLogManager', function () {
     sinon.restore();
   });
 
+  it('constructor throws with invalid prefixes', function () {
+    expect(() => {
+      new MongoLogManager({
+        directory,
+        retentionDays,
+        prefix: '%asdabs/',
+        onwarn,
+        onerror,
+      });
+    }).to.throw();
+
+    expect(() => {
+      new MongoLogManager({
+        directory,
+        retentionDays,
+        prefix: '$$$$',
+        onwarn,
+        onerror,
+      });
+    }).to.throw();
+
+    expect(() => {
+      new MongoLogManager({
+        directory,
+        retentionDays,
+        prefix: 'abc_',
+        onwarn,
+        onerror,
+      });
+    }).not.to.throw();
+
+    expect(() => {
+      new MongoLogManager({
+        directory,
+        retentionDays,
+        prefix: 'something',
+        onwarn,
+        onerror,
+      });
+    }).not.to.throw();
+  });
+
   it('allows creating and writing to log files', async function () {
     const manager = new MongoLogManager({
       directory,
@@ -144,8 +186,8 @@ describe('MongoLogManager', function () {
       directory,
       retentionDays,
       retentionGB: 3,
-      onerror,
       onwarn,
+      onerror,
     });
 
     const offset = Math.floor(Date.now() / 1000);

--- a/packages/mongodb-log-writer/src/mongo-log-manager.ts
+++ b/packages/mongodb-log-writer/src/mongo-log-manager.ts
@@ -21,10 +21,10 @@ interface MongoLogOptions {
   retentionGB?: number;
   /** Prefix to use for the log files */
   prefix?: string;
-  /** A handler for warnings related to a specific filesystem path. */
-  onerror: (err: Error, path: string) => unknown | Promise<void>;
   /** A handler for errors related to a specific filesystem path. */
   onerror: (err: Error, path: string) => unknown | Promise<void>;
+  /** A handler for warnings related to a specific filesystem path. */
+  onwarn: (err: Error, path: string) => unknown | Promise<void>;
 }
 
 /**
@@ -36,6 +36,13 @@ export class MongoLogManager {
   _options: MongoLogOptions;
 
   constructor(options: MongoLogOptions) {
+    if (options.prefix) {
+      if (!/^[a-z0-9_]+$/i.test(options.prefix)) {
+        throw new Error(
+          'Prefix must only contain letters, numbers, and underscores'
+        );
+      }
+    }
     this._options = options;
   }
 


### PR DESCRIPTION
This is needed for mongosh to use a `mongosh_` prefix for custom log directories.

Built on top of https://github.com/mongodb-js/devtools-shared/pull/504