### PR TITLE
feat(mongodb-constants): add vector similarity expression operators COMPASS-9553

### DIFF
--- a/packages/mongodb-constants/src/expression-operators.ts
+++ b/packages/mongodb-constants/src/expression-operators.ts
@@ -584,6 +584,27 @@ const EXPRESSION_OPERATORS = [
     version: '2.6.0',
   },
   {
+    name: '$similarityCosine',
+    value: '$similarityCosine',
+    score: 1,
+    meta: 'expr:arith',
+    version: '8.2.0',
+  },
+  {
+    name: '$similarityDotProduct',
+    value: '$similarityDotProduct',
+    score: 1,
+    meta: 'expr:arith',
+    version: '8.2.0',
+  },
+  {
+    name: '$similarityEuclidean',
+    value: '$similarityEuclidean',
+    score: 1,
+    meta: 'expr:arith',
+    version: '8.2.0',
+  },
+  {
     name: '$size',
     value: '$size',
     score: 1,


### PR DESCRIPTION
These three operators were added in v8.2.0 (https://jira.mongodb.org/browse/SERVER-104132)

## Checklist
- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
