### PR TITLE
chore: add mongodb-js namespace to packages that lost owner

### DIFF
--- a/packages/native-machine-id/package.json
+++ b/packages/native-machine-id/package.json
@@ -1,7 +1,10 @@
 {
-  "name": "native-machine-id",
+  "name": "@mongodb-js/native-machine-id",
   "version": "0.3.11",
   "description": "Native retrieval of a unique desktop machine ID without admin privileges or child processes. Faster and more reliable alternative to node-machine-id.",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/node-webpack-startup-snapshot-checker/package.json
+++ b/packages/node-webpack-startup-snapshot-checker/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-webpack-startup-snapshot-checker",
+  "name": "@mongodb-js/node-webpack-startup-snapshot-checker",
   "description": "Test script for verifying whether a given Node.js module can be included in Node.js snapshots",
   "author": {
     "name": "MongoDB Inc",


### PR DESCRIPTION
We can't figure out who owners on npm are, so I'm renaming so that we can add them to the npm mongodb-js org