### PR TITLE
feat(mongodb-constants): add $createUUID and $currentDate expression operators COMPASS-10049

### DIFF
--- a/packages/mongodb-constants/src/expression-operators.ts
+++ b/packages/mongodb-constants/src/expression-operators.ts
@@ -185,6 +185,20 @@ const EXPRESSION_OPERATORS = [
     version: '4.2.0',
   },
   {
+    name: '$createUUID',
+    value: '$createUUID',
+    score: 1,
+    meta: 'expr:misc',
+    version: '8.3.0',
+  },
+  {
+    name: '$currentDate',
+    value: '$currentDate',
+    score: 1,
+    meta: 'expr:date',
+    version: '8.3.0',
+  },
+  {
     name: '$dateAdd',
     value: '$dateAdd',
     score: 1,


### PR DESCRIPTION
## Description

Adds two new aggregation expression operators introduced in MongoDB 8.3 to the `mongodb-constants` package:

- **`$createUUID`** — generates a random UUID (BSON Binary subtype 4) per document. Categorised as `expr:misc`, analogous to `$rand`. ([SERVER-101136](https://jira.mongodb.org/browse/SERVER-101136))
- **`$currentDate`** — returns the current date/time as a BSON Date per document. Categorised as `expr:date`, sibling of `$$NOW`. ([SERVER-94282](https://jira.mongodb.org/browse/SERVER-94282))

Both operators are versioned at `8.3.0` so they are gated by the `serverVersion` filter — they will only surface in autocomplete when connected to a MongoDB 8.3+ server. They appear inside pipeline stage bodies (the `expr:*` meta category used by `stage-autocompleter`), not in the stage operator dropdown.

Note: these operators were designed primarily for Atlas Stream Processing use cases (continuous per-event timestamps and UUIDs), but they are valid aggregation expressions that also work in regular collection pipelines.

Jira: [COMPASS-10049](https://jira.mongodb.org/browse/COMPASS-10049)

## Open Questions

None — scope is clear: additive constants-only change, no Compass UI changes required.

## Checklist

- [x] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added