### PR TITLE
feat(mongodb-constants): add $subtype expression operator COMPASS-9668

### DIFF
--- a/packages/mongodb-constants/src/expression-operators.ts
+++ b/packages/mongodb-constants/src/expression-operators.ts
@@ -859,6 +859,13 @@ const EXPRESSION_OPERATORS = [
     version: '3.2.0',
   },
   {
+    name: '$subtype',
+    value: '$subtype',
+    score: 1,
+    meta: 'expr:type',
+    version: '8.3.0',
+  },
+  {
     name: '$switch',
     value: '$switch',
     score: 1,


### PR DESCRIPTION
## Description

Adds the `$subtype` aggregation expression operator introduced in MongoDB 8.3 (SERVER-103893).

The operator is added to `expression-operators.ts` with:
- `meta: 'expr:type'` — same category as `$type`, which also introspects value types
- `version: '8.3.0'`
- Alphabetical position between `$subtract` and `$switch`

## Open Questions

None.

## Checklist

- [x] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added