### PR TITLE
fix(tests): clean up writer to prevent windows test failure

### DIFF
--- a/packages/mongodb-log-writer/src/mongo-log-manager.spec.ts
+++ b/packages/mongodb-log-writer/src/mongo-log-manager.spec.ts
@@ -115,6 +115,9 @@ describe('MongoLogManager', function () {
 
     const writer = await manager.createLogWriter();
     expect(writer.logFilePath as string).to.match(/custom_/);
+
+    writer.end();
+    await once(writer, 'finish');
   });
 
   it('cleans up old log files when requested', async function () {
@@ -577,7 +580,9 @@ describe('MongoLogManager', function () {
       },
       close: sinon.stub().resolves(),
     };
-    const opendirStub = sinon.stub(fs, 'opendir').resolves(fakeDirHandle as any);
+    const opendirStub = sinon
+      .stub(fs, 'opendir')
+      .resolves(fakeDirHandle as any);
 
     retentionDays = 0.000001; // 86.4 ms
     const manager = new MongoLogManager({


### PR DESCRIPTION
We're applying a `writer.end()` to be consistent with other places of properly cleaning the writer after creation as it messes with Windows CI tests.
https://github.com/mongodb-js/devtools-shared/blob/e3b8add78daf222a514c53ecb7a5bb7ad6d1aa78/packages/mongodb-log-writer/src/mongo-log-manager.spec.ts#L571-L573
