### PR TITLE
feat(mongodb-constants): add expression operators to constants COMPASS-10200 COMPASS-10179 COMPASS-10168

### DIFF
--- a/packages/mongodb-constants/src/expression-operators.ts
+++ b/packages/mongodb-constants/src/expression-operators.ts
@@ -206,6 +206,13 @@ const EXPRESSION_OPERATORS = [
     version: '3.0.0',
   },
   {
+    name: '$deserializeEJSON',
+    value: '$deserializeEJSON',
+    score: 1,
+    meta: 'expr:type',
+    version: '8.3.0',
+  },
+  {
     name: '$divide',
     value: '$divide',
     score: 1,
@@ -561,6 +568,13 @@ const EXPRESSION_OPERATORS = [
     score: 1,
     meta: 'expr:date',
     version: '2.2.0',
+  },
+  {
+    name: '$serializeEJSON',
+    value: '$serializeEJSON',
+    score: 1,
+    meta: 'expr:type',
+    version: '8.3.0',
   },
   {
     name: '$setDifference',

--- a/packages/mongodb-constants/src/expression-operators.ts
+++ b/packages/mongodb-constants/src/expression-operators.ts
@@ -73,6 +73,20 @@ const EXPRESSION_OPERATORS = [
     version: '4.4.0',
   },
   {
+    name: '$bottom',
+    value: '$bottom',
+    score: 1,
+    meta: 'expr:array',
+    version: '8.1.0',
+  },
+  {
+    name: '$bottomN',
+    value: '$bottomN',
+    score: 1,
+    meta: 'expr:array',
+    version: '8.1.0',
+  },
+  {
     name: '$ceil',
     value: '$ceil',
     score: 1,
@@ -724,6 +738,20 @@ const EXPRESSION_OPERATORS = [
     score: 1,
     meta: 'expr:string',
     version: '2.2.0',
+  },
+  {
+    name: '$top',
+    value: '$top',
+    score: 1,
+    meta: 'expr:array',
+    version: '8.1.0',
+  },
+  {
+    name: '$topN',
+    value: '$topN',
+    score: 1,
+    meta: 'expr:array',
+    version: '8.1.0',
   },
   {
     name: '$tsSecond',

--- a/packages/mongodb-constants/src/expression-operators.ts
+++ b/packages/mongodb-constants/src/expression-operators.ts
@@ -283,6 +283,20 @@ const EXPRESSION_OPERATORS = [
     version: '2.2.0',
   },
   {
+    name: '$hash',
+    value: '$hash',
+    score: 1,
+    meta: 'expr:arith',
+    version: '8.3.0',
+  },
+  {
+    name: '$hexHash',
+    value: '$hexHash',
+    score: 1,
+    meta: 'expr:arith',
+    version: '8.3.0',
+  },
+  {
     name: '$hour',
     value: '$hour',
     score: 1,


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  Use `feat`, `fix` for user facing changes that should be part of release notes.

  # Semantic Versioning:

  Package versions will be bumped automatically according to the PR title:

  - The words `BREAKING CHANGE` in the title will cause a **major** bump to all the packages changed in the PR. All dependants will also have a major bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - A subject starting with `feat` will cause a **minor** bump to all the packages changed in the PR. All dependants will also have a minor bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - Any other change to any package will cause a `patch` bump to the package and all its dependants.
-->

## Tickets

- [COMPASS-10168](https://jira.mongodb.org/browse/COMPASS-10168)
- [COMPASS-10179](https://jira.mongodb.org/browse/COMPASS-10179)
- [COMPASS-10200](https://jira.mongodb.org/browse/COMPASS-10200)

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Add expression operators to constants as per the Jira tickets.

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Checklist
- [x] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
