### PR TITLE
fix(ci): use npm@9 across across all workflows

### DIFF
--- a/.github/workflows/bump-packages.yaml
+++ b/.github/workflows/bump-packages.yaml
@@ -36,7 +36,7 @@ jobs:
           cache: "npm"
 
       - name: Install npm
-        run: npm install -g npm@8
+        run: npm install -g npm@9
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/publish-packages.yaml
+++ b/.github/workflows/publish-packages.yaml
@@ -43,7 +43,7 @@ jobs:
           cache: "npm"
 
       - name: Install npm
-        run: npm install -g npm@8
+        run: npm install -g npm@9
 
       - name: Install Dependencies
         run: |


### PR DESCRIPTION
This is needed in all workflows otherwise it'd break.