### PR TITLE
feat(devtools-connect): emit tunnel error events on the logger COMPASS-8355

### DIFF
--- a/packages/devtools-connect/src/connect.spec.ts
+++ b/packages/devtools-connect/src/connect.spec.ts
@@ -10,6 +10,7 @@ import sinonChai from 'sinon-chai';
 import { Agent as HTTPSAgent } from 'https';
 import { MongoCluster } from 'mongodb-runner';
 import { tmpdir } from 'os';
+import * as devtoolsProxySupport from '@mongodb-js/devtools-proxy-support';
 
 chai.use(sinonChai);
 
@@ -529,6 +530,79 @@ describe('devtools connect', function () {
           proxyConnectEvents[1].agent.proxyOptions.ca,
         );
       });
+    });
+
+    describe('tunnel error events', function () {
+      let originalDescriptor: PropertyDescriptor;
+      let fakeTunnel: EventEmitter & {
+        listen: sinon.SinonStub;
+        close: sinon.SinonStub;
+        config: any;
+        logger: EventEmitter;
+      };
+
+      beforeEach(function () {
+        const tunnel = Object.assign(new EventEmitter(), {
+          listen: sinon.stub().resolves(),
+          close: sinon.stub().resolves(),
+          config: {
+            proxyHost: '127.0.0.1',
+            proxyPort: 1080,
+            proxyUsername: 'u',
+            proxyPassword: 'p',
+          },
+          logger: new EventEmitter(),
+        });
+        fakeTunnel = tunnel as any;
+
+        // devtools-proxy-support exports createSocks5Tunnel as a non-writable
+        // getter, so sinon.stub() can't replace it. Use Object.defineProperty
+        // directly to inject the fake tunnel factory.
+        originalDescriptor = Object.getOwnPropertyDescriptor(
+          devtoolsProxySupport,
+          'createSocks5Tunnel',
+        )!;
+        Object.defineProperty(devtoolsProxySupport, 'createSocks5Tunnel', {
+          configurable: true,
+          writable: true,
+          value: () => fakeTunnel,
+        });
+      });
+
+      afterEach(function () {
+        Object.defineProperty(
+          devtoolsProxySupport,
+          'createSocks5Tunnel',
+          originalDescriptor,
+        );
+      });
+
+      for (const [tunnelEvent, busEvent] of [
+        ['error', 'devtools-connect:tunnel-error'],
+        ['forwardingError', 'devtools-connect:tunnel-forwarding-error'],
+      ] as const) {
+        it(`emits ${busEvent} when tunnel emits '${tunnelEvent}'`, async function () {
+          const mClient = stubConstructor(FakeMongoClient);
+          const mClientType = sinon.stub().returns(mClient);
+          mClient.connect.resolves(mClient);
+
+          const { client } = await connectMongoClient(
+            'localhost:27017',
+            { ...defaultOpts, proxy: { proxy: 'socks5://localhost:1080' } },
+            bus,
+            mClientType as any,
+          );
+
+          const received: any[] = [];
+          bus.on(busEvent, (ev) => received.push(ev));
+          fakeTunnel.emit(tunnelEvent, new Error(`test ${tunnelEvent}`));
+
+          expect(received).to.have.lengthOf(1);
+          expect(received[0].error.message).to.equal(`test ${tunnelEvent}`);
+
+          mClient.emit('close');
+        });
+      }
     });
   });
 

