### PR TITLE
chore(devtools-connect): align `MongoLogWriter` interfaces between packages

### DIFF
--- a/packages/devtools-connect/src/index.ts
+++ b/packages/devtools-connect/src/index.ts
@@ -7,5 +7,5 @@ export type {
   AgentWithInitialize,
   ConnectMongoClientResult,
 } from './connect';
-export { hookLogger } from './log-hook';
+export { hookLogger, MongoLogWriter } from './log-hook';
 export { oidcServerRequestHandler } from './oidc/handler';

--- a/packages/devtools-connect/src/log-hook.ts
+++ b/packages/devtools-connect/src/log-hook.ts
@@ -11,15 +11,18 @@ import type {
   ConnectRetryAfterTLSErrorEvent,
 } from './types';
 
-import { hookLoggerToMongoLogWriter as oidcHookLogger } from '@mongodb-js/oidc-plugin';
-import { hookLogger as proxyHookLogger } from '@mongodb-js/devtools-proxy-support';
+import {
+  hookLoggerToMongoLogWriter as oidcHookLogger,
+  MongoLogWriter as OIDCMongoLogWriter,
+} from '@mongodb-js/oidc-plugin';
+import {
+  hookLogger as proxyHookLogger,
+  MongoLogWriter as ProxyMongoLogWriter,
+} from '@mongodb-js/devtools-proxy-support';
 
-interface MongoLogWriter {
-  info(c: string, id: unknown, ctx: string, msg: string, attr?: any): void;
-  warn(c: string, id: unknown, ctx: string, msg: string, attr?: any): void;
-  error(c: string, id: unknown, ctx: string, msg: string, attr?: any): void;
-  mongoLogId(this: void, id: number): unknown;
-}
+export interface MongoLogWriter
+  extends OIDCMongoLogWriter,
+    ProxyMongoLogWriter {}
 
 export function hookLogger(
   emitter: ConnectLogEmitter,

--- a/packages/devtools-proxy-support/src/index.ts
+++ b/packages/devtools-proxy-support/src/index.ts
@@ -13,5 +13,10 @@ export {
   RequestInfo,
   RequestInit,
 } from './fetch';
-export { ProxyEventMap, ProxyLogEmitter, hookLogger } from './logging';
+export {
+  ProxyEventMap,
+  ProxyLogEmitter,
+  hookLogger,
+  MongoLogWriter,
+} from './logging';
 export { systemCA, resetSystemCACache } from './system-ca';

--- a/packages/devtools-proxy-support/src/logging.ts
+++ b/packages/devtools-proxy-support/src/logging.ts
@@ -77,10 +77,10 @@ export interface ProxyLogEmitter {
   ): unknown;
 }
 
-interface MongoLogWriter {
-  info(c: string, id: unknown, ctx: string, msg: string, attr?: any): void;
-  warn(c: string, id: unknown, ctx: string, msg: string, attr?: any): void;
-  error(c: string, id: unknown, ctx: string, msg: string, attr?: any): void;
+export interface MongoLogWriter {
+  info(c: string, id: unknown, ctx: string, msg: string, attr?: unknown): void;
+  warn(c: string, id: unknown, ctx: string, msg: string, attr?: unknown): void;
+  error(c: string, id: unknown, ctx: string, msg: string, attr?: unknown): void;
   mongoLogId(this: void, id: number): unknown;
 }
 


### PR DESCRIPTION
Because the OIDC plugin's `MongoLogWriter` class has an optional `debug()` method and the devtools-connect one didn't, we accidentally missed adding this debug method in mongodb-js/mongosh@b340d790ed9c159. Aligning these interfaces should prevent this from happening again in the future.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  Use `feat`, `fix` for user facing changes that should be part of release notes.

  # Semantic Versioning:

  Package versions will be bumped automatically according to the PR title:

  - The words `BREAKING CHANGE` in the title will cause a **major** bump to all the packages changed in the PR. All dependants will also have a major bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - A subject starting with `feat` will cause a **minor** bump to all the packages changed in the PR. All dependants will also have a minor bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - Any other change to any package will cause a `patch` bump to the package and all its dependants.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Checklist
- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
