### PR TITLE
feat(dl-center): add support for session tokens COMPASS-9149

### DIFF
--- a/packages/dl-center/src/download-center.ts
+++ b/packages/dl-center/src/download-center.ts
@@ -24,8 +24,8 @@ export type S3BucketConfig = {
   secretAccessKey: string;
 
   /**
-  * The AWS session token
-  */
+   * The AWS session token
+   */
   sessionToken?: string;
 
   /**

--- a/packages/dl-center/src/download-center.ts
+++ b/packages/dl-center/src/download-center.ts
@@ -24,6 +24,11 @@ export type S3BucketConfig = {
   secretAccessKey: string;
 
   /**
+  * The AWS session token
+  */
+  sessionToken?: string;
+
+  /**
    * S3 service endpoint. Set this to connect to a local test server.
    */
   endpoint?: string;


### PR DESCRIPTION
This commit adjusts download-center.ts to support optional AWS session
tokens. These tokens are necessary if you want to use temporary credentials
for interacting with the download center, which we will in future commits
to mongosh/compass.
