### PR TITLE
feat(mongodb-constants): add $rankFusion stage for 8.1+ COMPASS-9429

### DIFF
--- a/packages/mongodb-constants/src/stage-operators.ts
+++ b/packages/mongodb-constants/src/stage-operators.ts
@@ -752,6 +752,48 @@ const STAGE_OPERATORS = [
 }`,
   },
   {
+    name: '$rankFusion',
+    value: '$rankFusion',
+    label: '$rankFusion',
+    outputStage: false,
+    fullScan: false,
+    firstStage: false,
+    score: 1,
+    env: [ATLAS],
+    meta: 'stage',
+    version: '8.1.0',
+    apiVersions: [],
+    namespaces: [COLLECTION],
+    description:
+      'Combines multiple pipelines using reciprocal rank fusion to create hybrid search results.',
+    comment: `/**
+ * input.pipelines: Required. Map from name to input pipeline. Each pipeline must be a Ranked Selection Pipeline operating on the same collection. Minimum of one pipeline.
+ * combination.weights: Optional. Map from pipeline name to numbers (non-negative). If unspecified, default weight is 1 for each pipeline.
+ * scoreDetails: Optional. Default false. Set to true to include detailed scoring information in {$meta: "scoreDetails"} for debugging and tuning.
+ */
+`,
+    snippet: `{
+  input: {
+    pipelines: {
+      \${1:searchPipeline}: [
+        {$search: {\${2:searchStage}}},
+        {$limit: \${3:limit}}
+      ],
+      \${4:vectorPipeline}: [
+        {$vectorSearch: {\${5:vectorSearchStage}}}
+      ]
+    }
+  },
+  combination: {
+    weights: {
+      \${1:searchPipeline}: \${6:number},
+      \${4:vectorPipeline}: \${7:number}
+    }
+  },
+  scoreDetails: \${8:false}
+}`,
+  },
+  {
     name: '$redact',
     value: '$redact',
     label: '$redact',


### PR DESCRIPTION
COMPASS-9429

Tech design for reference: https://docs.google.com/document/d/1WgwYPE64T0E-BChqLdGPw1wo5z0ZYrrcbEASOoFl81M/edit?tab=t.0#heading=h.1ivq9tntp9c 