### PR TITLE
fix(ci): use npm@9.x to avoid failing silently

### DIFF
--- a/.github/workflows/check-test.yaml
+++ b/.github/workflows/check-test.yaml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: read # we just need to checkout the repo
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   check-and-test:
@@ -60,7 +64,7 @@ jobs:
           cache: "npm"
 
       - name: Install npm
-        run: npm install -g npm@8
+        run: npm install -g npm@9
 
       - name: Use python@3.11
         # Default Python (3.12) doesn't have support for distutils

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       },
       "engines": {
         "node": ">=14.17.5",
-        "npm": ">=7.16.0"
+        "npm": ">=9.0.0"
       }
     },
     "configs/eslint-config-devtools": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "engines": {
     "node": ">=14.17.5",
-    "npm": ">=7.16.0"
+    "npm": ">=9.0.0"
   },
   "workspaces": [
     "packages/*",


### PR DESCRIPTION
Currently even if a lerna task fails, lerna still exits with success and so does the CI task.

The cause is the same as https://github.com/mongodb-js/mongosh/pull/1592 with NPM not sending the correct exit code. NPM 9 fixed this so this updates to that.

Example of a task which will actually fail now: https://github.com/mongodb-js/devtools-shared/actions/runs/13263792191/job/37026159185?pr=508
