### PR TITLE
chore(ci): do not cancel in progress tasks on the main branch

### DIFF
--- a/.github/workflows/check-test.yaml
+++ b/.github/workflows/check-test.yaml
@@ -16,7 +16,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
`concurrency` settings for the tests workflow currently stop tests if a new commit is merged. This is fine and works as intended but can look a bit weird in main since we usually have a bump commit right after, meaning most commits would end up having cancelled steps and look like CI is in red.

This makes it so the rule doesn't apply on main and we run those tests for every commit.