### PR TITLE
fix(mongodb-cloud-info): if the host's IP is not in a cloud's range, check if the CNAME resolves to AWS. COMPASS-8932

### DIFF
--- a/packages/dl-center/src/download-center.spec.ts
+++ b/packages/dl-center/src/download-center.spec.ts
@@ -86,11 +86,11 @@ describe('download center client', function () {
         createReadStream(fixturePath('asset.txt')),
         {
           acl: 'private',
-        }
+        },
       );
 
       const content = await downloadCenter.downloadAsset(
-        'prefix-private/asset.txt'
+        'prefix-private/asset.txt',
       );
       expect(content?.toString()).to.contain('content');
     });

--- a/packages/mongodb-cloud-info/src/index.spec.ts
+++ b/packages/mongodb-cloud-info/src/index.spec.ts
@@ -5,86 +5,100 @@ import path from 'path';
 
 const expect = chai.expect;
 
-describe('getCloudInfo', function () {
-  beforeEach(function () {
-    nock('https://raw.githubusercontent.com', {
-      reqheaders: {
-        accept: '*/*',
-        'user-agent': 'node-fetch/1.0 (+https://github.com/bitinn/node-fetch)',
-        'accept-encoding': 'gzip,deflate',
-      },
-    })
-      .get('/mongodb-js/devtools-shared/main/resources/cidrs.json')
-      .replyWithFile(
-        200,
-        path.resolve(__dirname, '../../../resources/cidrs.json'),
+describe
+  .only('getCloudInfo', function () {
+    beforeEach(function () {
+      nock('https://raw.githubusercontent.com', {
+        reqheaders: {
+          accept: '*/*',
+          'user-agent':
+            'node-fetch/1.0 (+https://github.com/bitinn/node-fetch)',
+          'accept-encoding': 'gzip,deflate',
+        },
+      })
+        .get('/mongodb-js/devtools-shared/main/resources/cidrs.json')
+        .replyWithFile(
+          200,
+          path.resolve(__dirname, '../../../resources/cidrs.json'),
+        );
+    });
+
+    afterEach(function () {
+      nock.cleanAll();
+    });
+
+    it('returns all false for undefined', async function () {
+      const cloudInfo = await getCloudInfo();
+      expect(cloudInfo).to.deep.equal({
+        isAws: false,
+        isGcp: false,
+        isAzure: false,
+      });
+    });
+
+    it('returns all false for localhost', async function () {
+      const cloudInfo = await getCloudInfo('localhost');
+      expect(cloudInfo).to.deep.equal({
+        isAws: false,
+        isGcp: false,
+        isAzure: false,
+      });
+    });
+
+    it('works with local ip address (127.0.0.1)', async function () {
+      const cloudInfo = await getCloudInfo('127.0.0.1');
+      expect(cloudInfo).to.deep.equal({
+        isAws: false,
+        isGcp: false,
+        isAzure: false,
+      });
+    });
+
+    it('works with local ipv6 address (::1)', async function () {
+      const cloudInfo = await getCloudInfo('::1');
+      expect(cloudInfo).to.deep.equal({
+        isAws: false,
+        isGcp: false,
+        isAzure: false,
+      });
+    });
+
+    it('returns {isAws: true} if hostname is an AWS ip', async function () {
+      const cloudInfo = await getCloudInfo('13.248.118.1');
+      expect(cloudInfo).to.deep.equal({
+        isAws: true,
+        isGcp: false,
+        isAzure: false,
+      });
+    });
+
+    it('returns {isGcp: true} if hostname is a GCP ip', async function () {
+      const cloudInfo = await getCloudInfo('8.34.208.1');
+      expect(cloudInfo).to.deep.equal({
+        isAws: false,
+        isGcp: true,
+        isAzure: false,
+      });
+    });
+
+    it('returns {isAzure: true} if hostname is an Azure ip', async function () {
+      const cloudInfo = await getCloudInfo('13.64.151.161');
+      expect(cloudInfo).to.deep.equal({
+        isAws: false,
+        isGcp: false,
+        isAzure: true,
+      });
+    });
+
+    it('returns {isAws: true} if CNAME resolves to an AWS host', async function () {
+      const cloudInfo = await getCloudInfo(
+        'compass-data-sets-shard-00-00.e06dc.mongodb.net',
       );
-  });
-
-  afterEach(function () {
-    nock.cleanAll();
-  });
-
-  it('returns all false for undefined', async function () {
-    const cloudInfo = await getCloudInfo();
-    expect(cloudInfo).to.deep.equal({
-      isAws: false,
-      isGcp: false,
-      isAzure: false,
+      expect(cloudInfo).to.deep.equal({
+        isAws: true,
+        isGcp: false,
+        isAzure: false,
+      });
     });
-  });
-
-  it('returns all false for localhost', async function () {
-    const cloudInfo = await getCloudInfo('localhost');
-    expect(cloudInfo).to.deep.equal({
-      isAws: false,
-      isGcp: false,
-      isAzure: false,
-    });
-  });
-
-  it('works with local ip address (127.0.0.1)', async function () {
-    const cloudInfo = await getCloudInfo('127.0.0.1');
-    expect(cloudInfo).to.deep.equal({
-      isAws: false,
-      isGcp: false,
-      isAzure: false,
-    });
-  });
-
-  it('works with local ipv6 address (::1)', async function () {
-    const cloudInfo = await getCloudInfo('::1');
-    expect(cloudInfo).to.deep.equal({
-      isAws: false,
-      isGcp: false,
-      isAzure: false,
-    });
-  });
-
-  it('returns {isAws: true} if hostname is an AWS ip', async function () {
-    const cloudInfo = await getCloudInfo('13.248.118.1');
-    expect(cloudInfo).to.deep.equal({
-      isAws: true,
-      isGcp: false,
-      isAzure: false,
-    });
-  });
-
-  it('returns {isGcp: true} if hostname is a GCP ip', async function () {
-    const cloudInfo = await getCloudInfo('8.34.208.1');
-    expect(cloudInfo).to.deep.equal({
-      isAws: false,
-      isGcp: true,
-      isAzure: false,
-    });
-  });
-
-  it('returns {isAzure: true} if hostname is an Azure ip', async function () {
-    const cloudInfo = await getCloudInfo('13.64.151.161');
-    expect(cloudInfo).to.deep.equal({
-      isAws: false,
-      isGcp: false,
-      isAzure: true,
-    });
-  });
-}).timeout(5000);
+  })
+  .timeout(5000);

--- a/packages/mongodb-cloud-info/src/index.spec.ts
+++ b/packages/mongodb-cloud-info/src/index.spec.ts
@@ -5,100 +5,97 @@ import path from 'path';
 
 const expect = chai.expect;
 
-describe
-  .only('getCloudInfo', function () {
-    beforeEach(function () {
-      nock('https://raw.githubusercontent.com', {
-        reqheaders: {
-          accept: '*/*',
-          'user-agent':
-            'node-fetch/1.0 (+https://github.com/bitinn/node-fetch)',
-          'accept-encoding': 'gzip,deflate',
-        },
-      })
-        .get('/mongodb-js/devtools-shared/main/resources/cidrs.json')
-        .replyWithFile(
-          200,
-          path.resolve(__dirname, '../../../resources/cidrs.json'),
-        );
-    });
-
-    afterEach(function () {
-      nock.cleanAll();
-    });
-
-    it('returns all false for undefined', async function () {
-      const cloudInfo = await getCloudInfo();
-      expect(cloudInfo).to.deep.equal({
-        isAws: false,
-        isGcp: false,
-        isAzure: false,
-      });
-    });
-
-    it('returns all false for localhost', async function () {
-      const cloudInfo = await getCloudInfo('localhost');
-      expect(cloudInfo).to.deep.equal({
-        isAws: false,
-        isGcp: false,
-        isAzure: false,
-      });
-    });
-
-    it('works with local ip address (127.0.0.1)', async function () {
-      const cloudInfo = await getCloudInfo('127.0.0.1');
-      expect(cloudInfo).to.deep.equal({
-        isAws: false,
-        isGcp: false,
-        isAzure: false,
-      });
-    });
-
-    it('works with local ipv6 address (::1)', async function () {
-      const cloudInfo = await getCloudInfo('::1');
-      expect(cloudInfo).to.deep.equal({
-        isAws: false,
-        isGcp: false,
-        isAzure: false,
-      });
-    });
-
-    it('returns {isAws: true} if hostname is an AWS ip', async function () {
-      const cloudInfo = await getCloudInfo('13.248.118.1');
-      expect(cloudInfo).to.deep.equal({
-        isAws: true,
-        isGcp: false,
-        isAzure: false,
-      });
-    });
-
-    it('returns {isGcp: true} if hostname is a GCP ip', async function () {
-      const cloudInfo = await getCloudInfo('8.34.208.1');
-      expect(cloudInfo).to.deep.equal({
-        isAws: false,
-        isGcp: true,
-        isAzure: false,
-      });
-    });
-
-    it('returns {isAzure: true} if hostname is an Azure ip', async function () {
-      const cloudInfo = await getCloudInfo('13.64.151.161');
-      expect(cloudInfo).to.deep.equal({
-        isAws: false,
-        isGcp: false,
-        isAzure: true,
-      });
-    });
-
-    it('returns {isAws: true} if CNAME resolves to an AWS host', async function () {
-      const cloudInfo = await getCloudInfo(
-        'compass-data-sets-shard-00-00.e06dc.mongodb.net',
+describe('getCloudInfo', function () {
+  beforeEach(function () {
+    nock('https://raw.githubusercontent.com', {
+      reqheaders: {
+        accept: '*/*',
+        'user-agent': 'node-fetch/1.0 (+https://github.com/bitinn/node-fetch)',
+        'accept-encoding': 'gzip,deflate',
+      },
+    })
+      .get('/mongodb-js/devtools-shared/main/resources/cidrs.json')
+      .replyWithFile(
+        200,
+        path.resolve(__dirname, '../../../resources/cidrs.json'),
       );
-      expect(cloudInfo).to.deep.equal({
-        isAws: true,
-        isGcp: false,
-        isAzure: false,
-      });
+  });
+
+  afterEach(function () {
+    nock.cleanAll();
+  });
+
+  it('returns all false for undefined', async function () {
+    const cloudInfo = await getCloudInfo();
+    expect(cloudInfo).to.deep.equal({
+      isAws: false,
+      isGcp: false,
+      isAzure: false,
     });
-  })
-  .timeout(5000);
+  });
+
+  it('returns all false for localhost', async function () {
+    const cloudInfo = await getCloudInfo('localhost');
+    expect(cloudInfo).to.deep.equal({
+      isAws: false,
+      isGcp: false,
+      isAzure: false,
+    });
+  });
+
+  it('works with local ip address (127.0.0.1)', async function () {
+    const cloudInfo = await getCloudInfo('127.0.0.1');
+    expect(cloudInfo).to.deep.equal({
+      isAws: false,
+      isGcp: false,
+      isAzure: false,
+    });
+  });
+
+  it('works with local ipv6 address (::1)', async function () {
+    const cloudInfo = await getCloudInfo('::1');
+    expect(cloudInfo).to.deep.equal({
+      isAws: false,
+      isGcp: false,
+      isAzure: false,
+    });
+  });
+
+  it('returns {isAws: true} if hostname is an AWS ip', async function () {
+    const cloudInfo = await getCloudInfo('13.248.118.1');
+    expect(cloudInfo).to.deep.equal({
+      isAws: true,
+      isGcp: false,
+      isAzure: false,
+    });
+  });
+
+  it('returns {isGcp: true} if hostname is a GCP ip', async function () {
+    const cloudInfo = await getCloudInfo('8.34.208.1');
+    expect(cloudInfo).to.deep.equal({
+      isAws: false,
+      isGcp: true,
+      isAzure: false,
+    });
+  });
+
+  it('returns {isAzure: true} if hostname is an Azure ip', async function () {
+    const cloudInfo = await getCloudInfo('13.64.151.161');
+    expect(cloudInfo).to.deep.equal({
+      isAws: false,
+      isGcp: false,
+      isAzure: true,
+    });
+  });
+
+  it('returns {isAws: true} if CNAME resolves to an AWS host', async function () {
+    const cloudInfo = await getCloudInfo(
+      'compass-data-sets-shard-00-00.e06dc.mongodb.net',
+    );
+    expect(cloudInfo).to.deep.equal({
+      isAws: true,
+      isGcp: false,
+      isAzure: false,
+    });
+  });
+}).timeout(5000);

--- a/packages/mongodb-cloud-info/src/index.ts
+++ b/packages/mongodb-cloud-info/src/index.ts
@@ -48,7 +48,7 @@ async function hasAWSCname(host: string) {
     return addresses.some((address) => address.endsWith('.amazonaws.com'));
   } catch (err: unknown) {
     // This can be any of a long list of codes, but in all cases we're just
-    // going to assume that it is not one an AWS host.
+    // going to assume that it is not on an AWS host.
     // (see https://nodejs.org/api/dns.html#error-codes)
     return false;
   }


### PR DESCRIPTION
This is to deal with the fact that Atlas has some of their own IP addresses for AWS hosts and that messes up telemetry reporting.