### PR TITLE
fix exports in package.json to work with ts's implementation of node16 moduleResolution

### DIFF
--- a/packages/device-id/package.json
+++ b/packages/device-id/package.json
@@ -23,14 +23,19 @@
   ],
   "license": "Apache-2.0",
   "main": "dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "import": "./dist/.esm-wrapper.mjs",
-      "types": "./dist/index.d.ts"
+      "require": {
+        "default": "./dist/index.js",
+        "types": "./dist/index.d.ts"
+      },
+      "import": {
+        "default": "./dist/.esm-wrapper.mjs",
+        "types": "./dist/index.d.ts"
+      }
     }
   },
-  "types": "./dist/index.d.ts",
   "scripts": {
     "bootstrap": "npm run compile",
     "prepublishOnly": "npm run compile",

--- a/packages/devtools-proxy-support/package.json
+++ b/packages/devtools-proxy-support/package.json
@@ -23,19 +23,29 @@
   ],
   "license": "Apache-2.0",
   "main": "dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "import": "./dist/.esm-wrapper.mjs",
-      "types": "./dist/index.d.ts"
+      "require": {
+        "default": "./dist/index.js",
+        "types": "./dist/index.d.ts"
+      },
+      "import": {
+        "default": "./dist/.esm-wrapper.mjs",
+        "types": "./dist/index.d.ts"
+      }
     },
     "./proxy-options": {
-      "require": "./dist/proxy-options-public.js",
-      "import": "./dist/.esm-wrapper-po.mjs",
-      "types": "./dist/proxy-options-public.d.ts"
+      "require": {
+        "default": "./dist/proxy-options-public.js",
+        "types": "./dist/proxy-options-public.d.ts"
+      },
+      "import": {
+        "default": "./dist/.esm-wrapper-po.mjs",
+        "types": "./dist/proxy-options-public.d.ts"
+      }
     }
   },
-  "types": "./dist/index.d.ts",
   "scripts": {
     "bootstrap": "npm run compile",
     "prepublishOnly": "npm run compile",

--- a/packages/dl-center/package.json
+++ b/packages/dl-center/package.json
@@ -23,12 +23,17 @@
   ],
   "license": "Apache-2.0",
   "main": "dist/index.js",
-  "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/.esm-wrapper.mjs",
-    "types": "./dist/index.d.ts"
-  },
   "types": "./dist/index.d.ts",
+  "exports": {
+    "require": {
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "import": {
+      "default": "./dist/.esm-wrapper.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "generate-config-from-schema": "json2ts -i src/download-center-config.schema.json -o src/download-center-config.ts --bannerComment \"/* AUTO-GENERATED DO NOT EDIT. */\"",
     "pretest": "npm run generate-config-from-schema && npm run reformat",

--- a/packages/download-url/package.json
+++ b/packages/download-url/package.json
@@ -21,12 +21,17 @@
     "reformat": "npm run prettier -- --write ."
   },
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "exports": {
-    "require": "./lib/index.js",
-    "import": "./.esm-wrapper.mjs",
-    "types": "./lib/index.d.ts"
+    "require": {
+      "default": "./lib/index.js",
+      "types": "./lib/index.d.ts"
+    },
+    "import": {
+      "default": "./.esm-wrapper.mjs",
+      "types": "./lib/index.d.ts"
+    }
   },
-  "typings": "lib/index.d.ts",
   "bin": {
     "mongodb-download-url": "bin/mongodb-download-url.js"
   },

--- a/packages/get-os-info/package.json
+++ b/packages/get-os-info/package.json
@@ -24,9 +24,14 @@
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/.esm-wrapper.mjs",
-    "types": "./dist/index.d.ts"
+    "require": {
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "import": {
+      "default": "./dist/.esm-wrapper.mjs",
+      "types": "./dist/index.d.ts"
+    }
   },
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/packages/mongodb-cloud-info/package.json
+++ b/packages/mongodb-cloud-info/package.json
@@ -23,12 +23,17 @@
   ],
   "license": "Apache-2.0",
   "main": "dist/index.js",
-  "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/.esm-wrapper.mjs",
-    "types": "./dist/index.d.ts"
-  },
   "types": "./dist/index.d.ts",
