### PR TITLE
feat(mongodb-constants): add quantization to auto-embed index template and model to vector search query COMPASS-10113

### DIFF
--- a/packages/mongodb-constants/src/atlas-search-templates.ts
+++ b/packages/mongodb-constants/src/atlas-search-templates.ts
@@ -139,7 +139,8 @@ export const ATLAS_VECTOR_SEARCH_AUTO_EMBED_TEMPLATE: SearchTemplate = {
     "type": "autoEmbed",
     "modality": "text",
     "path": "\${1:<field name to index>}",
-    "model": "voyage-4"
+    "model": "voyage-4",
+    "quantization": "\${2:<float | scalar | binary | binaryNoRescore>}"
   }]
 }`,
   version: '4.4.0',

--- a/packages/mongodb-constants/src/stage-operators.ts
+++ b/packages/mongodb-constants/src/stage-operators.ts
@@ -1387,13 +1387,14 @@ const VECTOR_SEARCH_AUTO_EMBED_STAGE = {
 `,
   snippet: `{
   // query: {"text": \${1:query string}},
-  // queryVector: [\${2:dimension1}, \${3:dimension2}, ...],
-  path: \${4:string},
-  numCandidates: \${5:numCandidates},
-  index: \${6:string},
-  limit: \${7:limit},
-  filter: {\${8:expression}},
-  exact: \${9:boolean}
+  // model: \${2:string},
+  // queryVector: [\${3:dimension1}, \${4:dimension2}, ...],
+  path: \${5:string},
+  numCandidates: \${6:numCandidates},
+  index: \${7:string},
+  limit: \${8:limit},
+  filter: {\${9:expression}},
+  exact: \${10:boolean}
 }`,
 };
 


### PR DESCRIPTION
## Description

Extends the vector search templates in `mongodb-constants` to reflect the new Public Preview auto-embedding syntax.

- **Auto-embed index template**: added an optional `quantization` field with the supported values as a snippet placeholder (`float | scalar | binary | binaryNoRescore`).
- **`$vectorSearch` query snippet**: added the `model` option (commented out alongside `query` / `queryVector`, since it is only used with auto-embedding `query.text`). Tab-stop placeholders renumbered to stay sequential.

## Open Questions

None.

## Checklist

- [x] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
