### PR TITLE
chore(mongodb-schema): aligning package version with latest published COMPASS-10911

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29331,7 +29331,7 @@
     },
     "packages/mongodb-schema": {
       "name": "@mongodb-js/mongodb-schema",
-      "version": "0.2.0",
+      "version": "12.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "reservoir": "^0.1.2"
@@ -29690,7 +29690,7 @@
       "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/mongodb-schema": "^0.2.0",
+        "@mongodb-js/mongodb-schema": "^12.7.0",
         "@mongodb-js/ts-autocomplete": "^0.5.13",
         "@mongosh/shell-api": "^5.1.6",
         "debug": "^4.4.0",
@@ -30084,7 +30084,7 @@
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-devtools": "^0.11.8",
-        "@mongodb-js/mongodb-schema": "^0.2.0",
+        "@mongodb-js/mongodb-schema": "^12.7.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.4",
         "@mongodb-js/shell-bson-parser": "^1.5.14",
         "@mongodb-js/tsconfig-devtools": "^1.1.3",
@@ -37312,7 +37312,7 @@
       "requires": {
         "@mongodb-js/eslint-config-devtools": "^0.11.8",
         "@mongodb-js/mocha-config-devtools": "^1.1.3",
-        "@mongodb-js/mongodb-schema": "^0.2.0",
+        "@mongodb-js/mongodb-schema": "^12.7.0",
         "@mongodb-js/mql-typescript": "^0.7.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.4",
         "@mongodb-js/ts-autocomplete": "^0.5.13",
@@ -37568,7 +37568,7 @@
       "version": "file:packages/mql-typescript",
       "requires": {
         "@mongodb-js/eslint-config-devtools": "^0.11.8",
-        "@mongodb-js/mongodb-schema": "^0.2.0",
+        "@mongodb-js/mongodb-schema": "^12.7.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.4",
         "@mongodb-js/shell-bson-parser": "^1.5.14",
         "@mongodb-js/tsconfig-devtools": "^1.1.3",

--- a/packages/mongodb-schema/package.json
+++ b/packages/mongodb-schema/package.json
@@ -13,7 +13,7 @@
     "email": "compass@mongodb.com"
   },
   "homepage": "https://github.com/mongodb-js/devtools-shared",
-  "version": "0.2.0",
+  "version": "12.7.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/mongodb-js/devtools-shared.git"

--- a/packages/mongodb-ts-autocomplete/package.json
+++ b/packages/mongodb-ts-autocomplete/package.json
@@ -53,7 +53,7 @@
     "extract-types": "ts-node scripts/extract-types.ts"
   },
   "dependencies": {
-    "@mongodb-js/mongodb-schema": "^0.2.0",
+    "@mongodb-js/mongodb-schema": "^12.7.0",
     "@mongodb-js/ts-autocomplete": "^0.5.13",
     "@mongosh/shell-api": "^5.1.6",
     "debug": "^4.4.0",

--- a/packages/mql-typescript/package.json
+++ b/packages/mql-typescript/package.json
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-devtools": "^0.11.8",
-    "@mongodb-js/mongodb-schema": "^0.2.0",
+    "@mongodb-js/mongodb-schema": "^12.7.0",
     "@mongodb-js/prettier-config-devtools": "^1.0.4",
     "@mongodb-js/shell-bson-parser": "^1.5.14",
     "@mongodb-js/tsconfig-devtools": "^1.1.3",


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  Use `feat`, `fix` for user facing changes that should be part of release notes.

  # Semantic Versioning:

  Package versions will be bumped automatically according to the PR title:

  - The words `BREAKING CHANGE` in the title will cause a **major** bump to all the packages changed in the PR. All dependants will also have a major bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - A subject starting with `feat` will cause a **minor** bump to all the packages changed in the PR. All dependants will also have a minor bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - Any other change to any package will cause a `patch` bump to the package and all its dependants.
-->

## Description

Aligning mongodb-schema version with latest published version on npm.

<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Checklist

- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
