### PR TITLE
feat(mongodb-constants): add $createObjectId expression operator COMPASS-9597

### DIFF
--- a/packages/mongodb-constants/src/expression-operators.ts
+++ b/packages/mongodb-constants/src/expression-operators.ts
@@ -185,6 +185,27 @@ const EXPRESSION_OPERATORS = [
     version: '4.2.0',
   },
   {
+    name: '$createObjectId',
+    value: '$createObjectId',
+    score: 1,
+    meta: 'expr:misc',
+    version: '8.3.0',
+  },
+  {
+    name: '$createUUID',
+    value: '$createUUID',
+    score: 1,
+    meta: 'expr:misc',
+    version: '8.3.0',
+  },
+  {
+    name: '$currentDate',
+    value: '$currentDate',
+    score: 1,
+    meta: 'expr:date',
+    version: '8.3.0',
+  },
+  {
     name: '$dateAdd',
     value: '$dateAdd',
     score: 1,


### PR DESCRIPTION
## Description

Adds `$createObjectId`, a new aggregation expression operator introduced in MongoDB 8.3 ([SERVER-106452](https://jira.mongodb.org/browse/SERVER-106452)).

Jira: [COMPASS-9597](https://jira.mongodb.org/browse/COMPASS-9597)

## Open Questions

None.

## Checklist

- [x] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added