### PR TITLE
fix(mongodb-runner): make close operation more resilient

### DIFF
--- a/packages/mongodb-runner/src/mongocluster.spec.ts
+++ b/packages/mongodb-runner/src/mongocluster.spec.ts
@@ -258,10 +258,10 @@ describe('MongoCluster', function () {
       secondaries: 0,
     });
     cluster = await MongoCluster.deserialize(cluster.serialize());
-    const { ok } = await cluster.withClient(async (client) => {
-      return await client.db('admin').command({ ping: 1 });
+    const doc = await cluster.withClient(async (client) => {
+      return await client.db('admin').collection('mongodbrunner').findOne();
     });
-    expect(ok).to.equal(1);
+    expect(doc?._id).to.be.a('string');
     await cluster.close();
   });
 });

--- a/packages/mongodb-runner/src/util.ts
+++ b/packages/mongodb-runner/src/util.ts
@@ -28,3 +28,16 @@ export async function parallelForEach<T>(
 
   return await Promise.allSettled(result);
 }
+
+export function pick<T extends object, K extends keyof T>(
+  obj: T,
+  keys: K[],
+): Pick<T, K> {
+  const ret: Partial<Pick<T, K>> = {};
+  for (const key of Object.keys(obj) as K[]) {
+    if (keys.includes(key)) {
+      ret[key] = obj[key];
+    }
+  }
+  return ret as Pick<T, K>;
+}


### PR DESCRIPTION
Store identifying information about a server in a database, then only actually run `process.kill()` on servers where this identifying information matches what we expect it to match.

Also, do not kill processes to which we cannot connect, and instead assume they have already been closed before.

Fixes: https://github.com/mongodb-js/devtools-shared/issues/483

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  Use `feat`, `fix` for user facing changes that should be part of release notes.

  # Semantic Versioning:

  Package versions will be bumped automatically according to the PR title:

  - The words `BREAKING CHANGE` in the title will cause a **major** bump to all the packages changed in the PR. All dependants will also have a major bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - A subject starting with `feat` will cause a **minor** bump to all the packages changed in the PR. All dependants will also have a minor bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - Any other change to any package will cause a `patch` bump to the package and all its dependants.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Checklist
- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
