### PR TITLE
feat(mongodb-constants): update $unionWith template with db field COMPASS-9980

### DIFF
--- a/packages/mongodb-constants/src/stage-operators.ts
+++ b/packages/mongodb-constants/src/stage-operators.ts
@@ -1260,6 +1260,7 @@ const STAGE_OPERATORS = [
     namespaces: [...ANY_NAMESPACE],
     description: 'Perform a union with a pipeline on another collection.',
     comment: `/**
+ * db: Optional. The target database name (MongoDB 9.0+).
  * coll: The collection name.
  * pipeline: The pipeline on the other collection.
  */


### PR DESCRIPTION
## Description

Updates the `$unionWith` stage template to document the new optional `db` field introduced in MongoDB 9.0 (SERVER-105087).

The `db` field allows cross-database unions — when present, `$unionWith` can union with a collection in a different database than the one the aggregate command is running against. Without `db`, the stage behaves identically to today (same-database union).

The change adds `db` to the `comment` only (not the default snippet), following the same convention as `$lookup` where optional/versioned fields are documented but not inserted by default. This avoids breaking users on MongoDB < 9.0 who use the template and would otherwise get an unsupported field.

## Open Questions

None.

## Checklist

- [x] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added