### PR TITLE
feat(mongodb-constants): add $$IDX system variable for MongoDB 8.3 MONGOSH-3244

### DIFF
--- a/packages/mongodb-constants/src/filter.spec.ts
+++ b/packages/mongodb-constants/src/filter.spec.ts
@@ -193,6 +193,29 @@ describe('completer', function () {
     });
   });
 
+  describe('$$IDX system variable', function () {
+    it('should include $$IDX system variable gated to MongoDB 8.3+', function () {
+      const idx = ALL_CONSTANTS.find((c) => c.value === '$$IDX');
+      expect(idx).to.exist;
+      expect(idx?.version).to.eq('8.3.0');
+      expect(idx?.meta).to.eq('variable:system');
+    });
+
+    it('should return $$IDX for server 8.3+ but not for older servers', function () {
+      const withIdx = getFilteredCompletions(
+        { serverVersion: '8.3.0' },
+        ALL_CONSTANTS,
+      ).map((c) => c.value);
+      expect(withIdx).to.include('$$IDX');
+
+      const withoutIdx = getFilteredCompletions(
+        { serverVersion: '8.2.0' },
+        ALL_CONSTANTS,
+      ).map((c) => c.value);
+      expect(withoutIdx).to.not.include('$$IDX');
+    });
+  });
+
   describe('all completions', function () {
     it('should have valid semver version or range specified', function () {
       ALL_CONSTANTS.forEach(({ name, version }) => {

--- a/packages/mongodb-constants/src/system-variables.ts
+++ b/packages/mongodb-constants/src/system-variables.ts
@@ -90,6 +90,15 @@ const SYSTEM_VARIABLES = [
     description:
       'A variable that stores the role names of the authenticated user running the command.',
   },
+  {
+    name: '$$IDX',
+    value: '$$IDX',
+    score: 1,
+    meta: 'variable:system',
+    version: '8.3.0',
+    description:
+      'A variable that references the index of the current array element in $map, $filter, and $reduce expressions. Use arrayIndexAs to specify a custom name instead.',
+  },
 ] as const;
 
 export { SYSTEM_VARIABLES };

--- a/packages/mongodb-ts-autocomplete/src/autocompleter.spec.ts
+++ b/packages/mongodb-ts-autocomplete/src/autocompleter.spec.ts
@@ -321,6 +321,26 @@ service host, so typescript wouldn't load all the dependencies.
     }
   });
 
+  it('suggests arrayIndexAs inside $filter, $map, $reduce operators', async function () {
+    // $filter narrows its type precisely — 'arrayIn' is needed to avoid
+    // JavaScript built-ins (Array, ArrayBuffer) shadowing the suggestion.
+    // $map and $reduce resolve via Expression<S> and work with 'array'.
+    const cases: [string, string][] = [
+      ['$filter', 'arrayIn'],
+      ['$map', 'array'],
+      ['$reduce', 'array'],
+    ];
+    for (const [op, prefix] of cases) {
+      const completions = await autocompleter.autocomplete(
+        `db.foo.aggregate([{ $project: { result: { ${op}: { ${prefix}`,
+      );
+      const names = completions.map((c) => c.name);
+      expect(names, `${op} should suggest arrayIndexAs`).to.include(
+        'arrayIndexAs',
+      );
+    }
+  });
+
   describe('getConnectionSchemaCode', function () {
     it('generates code for a connection', async function () {
       const docs = [


### PR DESCRIPTION
## Summary

- Adds `$$IDX` to `SYSTEM_VARIABLES` in `mongodb-constants`, version-gated to MongoDB 8.3+. It exposes the index of the current array element in `$map`, `$filter`, and `$reduce` expressions. Users can use `arrayIndexAs` to assign a custom name instead.
- Adds two tests to `filter.spec.ts` verifying `$$IDX` exists with the correct version and meta, and that it is included/excluded based on server version.
- Adds an integration test to `autocompleter.spec.ts` verifying `arrayIndexAs` is suggested for all three operators.

## Notes on the autocomplete test

`$filter` requires the prefix `arrayIn` rather than `array` to reliably surface `arrayIndexAs`. With the shorter `array` prefix, TypeScript resolves JavaScript built-ins (`Array`, `ArrayBuffer`) ahead of the operator-specific field due to a known inference limitation with `$filter`'s recursive generic type signature. `$map` and `$reduce` are not affected and work with the `array` prefix.

## Test plan

- [x] `mongodb-constants` — 123 tests passing
- [x] `mongodb-ts-autocomplete` — 12 tests passing (including new `arrayIndexAs` test)