### PR TITLE
feat(mongodb-constants): add $toArray and $toObject conversion operators COMPASS-9747

### DIFF
--- a/packages/mongodb-constants/src/conversion-operators.ts
+++ b/packages/mongodb-constants/src/conversion-operators.ts
@@ -24,6 +24,13 @@ const CONVERSION_OPERATORS = [
     version: '3.7.2',
   },
   {
+    name: '$toArray',
+    value: '$toArray',
+    score: 1,
+    meta: 'conv',
+    version: '8.3.0',
+  },
+  {
     name: '$toBool',
     value: '$toBool',
     score: 1,
@@ -64,6 +71,13 @@ const CONVERSION_OPERATORS = [
     score: 1,
     meta: 'conv',
     version: '3.7.2',
+  },
+  {
+    name: '$toObject',
+    value: '$toObject',
+    score: 1,
+    meta: 'conv',
+    version: '8.3.0',
   },
   {
     name: '$toObjectId',


### PR DESCRIPTION
## Description

Adds two new type conversion shorthand operators introduced in MongoDB 8.3 (SERVER-105087):

- **`$toArray`** — converts a JSON string to a BSON array (shorthand for `$convert` with `to: "array"`)
- **`$toObject`** — converts a JSON string to a BSON document/object (shorthand for `$convert` with `to: "object"`)

## Open Questions

None.

## Checklist

- [x] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added