--- a/packages/devtools-connect/src/connect.ts
+++ b/packages/devtools-connect/src/connect.ts
@@ -555,16 +555,14 @@ async function connectMongoClientImpl({
         'mongodb://',
       );
       cleanupOnClientClose.push(() => tunnel?.close());
-      if (tunnel) {
-        tunnel.on('error', (err) => {
-          logger.emit('devtools-connect:tunnel-error', { error: err });
+      tunnel?.on('error', (err) => {
+        logger.emit('devtools-connect:tunnel-error', { error: err });
+      });
+      tunnel?.on('forwardingError', (err) => {
+        logger.emit('devtools-connect:tunnel-forwarding-error', {
+          error: err,
         });
-        tunnel.on('forwardingError', (err) => {
-          logger.emit('devtools-connect:tunnel-forwarding-error', {
-            error: err,
-          });
-        });
-      }
+      });
     }
     for (const proxyLogger of new Set([
       tunnel?.logger,

--- a/packages/devtools-connect/src/connect.ts
+++ b/packages/devtools-connect/src/connect.ts
@@ -555,6 +555,16 @@ async function connectMongoClientImpl({
         'mongodb://',
       );
       cleanupOnClientClose.push(() => tunnel?.close());
+      if (tunnel) {
+        tunnel.on('error', (err) => {
+          logger.emit('devtools-connect:tunnel-error', { error: err });
+        });
+        tunnel.on('forwardingError', (err) => {
+          logger.emit('devtools-connect:tunnel-forwarding-error', {
+            error: err,
+          });
+        });
+      }
     }
     for (const proxyLogger of new Set([
       tunnel?.logger,

--- a/packages/devtools-connect/src/log-hook.ts
+++ b/packages/devtools-connect/src/log-hook.ts
@@ -21,7 +21,8 @@ import {
 } from '@mongodb-js/devtools-proxy-support';
 
 export interface MongoLogWriter
-  extends OIDCMongoLogWriter, ProxyMongoLogWriter {}
+  extends OIDCMongoLogWriter,
+    ProxyMongoLogWriter {}
 
 export function hookLogger(
   emitter: ConnectLogEmitter,

--- a/packages/devtools-connect/src/log-hook.ts
+++ b/packages/devtools-connect/src/log-hook.ts
@@ -21,8 +21,7 @@ import {
 } from '@mongodb-js/devtools-proxy-support';
 
 export interface MongoLogWriter
-  extends OIDCMongoLogWriter,
-    ProxyMongoLogWriter {}
+  extends OIDCMongoLogWriter, ProxyMongoLogWriter {}
 
 export function hookLogger(
   emitter: ConnectLogEmitter,

--- a/packages/devtools-connect/src/types.ts
+++ b/packages/devtools-connect/src/types.ts
@@ -66,8 +66,7 @@ export interface ConnectRetryAfterTLSErrorEvent {
 }
 
 export interface ConnectEventMap
-  extends MongoDBOIDCLogEventsMap,
-    ProxyEventMap {
+  extends MongoDBOIDCLogEventsMap, ProxyEventMap {
   /** Signals that a connection attempt is about to be performed. */
   'devtools-connect:connect-attempt-initialized': (
     ev: ConnectAttemptInitializedEvent,

--- a/packages/devtools-connect/src/types.ts
+++ b/packages/devtools-connect/src/types.ts
@@ -66,7 +66,8 @@ export interface ConnectRetryAfterTLSErrorEvent {
 }
 
 export interface ConnectEventMap
-  extends MongoDBOIDCLogEventsMap, ProxyEventMap {
+  extends MongoDBOIDCLogEventsMap,
+    ProxyEventMap {
   /** Signals that a connection attempt is about to be performed. */
   'devtools-connect:connect-attempt-initialized': (
     ev: ConnectAttemptInitializedEvent,
@@ -103,6 +104,10 @@ export interface ConnectEventMap
   'devtools-connect:retry-after-tls-error': (
     ev: ConnectRetryAfterTLSErrorEvent,
   ) => void;
+  /** Signals that the proxy tunnel encountered a session-level error (e.g. SSH connection lost) */
+  'devtools-connect:tunnel-error': (ev: { error: Error }) => void;
+  /** Signals that the proxy tunnel failed to forward a connection */
+  'devtools-connect:tunnel-forwarding-error': (ev: { error: Error }) => void;
 }
 
 export type ConnectEventArgs<K extends keyof ConnectEventMap> =


### PR DESCRIPTION
## Description

Adds two new events to `ConnectEventMap` and wires them from the `Tunnel` object in `connectMongoClient`:

- `devtools-connect:tunnel-error` — fires when the tunnel emits an `'error'` event (session-level, e.g. SSH connection lost)
- `devtools-connect:tunnel-forwarding-error` — fires when the tunnel emits a `'forwardingError'` event (individual forwarding failure)

This is step 2 of the SSH tunnel cleanup for COMPASS-8355 (step 1 was [devtools-shared#772](https://github.com/mongodb-js/devtools-shared/pull/772) — transparent SSH reconnect in `devtools-proxy-support`).

Previously, Compass held a direct reference to the `Tunnel` object in order to listen to these events and react to post-connection SSH failures. With these events now surfaced on the logger, callers no longer need to create or hold the tunnel themselves. Step 3 (a follow-up Compass PR) will remove the duplicate tunnel management code from `connect-mongo-client.ts`, `ssh-tunnel-helpers.ts`, and `data-service.ts`.

## Open Questions

None.

## Checklist

- [x] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added