### PR TITLE
feat(devtools-connect): enable driver network check during connect COMPASS-9455

### DIFF
--- a/packages/devtools-connect/src/connect.spec.ts
+++ b/packages/devtools-connect/src/connect.spec.ts
@@ -56,7 +56,6 @@ describe('devtools connect', function () {
       expect(
         Object.keys(mClientType.getCalls()[0].args[1]).sort(),
       ).to.deep.equal([
-        '__skipPingOnConnect',
         'allowPartialTrustChain',
         'ca',
         'lookup',
@@ -83,7 +82,6 @@ describe('devtools connect', function () {
       expect(
         Object.keys(mClientType.getCalls()[0].args[1]).sort(),
       ).to.deep.equal([
-        '__skipPingOnConnect',
         'allowPartialTrustChain',
         'autoEncryption',
         'ca',
@@ -130,7 +128,6 @@ describe('devtools connect', function () {
       expect(
         Object.keys(mClientType.getCalls()[0].args[1]).sort(),
       ).to.deep.equal([
-        '__skipPingOnConnect',
         'allowPartialTrustChain',
         'ca',
         'lookup',
@@ -213,7 +210,6 @@ describe('devtools connect', function () {
       expect(
         Object.keys(mClientType.getCalls()[0].args[1]).sort(),
       ).to.deep.equal([
-        '__skipPingOnConnect',
         'allowPartialTrustChain',
         'autoEncryption',
         'ca',
@@ -257,7 +253,6 @@ describe('devtools connect', function () {
       expect(
         Object.keys(mClientType.getCalls()[0].args[1]).sort(),
       ).to.deep.equal([
-        '__skipPingOnConnect',
         'allowPartialTrustChain',
         'ca',
         'lookup',
@@ -478,7 +473,6 @@ describe('devtools connect', function () {
         expect(
           Object.keys(mClientType.getCalls()[0].args[1]).sort(),
         ).to.deep.equal([
-          '__skipPingOnConnect',
           'allowPartialTrustChain',
           'ca',
           'lookup',
@@ -486,7 +480,6 @@ describe('devtools connect', function () {
         expect(
           Object.keys(mClientType.getCalls()[1].args[1]).sort(),
         ).to.deep.equal([
-          '__skipPingOnConnect',
           'allowPartialTrustChain',
           'lookup',
         ]);

--- a/packages/devtools-connect/src/connect.spec.ts
+++ b/packages/devtools-connect/src/connect.spec.ts
@@ -55,11 +55,7 @@ describe('devtools connect', function () {
       expect(mClientType.getCalls()[0].args[0]).to.equal(uri);
       expect(
         Object.keys(mClientType.getCalls()[0].args[1]).sort(),
-      ).to.deep.equal([
-        'allowPartialTrustChain',
-        'ca',
-        'lookup',
-      ]);
+      ).to.deep.equal(['allowPartialTrustChain', 'ca', 'lookup']);
       expect(mClient.connect.getCalls()).to.have.lengthOf(1);
       expect(result.client).to.equal(mClient);
     });
@@ -127,11 +123,7 @@ describe('devtools connect', function () {
       expect(calls[0].args[0]).to.equal(uri);
       expect(
         Object.keys(mClientType.getCalls()[0].args[1]).sort(),
-      ).to.deep.equal([
-        'allowPartialTrustChain',
-        'ca',
-        'lookup',
-      ]);
+      ).to.deep.equal(['allowPartialTrustChain', 'ca', 'lookup']);
       expect(commandSpy).to.have.been.calledOnceWithExactly({ buildInfo: 1 });
       expect(result.client).to.equal(mClientSecond);
     });
@@ -252,11 +244,7 @@ describe('devtools connect', function () {
       expect(mClientType.getCalls()[0].args[0]).to.equal(uri);
       expect(
         Object.keys(mClientType.getCalls()[0].args[1]).sort(),
-      ).to.deep.equal([
-        'allowPartialTrustChain',
-        'ca',
-        'lookup',
-      ]);
+      ).to.deep.equal(['allowPartialTrustChain', 'ca', 'lookup']);
       expect(commandSpy).to.have.been.calledOnceWithExactly({ buildInfo: 1 });
       expect(result.client).to.equal(mClientSecond);
     });
@@ -472,17 +460,10 @@ describe('devtools connect', function () {
         expect(mClientType.getCalls()).to.have.lengthOf(2);
         expect(
           Object.keys(mClientType.getCalls()[0].args[1]).sort(),
-        ).to.deep.equal([
-          'allowPartialTrustChain',
-          'ca',
-          'lookup',
-        ]);
+        ).to.deep.equal(['allowPartialTrustChain', 'ca', 'lookup']);
         expect(
           Object.keys(mClientType.getCalls()[1].args[1]).sort(),
-        ).to.deep.equal([
-          'allowPartialTrustChain',
-          'lookup',
-        ]);
+        ).to.deep.equal(['allowPartialTrustChain', 'lookup']);
         expect((mClient as any).connect.getCalls()).to.have.lengthOf(2);
 
         expect(earlyFailures).to.equal(2);

--- a/packages/devtools-connect/src/connect.ts
+++ b/packages/devtools-connect/src/connect.ts
@@ -590,7 +590,6 @@ async function connectMongoClientImpl({
       new DevtoolsConnectionState(clientOptions, logger);
     const mongoClientOptions: MongoClientOptions &
       Partial<DevtoolsConnectOptions> = merge(
-      { __skipPingOnConnect: true },
       clientOptions,
       shouldAddOidcCallbacks ? state.oidcPlugin.mongoClientOptions : {},
       { allowPartialTrustChain: true },


### PR DESCRIPTION
## Description

Previously https://github.com/mongodb-js/devtools-shared/pull/557 we disabled the driver's ping since compass did its own. Now the driver has removed its ping BUT has changed the condition to run an ismaster and return the healthy connection to the pool. This means loadBalancers without creds will throw network errors. 

Now we let the driver do this "ping" again, (its the handshake only) and we'll be able to remove compass' ping saving an RTT. big for DE.

## Open Questions


## Checklist
- [x] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [x] New tests and/or benchmarks are included
- [x] Documentation is changed or added
