### PR TITLE
fix(mongodb-constants): update $unionWith db field to MongoDB 9.1 COMPASS-9980

### DIFF
--- a/packages/mongodb-constants/src/stage-operators.ts
+++ b/packages/mongodb-constants/src/stage-operators.ts
@@ -1260,7 +1260,7 @@ const STAGE_OPERATORS = [
     namespaces: [...ANY_NAMESPACE],
     description: 'Perform a union with a pipeline on another collection.',
     comment: `/**
- * db: Optional. The target database name (MongoDB 9.0+).
+ * db: Optional. The target database name (MongoDB 9.1+).
  * coll: The collection name.
  * pipeline: The pipeline on the other collection.
  */


### PR DESCRIPTION
## Summary
The `$unionWith` `db` field (union across databases) was previously documented as available in MongoDB 9.0+. Per SERVER-128724, this syntax was **removed from 9.0** and is now tentatively planned for **9.1**.

This updates the `$unionWith` template comment in `mongodb-constants` accordingly (9.0+ → 9.1+).

## Changes
- `packages/mongodb-constants/src/stage-operators.ts`: `db` field comment now reads `(MongoDB 9.1+)`.

## Testing
- `npm run compile -w @mongodb-js/mongodb-constants` ✅
- `npm test -w @mongodb-js/mongodb-constants` ✅ (121 passing)

Jira: COMPASS-9980
Ref: SERVER-128724