### PR TITLE
fix(devtools-connect): skip driver ping during connect COMPASS-9536

### DIFF
--- a/packages/devtools-connect/src/connect.spec.ts
+++ b/packages/devtools-connect/src/connect.spec.ts
@@ -51,7 +51,12 @@ describe('devtools connect', function () {
       expect(mClientType.getCalls()[0].args[0]).to.equal(uri);
       expect(
         Object.keys(mClientType.getCalls()[0].args[1]).sort(),
-      ).to.deep.equal(['allowPartialTrustChain', 'ca', 'lookup']);
+      ).to.deep.equal([
+        '__skipPingOnConnect',
+        'allowPartialTrustChain',
+        'ca',
+        'lookup',
+      ]);
       expect(mClient.connect.getCalls()).to.have.lengthOf(1);
       expect(result.client).to.equal(mClient);
     });
@@ -74,6 +79,7 @@ describe('devtools connect', function () {
       expect(
         Object.keys(mClientType.getCalls()[0].args[1]).sort(),
       ).to.deep.equal([
+        '__skipPingOnConnect',
         'allowPartialTrustChain',
         'autoEncryption',
         'ca',
@@ -119,7 +125,12 @@ describe('devtools connect', function () {
       expect(calls[0].args[0]).to.equal(uri);
       expect(
         Object.keys(mClientType.getCalls()[0].args[1]).sort(),
-      ).to.deep.equal(['allowPartialTrustChain', 'ca', 'lookup']);
+      ).to.deep.equal([
+        '__skipPingOnConnect',
+        'allowPartialTrustChain',
+        'ca',
+        'lookup',
+      ]);
       expect(commandSpy).to.have.been.calledOnceWithExactly({ buildInfo: 1 });
       expect(result.client).to.equal(mClientSecond);
     });
@@ -198,6 +209,7 @@ describe('devtools connect', function () {
       expect(
         Object.keys(mClientType.getCalls()[0].args[1]).sort(),
       ).to.deep.equal([
+        '__skipPingOnConnect',
         'allowPartialTrustChain',
         'autoEncryption',
         'ca',
@@ -240,7 +252,12 @@ describe('devtools connect', function () {
       expect(mClientType.getCalls()[0].args[0]).to.equal(uri);
       expect(
         Object.keys(mClientType.getCalls()[0].args[1]).sort(),
-      ).to.deep.equal(['allowPartialTrustChain', 'ca', 'lookup']);
+      ).to.deep.equal([
+        '__skipPingOnConnect',
+        'allowPartialTrustChain',
+        'ca',
+        'lookup',
+      ]);
       expect(commandSpy).to.have.been.calledOnceWithExactly({ buildInfo: 1 });
       expect(result.client).to.equal(mClientSecond);
     });
@@ -395,10 +412,19 @@ describe('devtools connect', function () {
         expect(mClientType.getCalls()).to.have.lengthOf(2);
         expect(
           Object.keys(mClientType.getCalls()[0].args[1]).sort(),
-        ).to.deep.equal(['allowPartialTrustChain', 'ca', 'lookup']);
+        ).to.deep.equal([
+          '__skipPingOnConnect',
+          'allowPartialTrustChain',
+          'ca',
+          'lookup',
+        ]);
         expect(
           Object.keys(mClientType.getCalls()[1].args[1]).sort(),
-        ).to.deep.equal(['allowPartialTrustChain', 'lookup']);
+        ).to.deep.equal([
+          '__skipPingOnConnect',
+          'allowPartialTrustChain',
+          'lookup',
+        ]);
         expect((mClient as any).connect.getCalls()).to.have.lengthOf(2);
 
         expect(earlyFailures).to.equal(2);

--- a/packages/devtools-connect/src/connect.ts
+++ b/packages/devtools-connect/src/connect.ts
@@ -562,6 +562,8 @@ async function connectMongoClientImpl({
       return dns.lookup(hostname, { verbatim: false, ...options }, callback);
     };
 
+    (mongoClientOptions as any).__skipPingOnConnect = true;
+
     delete (mongoClientOptions as any).useSystemCA; // can be removed once no product uses this anymore
     delete mongoClientOptions.productDocsLink;
     delete mongoClientOptions.productName;

--- a/packages/devtools-connect/src/connect.ts
+++ b/packages/devtools-connect/src/connect.ts
@@ -549,7 +549,7 @@ async function connectMongoClientImpl({
       new DevtoolsConnectionState(clientOptions, logger, ca);
     const mongoClientOptions: MongoClientOptions &
       Partial<DevtoolsConnectOptions> = merge(
-      {},
+      { __skipPingOnConnect: true },
       clientOptions,
       shouldAddOidcCallbacks ? state.oidcPlugin.mongoClientOptions : {},
       { allowPartialTrustChain: true },
@@ -561,8 +561,6 @@ async function connectMongoClientImpl({
     mongoClientOptions.lookup = (hostname, options, callback) => {
       return dns.lookup(hostname, { verbatim: false, ...options }, callback);
     };
-
-    (mongoClientOptions as any).__skipPingOnConnect = true;
 
     delete (mongoClientOptions as any).useSystemCA; // can be removed once no product uses this anymore
     delete mongoClientOptions.productDocsLink;


### PR DESCRIPTION
## Description

https://github.com/mongodb-js/compass/pull/7083

Set the option that makes the driver _not_ run ping on connect.

This removes some errors that could happen:
- Ping tests for authentication because it is a command that runs through the connection pool the connection created must be auth-ed
- The server selected is the primary unless a client-wide read preference was set. This blocks the ping from running until a primary is discovered

This improves some scenarios:
- No longer is a pool (likely the primary) pre populated with one connection when connect returns
- Connect returns sooner than RTT to any particular node since it does not wait on monitoring / server selection 
  - Nor does connect wait for a MongoDB handshake RTT in addtion to the ping RTT

## Open Questions

Does the error timing matter to downstream projects? 

Any command can fail auth at anytime, and a primary may not be discoverable at boot but could be when you issue a command. Is "connect time" erroring important? 

## Checklist
- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
