### PR TITLE
fix: when autocompleting with insertText, use that rather than name

### DIFF
--- a/packages/mongodb-ts-autocomplete/src/autocompleter.spec.ts
+++ b/packages/mongodb-ts-autocomplete/src/autocompleter.spec.ts
@@ -220,7 +220,7 @@ service host, so typescript wouldn't load all the dependencies.
         {
           kind: 'property',
           name: 'one.two',
-          result: 'db.one.two',
+          result: 'db["one.two"]',
         },
       ]);
     }

--- a/packages/ts-autocomplete/src/index.spec.ts
+++ b/packages/ts-autocomplete/src/index.spec.ts
@@ -83,6 +83,11 @@ describe('Autocompleter', function () {
       expect(autoCompleter.autocomplete('myGlobalObject.')).to.deep.equal([
         {
           kind: 'property',
+          name: 'foo.bar',
+          result: 'myGlobalObject["foo.bar"]',
+        },
+        {
+          kind: 'property',
           name: 'functionProp',
           result: 'myGlobalObject.functionProp',
         },
@@ -100,6 +105,11 @@ describe('Autocompleter', function () {
       });
 
       expect(autoCompleter.autocomplete('myGlobalObject.str')).to.deep.equal([
+        {
+          kind: 'property',
+          name: 'foo.bar',
+          result: 'myGlobalObject["foo.bar"]',
+        },
         {
           kind: 'property',
           name: 'functionProp',
@@ -121,6 +131,11 @@ describe('Autocompleter', function () {
       expect(
         autoCompleter.autocomplete('myGlobalObject.doesNotExist'),
       ).to.deep.equal([
+        {
+          kind: 'property',
+          name: 'foo.bar',
+          result: 'myGlobalObject["foo.bar"]',
+        },
         {
           kind: 'property',
           name: 'functionProp',
@@ -207,6 +222,32 @@ describe('Autocompleter', function () {
         },
       ]);
     });
+
+    it('returns completions for variables with dots in their names', function () {
+      autoCompleter.updateCode({
+        '/code.d.ts': CODE_TS,
+      });
+
+      const completions = autoCompleter.autocomplete('myGlobalObject.fo');
+
+      expect(completions).to.deep.equal([
+        {
+          kind: 'property',
+          name: 'foo.bar',
+          result: 'myGlobalObject["foo.bar"]',
+        },
+        {
+          kind: 'property',
+          name: 'functionProp',
+          result: 'myGlobalObject.functionProp',
+        },
+        {
+          kind: 'property',
+          name: 'stringProp',
+          result: 'myGlobalObject.stringProp',
+        },
+      ]);
+    });
   });
 
   describe('with filter', function () {
@@ -250,6 +291,11 @@ describe('Autocompleter', function () {
         },
       ]);
       expect(autoCompleter.autocomplete('myGlobalObject.')).to.deep.equal([
+        {
+          kind: 'property',
+          name: 'foo.bar',
+          result: 'myGlobalObject["foo.bar"]',
+        },
         {
           kind: 'property',
           name: 'functionProp',

--- a/packages/ts-autocomplete/src/index.ts
+++ b/packages/ts-autocomplete/src/index.ts
@@ -190,8 +190,23 @@ function mapCompletions(
   return completions.entries
     .filter((entry) => filter({ trigger, kind: entry.kind, name: entry.name }))
     .map((entry) => {
+      /*
+      With the includeCompletionsWithInsertText option set, auto-completions
+      might have an insertText property for cases like where a property has
+      to be escaped.
+
+      An obvious example is autocompleting a collection name that has a dot in
+      it. Let's say you have the text db.fo and the collection name is foo.bar.
+      name would be 'foo.bar' and insertText would be '["foo.bar"]'.
+
+      In that case we also want to strip the dot from the prefix.
+      */
+      const result = entry.insertText
+        ? prefix.slice(0, -1) + entry.insertText
+        : prefix + entry.name;
+
       return {
-        result: prefix + entry.name,
+        result,
         name: entry.name,
         kind: entry.kind,
       };

--- a/packages/ts-autocomplete/test/fixtures/code.ts
+++ b/packages/ts-autocomplete/test/fixtures/code.ts
@@ -2,6 +2,7 @@
 export type MyObject = {
   stringProp: string;
   functionProp: (p1: number) => void;
+  'foo.bar': string;
 };
 
 export type MyFunctionParams = { param1: string; param2: string };


### PR DESCRIPTION
`db.fo` -> `db["foo.bar"]` rather than `db.foo.bar` so that the result is valid and then if you type on like `db["foo.bar"].fi` it will continue to autocomplete as `db["foo.bar"].find`.

Because `db.foo.bar.fi` won't autocomplete because `db.foo.bar` is invalid if the collection name is `foo.bar`. ie. there is no prop `foo` on `db`.