### PR TITLE
fix(sbom-tools): properly do relative lookups for external prod dependencies

### DIFF
--- a/packages/sbom-tools/src/production-deps.ts
+++ b/packages/sbom-tools/src/production-deps.ts
@@ -73,7 +73,7 @@ export function findAllProdDepsTreeLocations(from = process.cwd()): string[] {
       ...Object.keys(optionalDependencies),
     ].forEach((dep) => {
       try {
-        const depLocation = findPackageLocation(dep, from);
+        const depLocation = findPackageLocation(dep, packageLocation);
 
         if (depLocation) {
           allLocations.add(depLocation);

--- a/packages/sbom-tools/src/webpack-dependencies-plugin.spec.ts
+++ b/packages/sbom-tools/src/webpack-dependencies-plugin.spec.ts
@@ -185,6 +185,7 @@ describe('WebpackDependenciesPlugin', function () {
         version: '0.1.0',
         dependencies: {
           pkg2: '^0.1.0',
+          pkg4: '^1.2.3',
         },
       }),
       'node_modules/pkg1/index.js': '',
@@ -206,6 +207,16 @@ describe('WebpackDependenciesPlugin', function () {
         version: '0.1.0',
       }),
       'node_modules/pkg3/index.js': '',
+      'node_modules/pkg4/package.json': JSON.stringify({
+        name: 'pkg4',
+        version: '1.2.4', // should be ignored in favor of nested one
+      }),
+      'node_modules/pkg4/index.js': '',
+      'node_modules/pkg1/node_modules/pkg4/package.json': JSON.stringify({
+        name: 'pkg4',
+        version: '1.2.5',
+      }),
+      'node_modules/pkg1/node_modules/pkg4/index.js': '',
     };
 
     const dependencies = await runPlugin(structure, {
@@ -232,6 +243,11 @@ describe('WebpackDependenciesPlugin', function () {
         licenseFiles: [],
         name: 'pkg3',
         version: '0.1.0',
+      },
+      {
+        licenseFiles: [],
+        name: 'pkg4',
+        version: '1.2.5',
       },
     ]);
   });


### PR DESCRIPTION
We are currently receiving a vulnerability report for `brace-expansion` in mongosh even though we do not include said package in our production bundle.

Tracking down this discrepancy led to this bug in our webpack dependency plugin.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  Use `feat`, `fix` for user facing changes that should be part of release notes.

  # Semantic Versioning:

  Package versions will be bumped automatically according to the PR title:

  - The words `BREAKING CHANGE` in the title will cause a **major** bump to all the packages changed in the PR. All dependants will also have a major bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - A subject starting with `feat` will cause a **minor** bump to all the packages changed in the PR. All dependants will also have a minor bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - Any other change to any package will cause a `patch` bump to the package and all its dependants.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Checklist
- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
