### PR TITLE
feat(mql-typescript): add MongoDB 8.3 arrayIndexAs/as/valueAs to $filter and $reduce MONGOSH-3244

### DIFF
--- a/packages/mql-typescript/out/schema.d.ts
+++ b/packages/mql-typescript/out/schema.d.ts
@@ -1803,6 +1803,12 @@ export namespace Aggregation.Expression {
       as?: string;
 
       /**
+       * A name for the variable that represents the index of the current element in
+       * the input array. If specified, this variable is available within the cond expression.
+       */
+      arrayIndexAs?: string;
+
+      /**
        * A number expression that restricts the number of matching array elements that $filter returns. You cannot specify a limit less than 1. The matching array elements are returned in the order they appear in the input array.
        * If the specified limit is greater than the number of matching array elements, $filter returns all matching array elements. If the limit is null, $filter returns all matching array elements.
        */
@@ -2855,6 +2861,24 @@ export namespace Aggregation.Expression {
        * The initial cumulative value set before in is applied to the first element of the input array.
        */
       initialValue: Expression<S>;
+
+      /**
+       * A name for the variable that represents each individual element of the input array.
+       * If no name is specified, the variable name defaults to this.
+       */
+      as?: string;
+
+      /**
+       * A name for the variable that represents the cumulative value of the expression.
+       * If no name is specified, the variable name defaults to value.
+       */
+      valueAs?: string;
+
+      /**
+       * A name for the variable that represents the index of the current element in
+       * the input array. If specified, this variable is available within the in expression.
+       */
+      arrayIndexAs?: string;
 
       /**
        * A valid expression that $reduce applies to each element in the input array in left-to-right order. Wrap the input value with $reverseArray to yield the equivalent of applying the combining expression from right-to-left.

--- a/packages/mql-typescript/out/schema.d.ts
+++ b/packages/mql-typescript/out/schema.d.ts
@@ -1793,11 +1793,6 @@ export namespace Aggregation.Expression {
       input: ResolvesToArray<S>;
 
       /**
-       * An expression that resolves to a boolean value used to determine if an element should be included in the output array. The expression references each element of the input array individually with the variable name specified in as.
-       */
-      cond: ResolvesToBool<S>;
-
-      /**
        * A name for the variable that represents each individual element of the input array. If no name is specified, the variable name defaults to this.
        */
       as?: string;
@@ -1807,6 +1802,11 @@ export namespace Aggregation.Expression {
        * the input array. If specified, this variable is available within the cond expression.
        */
       arrayIndexAs?: string;
+
+      /**
+       * An expression that resolves to a boolean value used to determine if an element should be included in the output array. The expression references each element of the input array individually with the variable name specified in as, and the element index with the variable name specified in arrayIndexAs (MongoDB 8.3+).
+       */
+      cond: ResolvesToBool<S>;
 
       /**
        * A number expression that restricts the number of matching array elements that $filter returns. You cannot specify a limit less than 1. The matching array elements are returned in the order they appear in the input array.
@@ -2863,6 +2863,40 @@ export namespace Aggregation.Expression {
       initialValue: Expression<S>;
 
       /**
+       * A valid expression that $reduce applies to each element in the input array in left-to-right order. Wrap the input value with $reverseArray to yield the equivalent of applying the combining expression from right-to-left.
+       * During evaluation of the in expression, two variables will be available:
+       * - value is the variable that represents the cumulative value of the expression. Use valueAs (MongoDB 8.3+) to specify a custom name.
+       * - this is the variable that refers to the element being processed. Use as (MongoDB 8.3+) to specify a custom name.
+       */
+      in:
+        | Expression<
+            S & {
+              /**
+               * The variable that refers to the element being processed. Renamed via the as argument (MongoDB 8.3+).
+               */
+              $this: any;
+
+              /**
+               * The variable that represents the cumulative value of the expression. Renamed via the valueAs argument (MongoDB 8.3+).
+               */
+              $value: any;
+            }
+          >
+        | ExpressionMap<
+            S & {
+              /**
+               * The variable that refers to the element being processed. Renamed via the as argument (MongoDB 8.3+).
+               */
+              $this: any;
+
+              /**
+               * The variable that represents the cumulative value of the expression. Renamed via the valueAs argument (MongoDB 8.3+).
+               */
+              $value: any;
+            }
+          >;
+
+      /**
        * A name for the variable that represents each individual element of the input array.
        * If no name is specified, the variable name defaults to this.
        */
@@ -2879,40 +2913,6 @@ export namespace Aggregation.Expression {
        * the input array. If specified, this variable is available within the in expression.
        */
       arrayIndexAs?: string;
-
-      /**
-       * A valid expression that $reduce applies to each element in the input array in left-to-right order. Wrap the input value with $reverseArray to yield the equivalent of applying the combining expression from right-to-left.
-       * During evaluation of the in expression, two variables will be available:
-       * - value is the variable that represents the cumulative value of the expression.
-       * - this is the variable that refers to the element being processed.
-       */
-      in:
-        | Expression<
-            S & {
-              /**
-               * The variable that refers to the element being processed.
-               */
-              $this: any;
-
-              /**
-               * The variable that represents the cumulative value of the expression.
-               */
-              $value: any;
-            }
-          >
-        | ExpressionMap<
-            S & {
-              /**
-               * The variable that refers to the element being processed.
-               */
-              $this: any;
-
-              /**
-               * The variable that represents the cumulative value of the expression.
-               */
-              $value: any;
-            }
-          >;
     };
   }
 


### PR DESCRIPTION
## Summary

Bumps the `mql-specifications` submodule and regenerates `schema.d.ts` to include new MongoDB 8.3 argument definitions for `$filter` and `$reduce`.

New optional fields (all `minVersion: 8.3`):
- `$filter`: `arrayIndexAs` — exposes the index of the current element, usable within `cond`
- `$reduce`: `as`, `valueAs`, `arrayIndexAs` — custom names for the element variable (default `$$this`), cumulative value variable (default `$$value`), and element index

`$map` already had `arrayIndexAs` from a previous change.

## Dependency

> ~~⚠️ The submodule currently points to an **unmerged branch** (`MONGOSH-3244-array-index-args`) in `mongodb/mql-specifications`. This PR will be updated to the merge commit once [mql-specifications#54](https://github.com/mongodb/mql-specifications/pull/54) is merged before marking ready for review.~~ Submodule was bumped already.

## Test plan

- [x] `schema.d.ts` correctly includes `arrayIndexAs?: string` on `$filter` and `$reduce`, and `as?: string` / `valueAs?: string` on `$reduce`
- [ ] Downstream: `mongodb-ts-autocomplete` suggests these fields when typing inside `$filter`, `$map`, and `$reduce` in mongosh/Compass