### PR TITLE
feat(dl-center): add support for arbitrary acls COMPASS-9237

### DIFF
--- a/packages/dl-center/src/download-center.spec.ts
+++ b/packages/dl-center/src/download-center.spec.ts
@@ -79,6 +79,21 @@ describe('download center client', function () {
       const content = await downloadCenter.downloadAsset('prefix/asset.txt');
       expect(content?.toString()).to.contain('content');
     });
+
+    it('can upload a file with private acls and download it back', async function () {
+      await downloadCenter.uploadAsset(
+        'prefix-private/asset.txt',
+        createReadStream(fixturePath('asset.txt')),
+        {
+          acl: 'private',
+        }
+      );
+
+      const content = await downloadCenter.downloadAsset(
+        'prefix-private/asset.txt'
+      );
+      expect(content?.toString()).to.contain('content');
+    });
   });
 
   describe('upload / download config', function () {

--- a/packages/dl-center/src/download-center.ts
+++ b/packages/dl-center/src/download-center.ts
@@ -52,6 +52,7 @@ export type S3BucketConfig = {
 
 export type UploadAssetOptions = {
   contentType?: string;
+  acl?: string;
 };
 
 type S3UploadFunc = (
@@ -235,8 +236,10 @@ export class DownloadCenter {
       throw new Error('s3ObjectKey is required');
     }
 
+    const acl = options.acl ?? ACL_PUBLIC_READ;
+
     const uploadParams: S3.PutObjectRequest = {
-      ACL: ACL_PUBLIC_READ,
+      ACL: acl,
       Bucket: this.s3BucketName,
       Key: s3ObjectKey,
       Body: content,


### PR DESCRIPTION
This commit adjusts our DownloadCenter's UploadAssetOptions to support taking an optional 'acl' parameter. When we upload an asset to S3, this parameter is used to set the ACL on the put request. If no acl is set, we default to "public-read" to preserve backward compatibility.