### PR TITLE
fix: include type exports for mongodb-runner and native-machine-id

### DIFF
--- a/packages/mongodb-runner/package.json
+++ b/packages/mongodb-runner/package.json
@@ -28,8 +28,11 @@
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/.esm-wrapper.mjs"
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/.esm-wrapper.mjs",
+      "types": "./dist/index.d.ts"
+    }
   },
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/packages/native-machine-id/package.json
+++ b/packages/native-machine-id/package.json
@@ -25,9 +25,11 @@
   },
   "license": "Apache-2.0",
   "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/.esm-wrapper.mjs",
-    "types": "./dist/index.d.ts"
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/.esm-wrapper.mjs",
+      "types": "./dist/index.d.ts"
+    }
   },
   "homepage": "https://github.com/mongodb-js/devtools-shared",
   "repository": {


### PR DESCRIPTION
This is not necessary for native-machine-id but just doing this change to force a release through CI.