### PR TITLE
feat(constants): add $score stage, expressions $sigmoid $minMaxScaler, remove $new COMPASS-9277

### DIFF
--- a/packages/mongodb-constants/src/expression-operators.ts
+++ b/packages/mongodb-constants/src/expression-operators.ts
@@ -367,7 +367,7 @@ const EXPRESSION_OPERATORS = [
     version: '2.2.0',
   },
   {
-    name: '$lt',
+    name: '$lte',
     value: '$lte',
     score: 1,
     meta: 'expr:comp',
@@ -423,6 +423,13 @@ const EXPRESSION_OPERATORS = [
     version: '2.4.0',
   },
   {
+    name: '$minMaxScaler',
+    value: '$minMaxScaler',
+    score: 1,
+    meta: 'expr:arith',
+    version: '8.2.0',
+  },
+  {
     name: '$minute',
     value: '$minute',
     score: 1,
@@ -448,13 +455,6 @@ const EXPRESSION_OPERATORS = [
     value: '$multiply',
     score: 1,
     meta: 'expr:arith',
-    version: '2.2.0',
-  },
-  {
-    name: '$new',
-    value: '$new',
-    score: 1,
-    meta: 'expr:comp',
     version: '2.2.0',
   },
   {
@@ -582,6 +582,13 @@ const EXPRESSION_OPERATORS = [
     score: 1,
     meta: 'expr:set',
     version: '2.6.0',
+  },
+  {
+    name: '$sigmoid',
+    value: '$sigmoid',
+    score: 1,
+    meta: 'expr:arith',
+    version: '8.2.0',
   },
   {
     name: '$similarityCosine',

--- a/packages/mongodb-constants/src/stage-operators.ts
+++ b/packages/mongodb-constants/src/stage-operators.ts
@@ -760,7 +760,7 @@ const STAGE_OPERATORS = [
     fullScan: false,
     firstStage: false,
     score: 1,
-    env: [ATLAS, ON_PREM],
+    env: [ATLAS],
     meta: 'stage',
     version: '8.0.14',
     apiVersions: [],

--- a/packages/mongodb-constants/src/stage-operators.ts
+++ b/packages/mongodb-constants/src/stage-operators.ts
@@ -760,7 +760,7 @@ const STAGE_OPERATORS = [
     fullScan: false,
     firstStage: false,
     score: 1,
-    env: [ATLAS],
+    env: [ATLAS, ON_PREM],
     meta: 'stage',
     version: '8.0.14',
     apiVersions: [],
@@ -883,6 +883,35 @@ const STAGE_OPERATORS = [
 `,
     snippet: `{
   size: \${1:number}
+}`,
+  },
+  {
+    name: '$score',
+    value: '$score',
+    label: '$score',
+    outputStage: false,
+    fullScan: false,
+    firstStage: false,
+    score: 1,
+    env: [ATLAS],
+    meta: 'stage',
+    version: '8.2.0',
+    apiVersions: [],
+    namespaces: [COLLECTION],
+    description:
+      'Computes and returns a new score as metadata. It also optionally normalizes the input scores, by default to a range between zero and one.',
+    comment: `/**
+ * score: Required expression. Computes a new value from the input scores and stores the value in the $meta keyword score. Returns an error for non-numeric inputs.
+ * scoreDetails: Optional. Default false. Set to true to include detailed scoring information in {$meta: "scoreDetails"} for debugging and tuning.
+ * normalization: Optional. Default none. Normalizes the input scores before computing the new score. Value can be none, sigmoid or minMaxScaler.
+ * weight: Optional. Default 1. Multiplies the computed score by the weight value. Returns an error for non-numeric inputs.
+ */
+`,
+    snippet: `{
+  score: \${1:expression},
+  scoreDetails: \${2:false},
+  normalization: "\${2:none|sigmoid|minMaxScaler}",
+  weight: \${3:number},
 }`,
   },
   {

--- a/packages/mongodb-constants/src/stage-operators.ts
+++ b/packages/mongodb-constants/src/stage-operators.ts
@@ -893,7 +893,7 @@ const STAGE_OPERATORS = [
     fullScan: false,
     firstStage: false,
     score: 1,
-    env: [ATLAS],
+    env: [ATLAS, ON_PREM],
     meta: 'stage',
     version: '8.2.0',
     apiVersions: [],


### PR DESCRIPTION
COMPASS-9277

Adds:
[$score](https://docs.google.com/document/d/1WgwYPE64T0E-BChqLdGPw1wo5z0ZYrrcbEASOoFl81M/edit?tab=t.0#heading=h.70g1gwob1dxa) stage operator. [docs](https://www.mongodb.com/docs/manual/reference/operator/aggregation/score/)
[$sigmoid](https://docs.google.com/document/d/1WgwYPE64T0E-BChqLdGPw1wo5z0ZYrrcbEASOoFl81M/edit?tab=t.0#heading=h.f8l1ihw0bqy9) expression. [docs](https://www.mongodb.com/docs/manual/reference/operator/aggregation/sigmoid/)
[$minMaxScaler](https://docs.google.com/document/d/1WgwYPE64T0E-BChqLdGPw1wo5z0ZYrrcbEASOoFl81M/edit?tab=t.0#heading=h.n0bg23rjzx1m) expression. [docs](https://www.mongodb.com/docs/manual/reference/operator/aggregation/minMaxScaler/) *This is only available in the `$setWindowStage` but I reckon we should add it for autocomplete anyway.

Removes:
`$new` - This expression has been in here for 4+ years, it doesn't look like it was ever a thing?

Updates `$lt` naming to `$lte`, looks like it was a typo.