### PR TITLE
feat(mongodb-ns): show __mdb_internal_search in database lists COMPASS-10948

### DIFF
--- a/packages/mongodb-ns/README.md
+++ b/packages/mongodb-ns/README.md
@@ -24,7 +24,14 @@ canadian-things.songs-aboot-bacon
   special: false,
   specialish: false,
   normal: true,
+  internal: false,
   validDatabaseName: true,
   validCollectionName: true,
   databaseHash: 23620443216 }
 ```
+
+`internal` is `true` for
+[internal databases](https://www.mongodb.com/docs/atlas/reference/internal-database/#internal-databases)
+matching `__mdb_internal_*`, except `__mdb_internal_search` — UIs filter on
+`internal` to hide these, and that one needs to stay visible. It is still
+`special`/`specialish`.

--- a/packages/mongodb-ns/src/index.spec.ts
+++ b/packages/mongodb-ns/src/index.spec.ts
@@ -69,6 +69,16 @@ describe('ns', function () {
     it('should acccept `__mdb_internal_suffix`', function () {
       assert(ns('__mdb_internal_suffix').special);
     });
+    // COMPASS-10948: special via its own clause, not via `internal`.
+    it('should acccept `__mdb_internal_search`', function () {
+      assert(ns('__mdb_internal_search').special);
+    });
+  });
+
+  describe('should identify specialish namespaces', function () {
+    it('should acccept `__mdb_internal_search`', function () {
+      assert(ns('__mdb_internal_search').specialish);
+    });
   });
 
   describe('should identify system namespaces', function () {
@@ -103,6 +113,14 @@ describe('ns', function () {
     assert.equal(ns('__mdb_internal').isInternal(), false);
     assert(ns('__mdb_internal_bla').internal);
     assert(ns('__mdb_internal_foo_bar').isInternal());
+    // COMPASS-10948: only the exact database name is exempt.
+    assert.equal(ns('__mdb_internal_search').internal, false);
+    assert.equal(ns('__mdb_internal_search.someColl').isInternal(), false);
+    assert(ns('__mdb_internal_search_foo').internal);
+    assert(ns('__mdb_internal_searchfoo').internal);
+    assert(ns('__mdb_internal_searchX').internal);
+    assert(ns('__mdb_internal_Search').internal);
+    assert.equal(ns('__mdb_internal_').isInternal(), false);
   });
 
   describe('database name validation', function () {

--- a/packages/mongodb-ns/src/index.ts
+++ b/packages/mongodb-ns/src/index.ts
@@ -50,7 +50,9 @@ const NS: NSConstructor = function (this: NS, ns: string | NS): NS {
   }
 
   // https://www.mongodb.com/docs/atlas/reference/internal-database/#internal-databases
-  this.internal = /^__mdb_internal_\w/.test(this.database);
+  // `__mdb_internal_search` is exempt so UIs filtering on `internal` stop hiding
+  // it (COMPASS-10948). It stays `special` below — keep both changes together.
+  this.internal = /^__mdb_internal_(?!search$)\w/.test(this.database);
 
   this.system = /^(?:system(?!\.profile$).*|enxcol_)\./.test(this.collection);
 
@@ -63,7 +65,8 @@ const NS: NSConstructor = function (this: NS, ns: string | NS): NS {
     this.command ||
     this.system ||
     this.database === 'config' ||
-    this.internal;
+    this.internal ||
+    this.database === '__mdb_internal_search';
 
   this.specialish =
     this.special || ['local', 'admin'].indexOf(this.database) > -1;


### PR DESCRIPTION
## Description

Auto-Embedding stores its generated embeddings in `__mdb_internal_search` on the customer's cluster, and customers need to browse them. UIs hide `__mdb_internal_*` databases by filtering on `internal`, so Compass and Data Explorer currently drop it from the database list.

`internal` both classifies internal databases and drives that filtering. This separates the two: `__mdb_internal_search` is exempt from `internal` so it is no longer hidden, while a dedicated clause keeps it `special`/`specialish` — it is still a MongoDB-managed database. Both changes need to stay together: without the `special` clause, Compass treats these collections as user data and offers the Global Writes tab and the data-modeling wizards for them. The match is exact, so `__mdb_internal_search_*` and every other `__mdb_internal_*` database stay `internal`.

## Open Questions

On multi-tenant clusters mongot can name this database `<prefix>___mdb_internal_search`, taking the prefix from the source database name and falling back to the bare name when it has no underscore [AtlasInternalDatabaseResolver](http://github.com/10gen/mongot/blob/04d3053f754a7477860d4ae0237f786f0ee00c66/src/main/java/com/xgen/atlas/embedding/mongodb/common/AtlasInternalDatabaseResolver.java#L30-L38). The prefixed form never matched `^__mdb_internal_`, so it is already visible but never `special`, and the exact match here doesn't cover it — should the clause use a suffix match instead? This is from reading the resolver; I haven't confirmed it against a live multi-tenant cluster.

## Checklist

- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [x] New tests and/or benchmarks are included
- [x] Documentation is changed or added
