### PR TITLE
feat(mongodb-constants): add view to search stages

### DIFF
--- a/packages/mongodb-constants/src/stage-operators.ts
+++ b/packages/mongodb-constants/src/stage-operators.ts
@@ -6,6 +6,7 @@ import {
   DATABASE,
   ANY_COLLECTION_NAMESPACE,
   COLLECTION,
+  VIEW,
 } from './ns';
 
 type StageOperator = {
@@ -896,7 +897,7 @@ const STAGE_OPERATORS = [
     meta: 'stage',
     version: '4.1.11',
     apiVersions: [],
-    namespaces: [COLLECTION],
+    namespaces: [COLLECTION, VIEW],
     description: 'Performs a full-text search on the specified field(s).',
     comment: `/**
  * index: The name of the Search index.
@@ -929,7 +930,7 @@ const STAGE_OPERATORS = [
     meta: 'stage',
     version: '4.4.9',
     apiVersions: [],
-    namespaces: [COLLECTION],
+    namespaces: [COLLECTION, VIEW],
     description:
       'Performs a full-text search on the specified field(s) and gets back only the generated search meta data from a query.',
     comment: `/**
@@ -1193,7 +1194,7 @@ const STAGE_OPERATORS = [
     meta: 'stage',
     version: '>=6.0.10 <7.0.0 || >=7.0.2',
     apiVersions: [],
-    namespaces: [COLLECTION],
+    namespaces: [COLLECTION, VIEW],
     description:
       'Performs a kNN search on embeddings in the specified field(s)',
     comment: `/**


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  Use `feat`, `fix` for user facing changes that should be part of release notes.

  # Semantic Versioning:

  Package versions will be bumped automatically according to the PR title:

  - The words `BREAKING CHANGE` in the title will cause a **major** bump to all the packages changed in the PR. All dependants will also have a major bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - A subject starting with `feat` will cause a **minor** bump to all the packages changed in the PR. All dependants will also have a minor bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - Any other change to any package will cause a `patch` bump to the package and all its dependants.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Add 'view' to search stages as views are now search queryable in 8.1+ in compass and 8.0+ in de. We wish to show the search stages in Aggregations. We will handle disabling for <8.1 in compass and <8.0 in de in the compass codebase.

<img width="723" height="483" alt="Screenshot 2025-08-20 at 3 54 45 PM" src="https://github.com/user-attachments/assets/e04cd673-9889-45ca-b3a6-9aff9f10be26" />

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->
## Checklist
- [x] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
