### PR TITLE
fix(shell-bson-parser): do not allow arbitrary function calls on literals COMPASS-10678

### DIFF
--- a/packages/shell-bson-parser/src/check.ts
+++ b/packages/shell-bson-parser/src/check.ts
@@ -23,7 +23,16 @@ class Checker {
         const object = node.callee.object;
         const property = node.callee.property as Identifier;
         // If we're only referring to identifiers, we don't need to check deeply.
-        if (object.type === 'Identifier' && property.type === 'Identifier') {
+
+        if (object.type === 'Literal' && property.type === 'Identifier') {
+          return (
+            isMethodWhitelisted(typeof object.value, property.name) &&
+            node.arguments.every(this.checkSafeExpression)
+          );
+        } else if (
+          object.type === 'Identifier' &&
+          property.type === 'Identifier'
+        ) {
           return (
             isMethodWhitelisted(object.name, property.name) &&
             node.arguments.every(this.checkSafeExpression)

--- a/packages/shell-bson-parser/src/index.spec.ts
+++ b/packages/shell-bson-parser/src/index.spec.ts
@@ -724,6 +724,20 @@ describe('@mongodb-js/shell-bson-parser', function () {
         });
       });
     }
+
+    it('should not allow calling IIFE', function () {
+      expect(
+        parse('{ date: (function() { return "10"; })() }', options),
+      ).to.equal('');
+    });
+
+    it('should prevent attempting to break the sandbox', function () {
+      const withIdentifier =
+        "{ exploit: clearImmediate.constructor('return process;')().exit(1) }";
+      expect(parse(withIdentifier, options)).to.equal('');
+      const withLiteral = `{ exploit: "".toString.constructor('return process;')().exit(1) }`;
+      expect(parse(withLiteral, options)).to.equal('');
+    });
   });
 
   describe('Comments', function () {
@@ -749,16 +763,6 @@ describe('@mongodb-js/shell-bson-parser', function () {
         to: 'see',
       });
     });
-  });
-
-  it('should not allow calling IIFE', function () {
-    expect(parse('{ date: (function() { return "10"; })() }')).to.equal('');
-  });
-
-  it('should prevent attempting to break the sandbox', function () {
-    const input =
-      "{ exploit: clearImmediate.constructor('return process;')().exit(1) }";
-    expect(parse(input)).to.equal('');
   });
 
   it('should correctly parse NumberLong and Int64 bigger than Number.MAX_SAFE_INTEGER', function () {

--- a/packages/shell-bson-parser/src/index.spec.ts
+++ b/packages/shell-bson-parser/src/index.spec.ts
@@ -731,12 +731,15 @@ describe('@mongodb-js/shell-bson-parser', function () {
       ).to.equal('');
     });
 
-    it('should prevent attempting to break the sandbox', function () {
-      const withIdentifier =
+    it('should prevent attempting to break the sandbox for identifiers', function () {
+      const input =
         "{ exploit: clearImmediate.constructor('return process;')().exit(1) }";
-      expect(parse(withIdentifier, options)).to.equal('');
-      const withLiteral = `{ exploit: "".toString.constructor('return process;')().exit(1) }`;
-      expect(parse(withLiteral, options)).to.equal('');
+      expect(parse(input, options)).to.equal('');
+    });
+
+    it('should prevent attempting to break the sandbox for literals', function () {
+      const input = `{ exploit: "".toString.constructor('return process;')().exit(1) }`;
+      expect(parse(input, options)).to.equal('');
     });
   });
 


### PR DESCRIPTION
We are already pretty strict about allowed function calls during parse, this patch makes the logic a bit stricter. I can't think of a case where we'd want to allow these cases for any of our purposes, but tell me if we should allowlist some methods here

See COMPASS-10678 for some extra context