### PR TITLE
fix(devtools-proxy-support): serialize SSH reinit and cap consecutive failures COMPASS-10804

### DIFF
--- a/packages/devtools-proxy-support/src/ssh.spec.ts
+++ b/packages/devtools-proxy-support/src/ssh.spec.ts
@@ -1,4 +1,4 @@
-import { once } from 'events';
+import { EventEmitter, once } from 'events';
 import { HTTPServerProxyTestSetup } from '../test/helpers';
 import { SSHAgent } from './ssh';
 import { createFetch } from './fetch';
@@ -169,6 +169,81 @@ describe('SSHAgent', function () {
     await fetch('http://example.com/hello');
     // A fresh client was created and a new SSH handshake performed
     expect(setup.authHandler).to.have.been.calledTwice;
+  });
+
+  it('serializes concurrent reinit attempts, creating only one new SSH connection', async function () {
+    setup.authHandler = sinon.stub().returns(true);
+    agent = new SSHAgent({
+      proxy: `ssh://foo:bar@127.0.0.1:${setup.sshProxyPort}/`,
+    });
+    await agent.initialize();
+    const fetch = createFetch(agent);
+    await fetch('http://example.com/hello');
+
+    // Force the current client into a fatal state so every concurrent _connect
+    // call will need to reinitialize.
+    const brokenClient = (agent as any).sshClient;
+    brokenClient.connect = function () {
+      process.nextTick(() =>
+        brokenClient.emit(
+          'error',
+          new Error('Instance unusable after fatal error'),
+        ),
+      );
+    };
+    (agent as any).connected = false;
+
+    // Three requests in flight at the same moment, all requiring a reinit.
+    await Promise.all([
+      fetch('http://example.com/hello'),
+      fetch('http://example.com/hello'),
+      fetch('http://example.com/hello'),
+    ]);
+
+    // Despite three concurrent requests, only one new SSH handshake should occur.
+    expect(setup.authHandler).to.have.been.calledTwice;
+  });
+
+  it('marks itself as closed after too many consecutive reinit failures', async function () {
+    setup.authHandler = sinon.stub().returns(true);
+    agent = new SSHAgent({
+      proxy: `ssh://foo:bar@127.0.0.1:${setup.sshProxyPort}/`,
+    });
+    await agent.initialize();
+
+    // Stub createSshClient to always return a client that fails to connect,
+    // simulating a bastion that is unreachable after a long hibernate.
+    sinon.stub(agent as any, 'createSshClient').callsFake(() => {
+      const client = new EventEmitter() as any;
+      client.connect = () => {
+        process.nextTick(() =>
+          client.emit('error', new Error('Connection refused')),
+        );
+      };
+      client.end = () => {};
+      return client;
+    });
+    (agent as any).connected = false;
+
+    for (let i = 0; i < 3; i++) {
+      await agent.initialize(true).catch(() => {});
+    }
+
+    expect((agent as any).closed).to.be.true;
+
+    // Further calls must throw 'Disconnected.' without attempting a new connection.
+    const establishingEvents: unknown[] = [];
+    agent.logger.on('ssh:establishing-conection', (e: unknown) =>
+      establishingEvents.push(e),
+    );
+    try {
+      await agent.initialize();
+      expect.fail('missed exception');
+    } catch (err: any) {
+      expect(err.message).to.equal('Disconnected.');
+    }
+    expect(establishingEvents).to.have.length(0);
+    expect(setup.authHandler).to.have.been.calledOnce;
   });
 
   it('reconnects after the underlying connection is destroyed server-side', async function () {

--- a/packages/devtools-proxy-support/src/ssh.ts
+++ b/packages/devtools-proxy-support/src/ssh.ts
@@ -27,6 +27,8 @@ function ssh2(): typeof import('ssh2') {
   return require('ssh2');
 }
 
+const MAX_CONSECUTIVE_REINIT_FAILURES = 3;
+
 // The original version of this code was largely taken from
 // https://github.com/mongodb-js/compass/tree/55a5a608713d7316d158dc66febeb6b114d8b40d/packages/ssh-tunnel/src
 export class SSHAgent extends AgentBase implements AgentWithInitialize {
@@ -36,6 +38,8 @@ export class SSHAgent extends AgentBase implements AgentWithInitialize {
   private sshClient: SshClient;
   private connected = false;
   private connectingPromise?: Promise<void>;
+  private reinitializingPromise?: Promise<void>;
+  private consecutiveReinitFailures = 0;
   private closed = false;
   private forwardOut!: (
     srcIP: string,
@@ -88,16 +92,20 @@ export class SSHAgent extends AgentBase implements AgentWithInitialize {
     }
 
     if (reinitializeClient) {
-      // The previous ssh2 Client instance is in an unrecoverable state (e.g.
-      // "Instance unusable after fatal error" after the TCP connection was killed
-      // mid-stream during hibernate). End it to release the keepalive timer
-      // and any other internal handles, then create a fresh instance.
-      // ssh2's end() is a no-op when the underlying socket is already dead
-      // (it guards with isWritable()), so this is safe in all cases.
-      this.connectingPromise = undefined;
-      this.connected = false;
-      this.sshClient.end();
-      this.sshClient = this.createSshClient();
+      // Serialize concurrent reinit attempts: if one is already in progress,
+      // wait for it and then use the newly-connected client instead of racing
+      // to create another one. Without this, each concurrent _connect() caller
+      // bypasses connectingPromise deduplication and races through the reinit
+      // path, creating N fresh ssh2 clients (and N server-side sessions) per
+      // driver retry cycle.
+      if (this.reinitializingPromise) {
+        await this.reinitializingPromise;
+        return this.initialize(false);
+      }
+      this.reinitializingPromise = this._doReinit().finally(() => {
+        this.reinitializingPromise = undefined;
+      });
+      return this.reinitializingPromise;
     }
 
     const sshConnectConfig: ConnectConfig = {
@@ -210,6 +218,26 @@ export class SSHAgent extends AgentBase implements AgentWithInitialize {
         if (retriesLeft > 0) {
           await this.initialize(requiresNewClient);
           return await this._connect(req, connectOpts, retriesLeft - 1);
+        }
+      }
+      throw err;
+    }
+  }
+
+  private async _doReinit(): Promise<void> {
+    this.connectingPromise = undefined;
+    this.connected = false;
+    this.sshClient.end();
+    this.sshClient = this.createSshClient();
+    try {
+      await this.initialize(false);
+      this.consecutiveReinitFailures = 0;
+    } catch (err) {
+      // Only count failures that aren't from an intentional destroy().
+      if (!this.closed) {
+        this.consecutiveReinitFailures++;
+        if (this.consecutiveReinitFailures >= MAX_CONSECUTIVE_REINIT_FAILURES) {
+          this.closed = true;
         }
       }
       throw err;


### PR DESCRIPTION
## Description

Fixes a regression introduced in COMPASS-8355 / [devtools-shared#772](https://github.com/mongodb-js/devtools-shared/pull/772) where Compass could accumulate hundreds of dangling SSH sessions on the bastion host after a laptop hibernate or screen lock, eventually exhausting the bastion's RAM.

### Root cause

When the SSH tunnel breaks, the MongoDB driver's heartbeat loop issues N concurrent `_connect()` calls (one per replica set member). Each call hits `initialize(reinitializeClient=true)`, which is supposed to replace the broken ssh2 `Client` with a fresh one. However, the `reinitializeClient` path bypassed the existing `connectingPromise` deduplication guard, so all N concurrent callers raced through the reinit simultaneously: each called `sshClient.end()` + `createSshClient()` + `connect()` in sequence, orphaning the client created by the previous call before it could even complete the handshake. The driver retries every ~10 s indefinitely, producing up to 6 new server-side SSH sessions per cycle. At 300+ sessions (observed in the field) the bastion ran out of RAM.

The full failure sequence is visible in the customer logs: 3 simultaneous `"Establishing new SSH connection"` entries firing at the same timestamp per driver retry cycle confirms the race.

### Changes

**`initialize(reinitializeClient=true)` — serialize concurrent reinit attempts (`reinitializingPromise`)**

The first concurrent caller that needs a new client owns the reinit and stores its work in `reinitializingPromise`. All other concurrent callers await that same promise and then fall through to `initialize(false)` to use the freshly-connected client. Only one new SSH session is opened per reinit cycle regardless of how many `_connect()` callers are in flight.

**`_doReinit()` — cap consecutive failures (`consecutiveReinitFailures`)**

A new counter increments each time `_doReinit()` fails and resets to zero on success. After `MAX_CONSECUTIVE_REINIT_FAILURES` (3) consecutive failures the agent sets `closed = true`, causing all subsequent `initialize()` calls to throw `'Disconnected.'` immediately. This surfaces a clean error to the MongoDB driver rather than looping indefinitely and leaking sessions.

The counter only increments when the agent is not already intentionally closed (i.e. `destroy()` was not called), so a deliberate disconnect is unaffected.

## Open Questions

- `MAX_CONSECUTIVE_REINIT_FAILURES` is hardcoded to 3. This means ~30 s of failed reconnects before the agent gives up. Feedback welcome on whether that window feels right, though changing it is a one-liner if needed.

## Checklist

- [x] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added