### PR TITLE
shell-api 3.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8104,9 +8104,9 @@
       }
     },
     "node_modules/@mongosh/shell-api": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-3.11.0.tgz",
-      "integrity": "sha512-JrhPX1XHE+7rLqT1S0ZPfzZ8+YbgrycbfknZ1yCgPUy1zf9Ee//uW4WRguPbI8DM6hSECvpLJU7CFKbHw0FUXw==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-3.13.0.tgz",
+      "integrity": "sha512-OhwHMQ25F743UMKJKG0iZjwhCFyeD8QzSSjc68v7sZ73kVG15CEqYvFec4wZxBDDxVzRPPnAoc2bOmIgblJb8A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -31009,7 +31009,7 @@
         "@mongodb-js/mocha-config-devtools": "^1.0.5",
         "@mongodb-js/prettier-config-devtools": "^1.0.2",
         "@mongodb-js/tsconfig-devtools": "^1.0.3",
-        "@mongosh/shell-api": "^3.11.0",
+        "@mongosh/shell-api": "^3.13.0",
         "@types/chai": "^4.2.21",
         "@types/mocha": "^9.1.1",
         "@types/node": "^22.15.30",
@@ -31026,7 +31026,7 @@
         "ts-node": "^10.9.2"
       },
       "peerDependencies": {
-        "@mongosh/shell-api": "^3.11.0"
+        "@mongosh/shell-api": "^3.13.0"
       }
     },
     "packages/mongodb-ts-autocomplete/node_modules/typescript": {
@@ -38999,7 +38999,7 @@
         "@mongodb-js/prettier-config-devtools": "^1.0.2",
         "@mongodb-js/ts-autocomplete": "^0.3.2",
         "@mongodb-js/tsconfig-devtools": "^1.0.3",
-        "@mongosh/shell-api": "^3.11.0",
+        "@mongosh/shell-api": "^3.13.0",
         "@types/chai": "^4.2.21",
         "@types/mocha": "^9.1.1",
         "@types/node": "^22.15.30",
@@ -39862,9 +39862,9 @@
       }
     },
     "@mongosh/shell-api": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-3.11.0.tgz",
-      "integrity": "sha512-JrhPX1XHE+7rLqT1S0ZPfzZ8+YbgrycbfknZ1yCgPUy1zf9Ee//uW4WRguPbI8DM6hSECvpLJU7CFKbHw0FUXw==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-3.13.0.tgz",
+      "integrity": "sha512-OhwHMQ25F743UMKJKG0iZjwhCFyeD8QzSSjc68v7sZ73kVG15CEqYvFec4wZxBDDxVzRPPnAoc2bOmIgblJb8A==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.26.10",

--- a/packages/mongodb-ts-autocomplete/package.json
+++ b/packages/mongodb-ts-autocomplete/package.json
@@ -48,7 +48,7 @@
     "extract-types": "ts-node scripts/extract-types.ts"
   },
   "peerDependencies": {
-    "@mongosh/shell-api": "^3.11.0"
+    "@mongosh/shell-api": "^3.13.0"
   },
   "dependencies": {
     "@mongodb-js/ts-autocomplete": "^0.3.2",
@@ -61,7 +61,7 @@
     "@mongodb-js/mocha-config-devtools": "^1.0.5",
     "@mongodb-js/prettier-config-devtools": "^1.0.2",
     "@mongodb-js/tsconfig-devtools": "^1.0.3",
-    "@mongosh/shell-api": "^3.11.0",
+    "@mongosh/shell-api": "^3.13.0",
     "@types/chai": "^4.2.21",
     "@types/mocha": "^9.1.1",
     "@types/node": "^22.15.30",


### PR DESCRIPTION
mongodb-ts-autocomplete now doesn't want to install from shell-api because the peer dep version doesn't match. I guess this will then break again the moment shell-api bumps after merging the PR there..