+  "exports": {
+    "require": {
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "import": {
+      "default": "./dist/.esm-wrapper.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "bootstrap": "npm run compile",
     "prepublishOnly": "npm run compile",

--- a/packages/mongodb-constants/package.json
+++ b/packages/mongodb-constants/package.json
@@ -23,12 +23,17 @@
   ],
   "license": "Apache-2.0",
   "main": "dist/index.js",
-  "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/.esm-wrapper.mjs",
-    "types": "./dist/index.d.ts"
-  },
   "types": "./dist/index.d.ts",
+  "exports": {
+    "require": {
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "import": {
+      "default": "./dist/.esm-wrapper.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "bootstrap": "npm run compile",
     "prepublishOnly": "npm run compile",

--- a/packages/mongodb-downloader/package.json
+++ b/packages/mongodb-downloader/package.json
@@ -23,12 +23,17 @@
   ],
   "license": "Apache-2.0",
   "main": "dist/index.js",
-  "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/.esm-wrapper.mjs",
-    "types": "./dist/index.d.ts"
-  },
   "types": "./dist/index.d.ts",
+  "exports": {
+    "require": {
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "import": {
+      "default": "./dist/.esm-wrapper.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "bootstrap": "npm run compile",
     "prepublishOnly": "npm run compile",

--- a/packages/mongodb-redact/package.json
+++ b/packages/mongodb-redact/package.json
@@ -23,12 +23,17 @@
   ],
   "license": "Apache-2.0",
   "main": "dist/index.js",
-  "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/.esm-wrapper.mjs",
-    "types": "./dist/index.d.ts"
-  },
   "types": "./dist/index.d.ts",
+  "exports": {
+    "require": {
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "import": {
+      "default": "./dist/.esm-wrapper.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "bootstrap": "npm run compile",
     "prepublishOnly": "npm run compile",

--- a/packages/mongodb-runner/package.json
+++ b/packages/mongodb-runner/package.json
@@ -27,14 +27,17 @@
   },
   "license": "Apache-2.0",
   "main": "dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": {
-      "require": "./dist/index.js",
-      "import": "./dist/.esm-wrapper.mjs",
+    "require": {
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "import": {
+      "default": "./dist/.esm-wrapper.mjs",
       "types": "./dist/index.d.ts"
     }
   },
-  "types": "./dist/index.d.ts",
   "scripts": {
     "bootstrap": "npm run compile",
     "prepublishOnly": "npm run compile",

--- a/packages/mongodb-ts-autocomplete/package.json
+++ b/packages/mongodb-ts-autocomplete/package.json
@@ -23,12 +23,17 @@
   ],
   "license": "Apache-2.0",
   "main": "dist/index.js",
-  "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/.esm-wrapper.mjs",
-    "types": "./dist/index.d.ts"
-  },
   "types": "./dist/index.d.ts",
+  "exports": {
+    "require": {
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "import": {
+      "default": "./dist/.esm-wrapper.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "bootstrap": "npm run compile",
     "prepublishOnly": "npm run compile",

--- a/packages/mql-typescript/package.json
+++ b/packages/mql-typescript/package.json
@@ -27,12 +27,22 @@
   },
   "license": "Apache-2.0",
   "main": "dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
+    ".": {
+      "require": {
+        "default": "./dist/index.js",
+        "types": "./dist/index.d.ts"
+      },
+      "import": {
+        "default": "./dist/.esm-wrapper.mjs",
+        "types": "./dist/index.d.ts"
+      }
+    },
     "./schema": {
       "types": "./out/schema.d.ts"
     }
   },
-  "types": "./dist/index.d.ts",
   "scripts": {
     "bootstrap": "npm run compile",
     "prepublishOnly": "npm run compile",

--- a/packages/native-machine-id/package.json
+++ b/packages/native-machine-id/package.json
@@ -28,9 +28,12 @@
   },
   "license": "Apache-2.0",
   "exports": {
-    ".": {
-      "require": "./dist/index.js",
-      "import": "./dist/.esm-wrapper.mjs",
+    "require": {
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "import": {
+      "default": "./dist/.esm-wrapper.mjs",
       "types": "./dist/index.d.ts"
     }
   },

--- a/packages/oidc-http-server-pages/package.json
+++ b/packages/oidc-http-server-pages/package.json
@@ -23,12 +23,17 @@
   ],
   "license": "Apache-2.0",
   "main": "dist/index.js",
-  "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/.esm-wrapper.mjs",
-    "types": "./dist/index.d.ts"
-  },
   "types": "./dist/index.d.ts",
+  "exports": {
+    "require": {
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "import": {
+      "default": "./dist/.esm-wrapper.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "bootstrap": "npm run compile",
     "prepublishOnly": "npm run compile",

--- a/packages/oidc-mock-provider/package.json
+++ b/packages/oidc-mock-provider/package.json
@@ -28,12 +28,17 @@
   },
   "license": "Apache-2.0",
   "main": "dist/index.js",
-  "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/.esm-wrapper.mjs",
-    "types": "./dist/index.d.ts"
-  },
   "types": "./dist/index.d.ts",
+  "exports": {
+    "require": {
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "import": {
+      "default": "./dist/.esm-wrapper.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "bootstrap": "npm run compile",
     "prepublishOnly": "npm run compile",

--- a/packages/query-parser/package.json
+++ b/packages/query-parser/package.json
@@ -23,12 +23,17 @@
   ],
   "license": "Apache-2.0",
   "main": "dist/index.js",
-  "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/.esm-wrapper.mjs",
-    "types": "./dist/index.d.ts"
-  },
   "types": "./dist/index.d.ts",
+  "exports": {
+    "require": {
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "import": {
+      "default": "./dist/.esm-wrapper.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "bootstrap": "npm run compile",
     "prepublishOnly": "npm run compile",

--- a/packages/sbom-tools/package.json
+++ b/packages/sbom-tools/package.json
@@ -26,12 +26,17 @@
   ],
   "license": "Apache-2.0",
   "main": "dist/index.js",
-  "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/.esm-wrapper.mjs",
-    "types": "./dist/index.d.ts"
-  },
   "types": "./dist/index.d.ts",
+  "exports": {
+    "require": {
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "import": {
+      "default": "./dist/.esm-wrapper.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "bootstrap": "npm run compile",
     "prepublishOnly": "npm run compile",

--- a/packages/shell-bson-parser/package.json
+++ b/packages/shell-bson-parser/package.json
@@ -23,9 +23,16 @@
   ],
   "license": "Apache-2.0",
   "main": "dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/.esm-wrapper.mjs"
+    "require": {
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "import": {
+      "default": "./dist/.esm-wrapper.mjs",
+      "types": "./dist/index.d.ts"
+    }
   },
   "scripts": {
     "bootstrap": "npm run compile",

--- a/packages/signing-utils/package.json
+++ b/packages/signing-utils/package.json
@@ -24,12 +24,17 @@
   ],
   "license": "SSPL",
   "main": "dist/index.js",
-  "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/.esm-wrapper.mjs",
-    "types": "./dist/index.d.ts"
-  },
   "types": "./dist/index.d.ts",
+  "exports": {
+    "require": {
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "import": {
+      "default": "./dist/.esm-wrapper.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "bootstrap": "npm run compile",
     "prepublishOnly": "npm run compile",

--- a/packages/ts-autocomplete/package.json
+++ b/packages/ts-autocomplete/package.json
@@ -23,12 +23,17 @@
   ],
   "license": "Apache-2.0",
   "main": "dist/index.js",
-  "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/.esm-wrapper.mjs",
-    "types": "./dist/index.d.ts"
-  },
   "types": "./dist/index.d.ts",
+  "exports": {
+    "require": {
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "import": {
+      "default": "./dist/.esm-wrapper.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "bootstrap": "npm run compile",
     "prepublishOnly": "npm run compile",

--- a/scripts/src/create-workspace.js
+++ b/scripts/src/create-workspace.js
@@ -168,11 +168,17 @@ async function main(argv) {
     files: ['dist'],
     license: license,
     main: 'dist/index.js',
-    exports: {
-      require: './dist/index.js',
-      import: './dist/.esm-wrapper.mjs',
-    },
     types: './dist/index.d.ts',
+    exports: {
+      require: {
+        default: './dist/index.js',
+        types: './dist/index.d.ts',
+      },
+      import: {
+        default: './dist/.esm-wrapper.mjs',
+        types: './dist/index.d.ts',
+      },
+    },
     scripts: {
       bootstrap: 'npm run compile',
       prepublishOnly: 'npm run compile',


### PR DESCRIPTION
This is a follow-up to https://github.com/mongodb-js/devtools-shared/pull/546 where I didn't properly understand this.

The context of why/where I need this is to be able to use a separate types export from the default one [from mongosh](https://github.com/mongodb-js/mongosh/pull/2478/files). 

The latest error I'm getting there:

```
src/index.ts:428:5 - error TS7016: Could not find a declaration file for module '@mongodb-js/mongodb-ts-autocomplete'. '/Users/leroux.bodenstein/mongo/mongosh/packages/autocomplete/node_modules/@mongodb-js/mongodb-ts-autocomplete/dist/.esm-wrapper.mjs' implicitly has an 'any' type.
  There are types at '/Users/leroux.bodenstein/mongo/mongosh/packages/autocomplete/node_modules/@mongodb-js/mongodb-ts-autocomplete/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@mongodb-js/mongodb-ts-autocomplete' library may need to update its package.json or typings.

428     '@mongodb-js/mongodb-ts-autocomplete'
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Basically TS _sees_ the right types but refuses to use it 😛 

The way this should work is actually, if you're exporting multiple things:

```javascript
exports: {
  '.': {
    import: {
      default: '',
      types: '',
    },
    require: {
      default: '',
      types: '',
    }
  }
  foo: {
    import: {
      default: '',
      types: '',
    },
    require: {
      default: '',
      types: '',
    }
  }
}
```

then if you're just exporting one thing (the usual case):

```javascript
exports: {
  import: {
    default: '',
    types: '',
  },
  require: {
    default: '',
    types: '',
  }
}
```

Then there's also "main" and "types" for things that don't support "exports" yet.

References:
* https://www.typescriptlang.org/tsconfig/#moduleResolution (not much there, unfortunately)
* https://github.com/microsoft/TypeScript/issues/52363#issuecomment-1659179354 and the subsequent comment.
* https://github.com/addaleax/gen-esm-wrapper

