### PR TITLE
chore(mongodb-ns): fix publishing ns package by renaming test file

### DIFF
--- a/packages/mongodb-ns/src/index.spec.ts
+++ b/packages/mongodb-ns/src/index.spec.ts
@@ -1,5 +1,5 @@
-var assert = require('assert');
-var ns = require('..');
+import assert from 'assert';
+import ns from './index';
 
 describe('ns', function () {
   describe('normal', function () {
@@ -112,23 +112,23 @@ describe('ns', function () {
     it('should not accept `foo"bar` as a valid database name', function () {
       assert.equal(ns('foo"bar').validDatabaseName, false);
     });
-    it.skip('should not accept `foo*bar` as a valid database name', function () {
-      assert.equal(ns('foo*bar').validDatabaseName, false);
+    it('should accept `foo*bar` as a valid database name', function () {
+      assert.equal(ns('foo*bar').validDatabaseName, true);
     });
-    it.skip('should not accept `foo<bar` as a valid database name', function () {
-      assert.equal(ns('foo<bar').validDatabaseName, false);
+    it('should accept `foo<bar` as a valid database name', function () {
+      assert.equal(ns('foo<bar').validDatabaseName, true);
     });
-    it.skip('should not accept `foo>bar` as a valid database name', function () {
-      assert.equal(ns('foo>bar').validDatabaseName, false);
+    it('should accept `foo>bar` as a valid database name', function () {
+      assert.equal(ns('foo>bar').validDatabaseName, true);
     });
-    it.skip('should not accept `foo:bar` as a valid database name', function () {
-      assert.equal(ns('foo:bar').validDatabaseName, false);
+    it('should accept `foo:bar` as a valid database name', function () {
+      assert.equal(ns('foo:bar').validDatabaseName, true);
     });
-    it.skip('should not accept `foo|bar` as a valid database name', function () {
-      assert.equal(ns('foo|bar').validDatabaseName, false);
+    it('should accept `foo|bar` as a valid database name', function () {
+      assert.equal(ns('foo|bar').validDatabaseName, true);
     });
-    it.skip('should not accept `foo?bar` as a valid database name', function () {
-      assert.equal(ns('foo?bar').validDatabaseName, false);
+    it('should accept `foo?bar` as a valid database name', function () {
+      assert.equal(ns('foo?bar').validDatabaseName, true);
     });
   });
 
@@ -224,7 +224,7 @@ describe('ns', function () {
 
   describe('sorting', function () {
     it('should sort them', function () {
-      var names = [
+      const names = [
         'admin',
         'canadian-things',
         'github',
@@ -233,7 +233,7 @@ describe('ns', function () {
         'statsd',
         'test',
       ];
-      var expect = [
+      const expect = [
         'canadian-things',
         'github',
         'scope_stat',

--- a/packages/mongodb-ns/tsconfig.json
+++ b/packages/mongodb-ns/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "extends": "@mongodb-js/tsconfig-devtools/tsconfig.common.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "allowJs": true,
-    "strict": true
+    "outDir": "dist"
   },
   "include": ["src/**/*"],
   "exclude": ["./src/**/*.spec.*"]


### PR DESCRIPTION
## Description

We nearly got it on the first try. Because the test file wasn't named with the "spec" pattern and allowJs was set to true TS was trying to compile index.ts and index.test.js to the same file, and it throws saying it will overwrite. I took the liberty of changing the file both to spec and TS, and unskipped the skipped tests by verifying that all those DB names are valid. 

<img width="248" height="268" alt="image" src="https://github.com/user-attachments/assets/04726098-ed17-4680-be94-678832aa61b8" />

## Open Questions

Can we rerun bump packages / publish with the 3.0.0 version since it never actually released or should I make this a "fix" just to get the 3.0.1 version put in the package.json?

## Checklist
- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
