### PR TITLE
chore(mongodb-schema): update test timeout on windows and ensure close COMPASS-10932

### DIFF
--- a/packages/mongodb-schema/test/integration/generate-and-validate.test.ts
+++ b/packages/mongodb-schema/test/integration/generate-and-validate.test.ts
@@ -54,8 +54,21 @@ describe('Documents -> Generate schema -> Validate Documents against the schema'
 });
 
 describe('With a MongoDB Cluster', function () {
+  if (process.platform === 'win32') {
+    // Shutting down mongod and removing its data files is much slower on
+    // Windows CI than the default mocha timeout allows for.
+    this.timeout(120_000);
+  }
+
   let client: MongoClient;
   let db: Db;
+
+  // We need to register this before mochaTestServer() so that mocha runs it first and the
+  // client is closed before the cluster it is connected to goes away.
+  after(async function () {
+    await client?.close();
+  });
+
   const cluster = mochaTestServer();
 
   before(async function () {
@@ -64,10 +77,6 @@ describe('With a MongoDB Cluster', function () {
     client = new MongoClient(connectionString);
     await client.connect();
     db = client.db('test');
-  });
-
-  after(async function () {
-    await client?.close();
   });
 
   describe('Documents -> Generate basic schema -> Use schema in validation rule in MongoDB -> Validate documents against the schema', function () {

--- a/packages/mongodb-schema/test/integration/generate-and-validate.test.ts
+++ b/packages/mongodb-schema/test/integration/generate-and-validate.test.ts
@@ -63,8 +63,8 @@ describe('With a MongoDB Cluster', function () {
   let client: MongoClient;
   let db: Db;
 
-  // We need to register this before mochaTestServer() so that mocha runs it first and the
-  // client is closed before the cluster it is connected to goes away.
+  // We register this before mochaTestServer() so that mocha runs it first and the
+  // client is closed before closing the cluster.
   after(async function () {
     await client?.close();
   });


### PR DESCRIPTION
COMPASS-10932

Adding this package also shuffled which tests land in which test group (1-4). mongodb-schema is in group 3. I didn't deep dive all of the failures, on the two I did look at it was 3 timing out in mongodb-schema.