### PR TITLE
fix(mongodb-log-writer): update prepack to match new naming

### DIFF
--- a/packages/mongodb-log-writer/package.json
+++ b/packages/mongodb-log-writer/package.json
@@ -58,7 +58,7 @@
     "test": "npm run lint && npm run compile && npm run test-only",
     "test-ci": "npm run test",
     "compile": "tsc -p tsconfig.json && gen-esm-wrapper . ./.esm-wrapper.mjs",
-    "prepack": "npm run build",
+    "prepack": "npm run compile",
     "bootstrap": "npm run compile"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
prepack was not updated to match the new compile naming