### PR TITLE
feat(get-os-info): derive Darwin / MacOS specific OS info COMPASS-9079

### DIFF
--- a/packages/get-os-info/src/get-os-info.spec.ts
+++ b/packages/get-os-info/src/get-os-info.spec.ts
@@ -67,4 +67,59 @@ describe('get-os-info', function () {
       });
     });
   });
+
+  describe('on darwin', function () {
+    it('parses the SystemVersion.plist file', function () {
+      const fixture = `
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+                <key>BuildID</key>
+                <string>2B3829A8-E319-11EF-8892-025514DE0AB1</string>
+                <key>ProductBuildVersion</key>
+                <string>24D70</string>
+                <key>ProductCopyright</key>
+                <string>1983-2025 Apple Inc.</string>
+                <key>ProductName</key>
+                <string>macOS</string>
+                <key>ProductUserVisibleVersion</key>
+                <string>15.3.1</string>
+                <key>ProductVersion</key>
+                <string>15.3.1</string>
+                <key>iOSSupportVersion</key>
+                <string>18.3</string>
+        </dict>
+        </plist>
+      `;
+
+      expect(parseDarwinInfo(fixture)).to.deep.equal({
+        os_darwin_product_name: 'macOS',
+        os_darwin_product_version: '15.3.1',
+        os_darwin_product_build_version: '24D70',
+      });
+    });
+
+    it('returns info from /System/Library/CoreServices/SystemVersion.plist', async function () {
+      if (process.platform !== 'darwin') {
+        this.skip();
+      }
+
+      const systemVersionPlist = await fs.readFile(
+        '/System/Library/CoreServices/SystemVersion.plist',
+        'utf-8'
+      );
+
+      const {
+        os_darwin_product_name,
+        os_darwin_product_version,
+        os_darwin_product_build_version,
+      } = await getOsInfo();
+
+      // Instead of reimplementing the parser, we simply check that the values are present in the original file
+      expect(systemVersionPlist).contains(os_darwin_product_name);
+      expect(systemVersionPlist).contains(os_darwin_product_version);
+      expect(systemVersionPlist).contains(os_darwin_product_build_version);
+    });
+  });
 });

--- a/packages/get-os-info/src/get-os-info.spec.ts
+++ b/packages/get-os-info/src/get-os-info.spec.ts
@@ -2,16 +2,11 @@ import { expect } from 'chai';
 import os from 'os';
 import { promises as fs } from 'fs';
 
-import { getOsInfo } from './get-os-info';
+import { getOsInfo, parseDarwinInfo, parseLinuxInfo } from './get-os-info';
 
 describe('get-os-info', function () {
-  let osInfo;
-  beforeEach(async function () {
-    osInfo = await getOsInfo();
-  });
-
-  it('returns info from "os" module', function () {
-    const { os_arch, os_type, os_version, os_release } = osInfo;
+  it('returns info from "os" module', async function () {
+    const { os_arch, os_type, os_version, os_release } = await getOsInfo();
     expect({ os_arch, os_type, os_version, os_release }).to.deep.equal({
       os_arch: os.arch(),
       os_type: os.type(),
@@ -21,13 +16,31 @@ describe('get-os-info', function () {
   });
 
   describe('on linux', function () {
-    beforeEach(function () {
-      if (process.platform !== 'linux') {
-        this.skip();
-      }
+    it('parses os-release file', function () {
+      // Copied from https://manpages.ubuntu.com/manpages/focal/man5/os-release.5.html#example
+      const fixture = `
+        NAME=Fedora
+        VERSION="17 (Beefy Miracle)"
+        ID=fedora
+        VERSION_ID=17
+        PRETTY_NAME="Fedora 17 (Beefy Miracle)"
+        ANSI_COLOR="0;34"
+        CPE_NAME="cpe:/o:fedoraproject:fedora:17"
+        HOME_URL="https://fedoraproject.org/"
+        BUG_REPORT_URL="https://bugzilla.redhat.com/"
+      `;
+
+      expect(parseLinuxInfo(fixture)).to.deep.equal({
+        os_linux_dist: 'fedora',
+        os_linux_release: '17',
+      });
     });
 
     it('returns info from /etc/releases', async function () {
+      if (process.platform !== 'linux') {
+        this.skip();
+      }
+
       const etcRelease = await fs.readFile('/etc/os-release', 'utf-8');
 
       const releaseKv = etcRelease
@@ -47,7 +60,7 @@ describe('get-os-info', function () {
       expect(distroId).to.match(/^(rhel|ubuntu|debian)$/);
       expect(distroVer).to.match(/^\d+/);
 
-      const { os_linux_dist, os_linux_release } = osInfo;
+      const { os_linux_dist, os_linux_release } = await getOsInfo();
       expect({ os_linux_dist, os_linux_release }).to.deep.equal({
         os_linux_dist: distroId,
         os_linux_release: distroVer,

--- a/packages/get-os-info/src/get-os-info.ts
+++ b/packages/get-os-info/src/get-os-info.ts
@@ -1,46 +1,44 @@
 import os from 'os';
 import { promises as fs } from 'fs';
 
+type LinuxInfo = {
+  os_linux_dist: string;
+  os_linux_release: string;
+};
+
 type OsInfo = {
   os_type: string;
   os_version: string;
   os_arch: string;
   os_release: string;
-  os_linux_dist?: string;
-  os_linux_release?: string;
-};
+} & Partial<LinuxInfo>;
 
-async function getLinuxInfo(): Promise<{
-  os_linux_dist: string;
-  os_linux_release: string;
-}> {
+async function getLinuxInfo(): Promise<LinuxInfo> {
   try {
     const releaseFile = '/etc/os-release';
     const etcRelease = await fs.readFile(releaseFile, 'utf-8');
-
-    const osReleaseEntries = etcRelease
-      .split('\n')
-      .map((l) => l.trim())
-      .filter(Boolean)
-      .map((l) => l.split('='))
-      .map(([k, v]) => [
-        k,
-        (v || '').replace(/^["']/, '').replace(/["']$/, ''),
-      ]);
-
-    const osReleaseKv = Object.fromEntries(osReleaseEntries);
-
-    return {
-      os_linux_dist: osReleaseKv.ID || 'unknown',
-      os_linux_release: osReleaseKv.VERSION_ID || 'unknown',
-    };
+    return parseLinuxInfo(etcRelease);
   } catch (e) {
-    // couldn't read /etc/os-release
+    return {
+      os_linux_dist: 'unknown',
+      os_linux_release: 'unknown',
+    };
   }
+}
+
+export function parseLinuxInfo(etcRelease: string): LinuxInfo {
+  const osReleaseEntries = etcRelease
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .map((l) => l.split('='))
+    .map(([k, v]) => [k, (v || '').replace(/^["']/, '').replace(/["']$/, '')]);
+
+  const osReleaseKv = Object.fromEntries(osReleaseEntries);
 
   return {
-    os_linux_dist: 'unknown',
-    os_linux_release: 'unknown',
+    os_linux_dist: osReleaseKv.ID || 'unknown',
+    os_linux_release: osReleaseKv.VERSION_ID || 'unknown',
   };
 }
 


### PR DESCRIPTION
## Description

Merging this PR will:
- Refactor the Linux implementation and tests into a parser and something reading the file.
- Add Darwin specific implementation and tests.

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Checklist
- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
