### PR TITLE
ci: add workflow_dispatch trigger to CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,7 @@ on:
       - main
   schedule:
     - cron: "30 14 * * 4"
+  workflow_dispatch:
 
 jobs:
   analyze:


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to the CodeQL workflow so it can be manually run on specific refs (e.g., release tags).

## Motivation

The SBOM tooling (`create_static_analysis_report` Evergreen task in Compass) requires a CodeQL SARIF report for the exact commit SHA of each published first-party package. The `@mongodb-js/mongodb-constants@0.25.0` tag currently points to a `chore: update cidrs.json [skip ci]` bot commit, which skipped CI and therefore has no CodeQL results. This change allows manually triggering CodeQL on that tag ref to generate the required SARIF report.

## After merging

Once merged, trigger CodeQL on the release tag:
```sh
gh workflow run codeql.yml --repo mongodb-js/devtools-shared --ref "@mongodb-js/mongodb-constants@0.25.0"
```