### PR TITLE
fix(query-parser): use json stringify to return code block COMPASS-10946

### DIFF
--- a/packages/query-parser/src/index.spec.ts
+++ b/packages/query-parser/src/index.spec.ts
@@ -426,6 +426,24 @@ e  s`,
         "{a:{name:'multi-line with s  p    a   c\\n        \\ne  s'}}",
       );
     });
+
+    it('escapes quotes, backslashes and newlines in Code', function () {
+      const code = `a "b" 'c' \\d\ne`;
+      const jsString = toJSString({ a: new bson.Code(code) }) as string;
+      assert.deepEqual(parseFilter(jsString), {
+        a: new bson.Code(code),
+      });
+    });
+
+    it('escapes Code with a scope', function () {
+      const code = `');process.exit(1);('`;
+      const jsString = toJSString({
+        a: new bson.Code(code, { b: 1 }),
+      }) as string;
+      assert.deepEqual(parseFilter(jsString), {
+        a: new bson.Code(code, { b: 1 }),
+      });
+    });
   });
 
   describe('stringify', function () {

--- a/packages/query-parser/src/stringify.ts
+++ b/packages/query-parser/src/stringify.ts
@@ -48,10 +48,11 @@ function getTypeDescriptorForValue(value: BSONValue) {
 
 const BSON_TO_JS_STRING = {
   Code: function (v: Code) {
+    const code = JSON.stringify(v.code);
     if (v.scope) {
-      return `Code('${v.code}',${JSON.stringify(v.scope)})`;
+      return `Code(${code},${JSON.stringify(v.scope)})`;
     }
-    return `Code('${v.code}')`;
+    return `Code(${code})`;
   },
   ObjectID: function (v: ObjectId) {
     return `ObjectId('${v.toString('hex')}')`;


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  Use `feat`, `fix` for user facing changes that should be part of release notes.

  # Semantic Versioning:

  Package versions will be bumped automatically according to the PR title:

  - The words `BREAKING CHANGE` in the title will cause a **major** bump to all the packages changed in the PR. All dependants will also have a major bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - A subject starting with `feat` will cause a **minor** bump to all the packages changed in the PR. All dependants will also have a minor bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - Any other change to any package will cause a `patch` bump to the package and all its dependants.
-->

## Description

Using JSON.stringify to scape code before returning string, more details on ticket.

<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Checklist

- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
