### PR TITLE
feat(get-os-info): export OsInfo type MONGOSH-3489

### DIFF
--- a/packages/get-os-info/src/get-os-info.ts
+++ b/packages/get-os-info/src/get-os-info.ts
@@ -1,18 +1,18 @@
 import os from 'os';
 import { promises as fs } from 'fs';
 
-type LinuxInfo = {
+export type LinuxInfo = {
   os_linux_dist: string;
   os_linux_release: string;
 };
 
-type DarwinInfo = {
+export type DarwinInfo = {
   os_darwin_product_name: string;
   os_darwin_product_version: string;
   os_darwin_product_build_version: string;
 };
 
-type OsInfo = {
+export type OsInfo = {
   os_type: string;
   os_version: string;
   os_arch: string;

--- a/packages/get-os-info/src/index.ts
+++ b/packages/get-os-info/src/index.ts
@@ -1,1 +1,2 @@
 export { getOsInfo } from './get-os-info';
+export type { OsInfo, LinuxInfo, DarwinInfo } from './get-os-info';


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  Use `feat`, `fix` for user facing changes that should be part of release notes.

  # Semantic Versioning:

  Package versions will be bumped automatically according to the PR title:

  - The words `BREAKING CHANGE` in the title will cause a **major** bump to all the packages changed in the PR. All dependants will also have a major bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - A subject starting with `feat` will cause a **minor** bump to all the packages changed in the PR. All dependants will also have a minor bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - Any other change to any package will cause a `patch` bump to the package and all its dependants.
-->

## Description

Export the type def for the return type of `getOsInfo`

## Checklist
- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
