### PR TITLE
fix(oidc-http-server-pages): bump compass-components version COMPASS-10980

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2053,13 +2053,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
-      "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "dev": true,
-      "dependencies": {
-        "regenerator-runtime": "^0.13.4"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2443,6 +2441,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
     "node_modules/@emotion/memoize": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
@@ -2515,6 +2523,30 @@
       "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@emotion/styled": {
+      "version": "11.14.1",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
+      "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/is-prop-valid": "^1.3.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@emotion/unitless": {
       "version": "0.10.0",
@@ -2638,6 +2670,64 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.26.28",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
+      "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.8",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.8.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -3395,459 +3485,169 @@
       "license": "MIT"
     },
     "node_modules/@leafygreen-ui/a11y": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/a11y/-/a11y-1.5.0.tgz",
-      "integrity": "sha512-QKnzWWFsw8FR9+KVqQbgzSGC5T2NcsUI1+6bc6+mNh1HwH8nUctrXj0tjTkrV+Dmab8zdeArUz24ly9eEvl7UA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/a11y/-/a11y-3.0.5.tgz",
+      "integrity": "sha512-HJqDsLCNj4d1RQiifYuhpazZVYgsLZJeEboaQ+UsNhAppV13kdPb2qX7H4RbGmXkalTBzHOkbAYp6vvioSAVdQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/lib": "^13.6.1"
+        "@leafygreen-ui/emotion": "^5.0.3",
+        "@leafygreen-ui/hooks": "^9.1.4",
+        "@leafygreen-ui/lib": "^15.4.0"
       }
     },
-    "node_modules/@leafygreen-ui/a11y/node_modules/@leafygreen-ui/hooks": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-      "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
+    "node_modules/@leafygreen-ui/avatar": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/avatar/-/avatar-3.3.0.tgz",
+      "integrity": "sha512-3x4wx40yB0kl224d7HK9AihwJmaZtQU2K2u6MrzJoG+LNp8ptFJ+tHrR2WFXKn5Heo7sKWW9AbD6DuUQp32MvA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/lib": "^14.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/a11y/node_modules/@leafygreen-ui/hooks/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/logo": "^11.1.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
         "lodash": "^4.17.21"
       },
       "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/a11y/node_modules/@leafygreen-ui/lib": {
-      "version": "13.8.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-      "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
     "node_modules/@leafygreen-ui/badge": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/badge/-/badge-8.1.0.tgz",
-      "integrity": "sha512-lbdjkFQd2Gwl7IeiLJKfDg/jg9rDgdPaAfFtQc0DfO/jDhnXG6eoXwWgxVFkIDvdUv8iZQofgZZcdmo3XtppOA==",
-      "dev": true,
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.1.4"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
-      }
-    },
-    "node_modules/@leafygreen-ui/badge/node_modules/@leafygreen-ui/lib": {
-      "version": "13.8.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-      "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/badge/-/badge-10.2.4.tgz",
+      "integrity": "sha512-iWciiIrnmlrSOtgq438x7Tg0mYjLd148LeCNFypGpeiyfecZz3XmfCQM4NAydT2zA7Q65kcX7f+Yt+cuCz8Mqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2"
       },
       "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/badge/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/badge/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/badge/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
     "node_modules/@leafygreen-ui/banner": {
-      "version": "7.0.18",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/banner/-/banner-7.0.18.tgz",
-      "integrity": "sha512-EdH40+L6hrq3y1pPayIHawtQXUp9rzZtziDHlKeuUg2AgsSwfQ3WF48H2IP1ADF9I3npHpwMPsO3wGktEMG8lA==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/banner/-/banner-10.2.5.tgz",
+      "integrity": "sha512-CE3Stz4S00kyDqjhfPutJlxxDDdVuynyT/cWpufxhB+a/RvWktRRZL3o3AKPPBwnwzp5e18p+vzAMAilIJ0s0Q==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/icon": "^11.25.1",
-        "@leafygreen-ui/icon-button": "^15.0.19",
-        "@leafygreen-ui/lib": "^13.1.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.1.4",
-        "@leafygreen-ui/typography": "^18.0.0"
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
-    },
-    "node_modules/@leafygreen-ui/banner/node_modules/@leafygreen-ui/lib": {
-      "version": "13.8.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-      "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/banner/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/banner/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/banner/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/banner/node_modules/@leafygreen-ui/typography": {
-      "version": "18.4.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-18.4.0.tgz",
-      "integrity": "sha512-2pfoBv6jEPupMzT/rciyP6oN53Fc2h0Nl/uXubSRuFcIDwUAE6CIb3+IjK3UNyQrnOixGU4lWQhxIPTrnyxCpQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/icon": "^12.1.0",
-        "@leafygreen-ui/lib": "^13.4.0",
-        "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/polymorphic": "^1.3.7",
-        "@leafygreen-ui/tokens": "^2.5.2"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
-      }
-    },
-    "node_modules/@leafygreen-ui/banner/node_modules/@leafygreen-ui/typography/node_modules/@leafygreen-ui/icon": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-      "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/box": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/box/-/box-3.1.9.tgz",
-      "integrity": "sha512-hY05VQKDVhqqBH/Dz1kxonjQmqrMR9URa3Dw3YgdLbVUd1hMQkoWbplamiE4S4vq2+81SQBgNw53i+/Vd0Cl0g==",
-      "deprecated": "This package is deprecated. Please use @leafygreen-ui/polymorphic instead.",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/@leafygreen-ui/button": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/button/-/button-19.0.4.tgz",
-      "integrity": "sha512-T72lmAHS63cvhyAKaO53tNysL3xDsjnmIoaP0I55eOFOYlEy522U7vf0RMi/BsOePyAJak+x9yZ4uj8AWMCsbg==",
-      "dev": true,
-      "dependencies": {
-        "@leafygreen-ui/box": "^3.1.1",
-        "@leafygreen-ui/emotion": "^4.0.3",
-        "@leafygreen-ui/lib": "^10.0.0",
-        "@leafygreen-ui/palette": "^3.4.7",
-        "@leafygreen-ui/ripple": "^1.1.8",
-        "@leafygreen-ui/tokens": "^2.0.0",
-        "polished": "^4.2.2"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/button/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
+      "version": "25.2.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/button/-/button-25.2.1.tgz",
+      "integrity": "sha512-hJWf4K1WNCSaM1VWj8obGuMAxnd1/KCORnGNqphjBKS83Nu0XYCWedl6rhwQTkpCDzESQYAExw3KJV+moygB/w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/ripple": "^2.0.7",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@lg-tools/test-harnesses": "^0.3.4",
         "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/button/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
       },
       "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
-    },
-    "node_modules/@leafygreen-ui/button/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/@leafygreen-ui/card": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/card/-/card-9.0.9.tgz",
-      "integrity": "sha512-WeQiYUpWctuM8GWWgze1RuKOta+sXfYMEQPidcSIhTJK/9OKCLI4CfvJoH0vJdDlMKJWeozQh75pmYzSeWDfxA==",
-      "dev": true,
-      "dependencies": {
-        "@leafygreen-ui/box": "^3.1.4",
-        "@leafygreen-ui/emotion": "^4.0.4",
-        "@leafygreen-ui/lib": "^10.4.0",
-        "@leafygreen-ui/palette": "^4.0.3",
-        "@leafygreen-ui/tokens": "^2.1.1",
-        "polished": "^4.2.2"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.3"
-      }
-    },
-    "node_modules/@leafygreen-ui/card/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/card/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/card/-/card-13.3.1.tgz",
+      "integrity": "sha512-WkH0VbSqy2y959pVQstF4RFF9T31ps+1gl6c7Y8q5Pzt/GEQoUA4y8DvbInrd0RJwyHsIXMV2bbujiMUrh3tvw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/card/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/tokens": "^4.2.2"
       },
       "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
     "node_modules/@leafygreen-ui/checkbox": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/checkbox/-/checkbox-12.1.0.tgz",
-      "integrity": "sha512-3KaRyKYb9ghXcJcNRP4ZYXgjP9qIe4Ltc5o1HGh7v3TjRyxjlVJ+RwXE5g2mD43vVs3flemcCZD1nc9FgkMq6A==",
+      "version": "18.1.5",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/checkbox/-/checkbox-18.1.5.tgz",
+      "integrity": "sha512-KTvSdlZPY+gmfCuTrRhM+slyGoILzAuVgoXdanneLVDZiD8W3j3t4z69znCYK/tL1pNLin1FaRkO/kpQAkv/DQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/a11y": "^1.4.11",
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.0.0",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.2.0",
-        "@leafygreen-ui/typography": "^18.2.0",
+        "@leafygreen-ui/a11y": "^3.0.5",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "@lg-tools/test-harnesses": "^0.3.4",
         "react-transition-group": "^4.4.5"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
-    "node_modules/@leafygreen-ui/checkbox/node_modules/@leafygreen-ui/hooks": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-      "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
+    "node_modules/@leafygreen-ui/chip": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/chip/-/chip-4.2.1.tgz",
+      "integrity": "sha512-xLnRfz01dNwUWrE5074QjlGolq3XboLAvgJrXR+KCkTyLFExVOMCMXTn5nq4mG5v3rnHB6D3BhOLLDm8euTlxA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/lib": "^14.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/checkbox/node_modules/@leafygreen-ui/hooks/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/inline-definition": "^9.2.1",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2"
       },
       "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/checkbox/node_modules/@leafygreen-ui/icon": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-      "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/checkbox/node_modules/@leafygreen-ui/lib": {
-      "version": "13.8.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-      "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/checkbox/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/checkbox/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/checkbox/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/checkbox/node_modules/@leafygreen-ui/typography": {
-      "version": "18.4.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-18.4.0.tgz",
-      "integrity": "sha512-2pfoBv6jEPupMzT/rciyP6oN53Fc2h0Nl/uXubSRuFcIDwUAE6CIb3+IjK3UNyQrnOixGU4lWQhxIPTrnyxCpQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/icon": "^12.1.0",
-        "@leafygreen-ui/lib": "^13.4.0",
-        "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/polymorphic": "^1.3.7",
-        "@leafygreen-ui/tokens": "^2.5.2"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
     "node_modules/@leafygreen-ui/code": {
-      "version": "14.2.18",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/code/-/code-14.2.18.tgz",
-      "integrity": "sha512-vtAEzURQ/Or8G9vBjsjN4aCWoysHr/Ny/3ewEcLRpz66vkC0kplArdnmG5dVSmklzImU4jKa+QOeM74l3DTHUQ==",
+      "version": "20.2.8",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/code/-/code-20.2.8.tgz",
+      "integrity": "sha512-Y9iaaelKP6I7PZskHMPMkg6K5vszhBOc5AQ5BSNoRIzEnaJdOrB9lCNtPzc1sVyp4kL2ryuYyy2Dcv4HwBVVeA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/a11y": "^1.4.11",
-        "@leafygreen-ui/button": "^21.0.11",
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.0.0",
-        "@leafygreen-ui/icon": "^11.25.1",
-        "@leafygreen-ui/icon-button": "^15.0.19",
-        "@leafygreen-ui/lib": "^13.1.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/select": "^11.0.1",
-        "@leafygreen-ui/tokens": "^2.2.0",
+        "@leafygreen-ui/a11y": "^3.0.5",
+        "@leafygreen-ui/button": "^25.2.1",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.9.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/select": "^17.1.0",
+        "@leafygreen-ui/skeleton-loader": "^3.0.11",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/tooltip": "^14.3.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "@lg-tools/test-harnesses": "^0.3.4",
         "@types/facepaint": "^1.2.1",
         "@types/highlight.js": "^10.1.0",
         "clipboard": "^2.0.6",
@@ -3858,2377 +3658,637 @@
         "polished": "^4.2.2"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
-    "node_modules/@leafygreen-ui/code/node_modules/@leafygreen-ui/button": {
-      "version": "21.3.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/button/-/button-21.3.0.tgz",
-      "integrity": "sha512-v9qipsRWHQBN9sC4RNWmJ/PVQCcYZdg9Wa+k9Q6LFjgahI1/6BXYTZOP4wPJQDp2AG6+dx2CF7Rp60ymM+wtLw==",
+    "node_modules/@leafygreen-ui/combobox": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/combobox/-/combobox-12.5.1.tgz",
+      "integrity": "sha512-Wf78P44DHq+19b+LLIbFnfF2zTlhuo0kgrCDnm9QcqYwIzyWDHLx2bOQslfpj0Xbm3oFYMIOChnUNK5kHON8Aw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/box": "^3.1.9",
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/lib": "^13.4.0",
-        "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/ripple": "^1.1.13",
-        "@leafygreen-ui/tokens": "^2.5.2",
-        "@lg-tools/test-harnesses": "^0.1.2",
+        "@leafygreen-ui/checkbox": "^18.1.5",
+        "@leafygreen-ui/chip": "^4.2.1",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/form-field": "^4.0.9",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/input-option": "^4.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/popover": "^14.3.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "chalk": "^4.1.2",
+        "lodash": "^4.17.21",
         "polished": "^4.2.2"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
-    "node_modules/@leafygreen-ui/code/node_modules/@leafygreen-ui/hooks": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-      "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/lib": "^14.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/code/node_modules/@leafygreen-ui/hooks/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/code/node_modules/@leafygreen-ui/lib": {
-      "version": "13.8.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-      "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/code/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
+    "node_modules/@leafygreen-ui/compound-component": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/compound-component/-/compound-component-0.3.0.tgz",
+      "integrity": "sha512-gTso3f6nOHIgz9zCIl7AqO9lhFzGcJHPjuh2IahM27PXBRdNXOdjhx8T0WywC5RLLhHOy7eDXZubkBdiii0qDA==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/code/node_modules/@leafygreen-ui/polymorphic": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/polymorphic/-/polymorphic-2.0.7.tgz",
-      "integrity": "sha512-MUw76DT7R7msTDjhqAvZs5dqrt5684fAKm+QhpdzKB9ywh3LCdo9syg/Hva72rDa0fRV5i/V6nYEY8zM1N005A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/lib": "^14.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/code/node_modules/@leafygreen-ui/polymorphic/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/code/node_modules/@leafygreen-ui/select": {
-      "version": "11.3.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/select/-/select-11.3.2.tgz",
-      "integrity": "sha512-qPAXYibI4UNX+xW7QdspoT+fg9WfkqTwCsD9j27rTyJZ+pR2BOW5oynG5gKnm0AVPWullms5/SdxiLWai1GxNA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/button": "^21.2.0",
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/icon": "^12.1.0",
-        "@leafygreen-ui/input-option": "^1.1.3",
-        "@leafygreen-ui/lib": "^13.4.0",
-        "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/popover": "^11.3.1",
-        "@leafygreen-ui/tokens": "^2.5.2",
-        "@leafygreen-ui/typography": "^19.0.0",
-        "@lg-tools/test-harnesses": "^0.1.2",
-        "@types/react-is": "^18.0.0",
-        "lodash": "^4.17.21",
-        "polished": "^4.1.3",
-        "react-is": "^18.0.1"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
-      }
-    },
-    "node_modules/@leafygreen-ui/code/node_modules/@leafygreen-ui/select/node_modules/@leafygreen-ui/icon": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-      "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/code/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/code/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/code/node_modules/@leafygreen-ui/typography": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-19.3.0.tgz",
-      "integrity": "sha512-pgTRcc4usW/S9nDDzkf5Ac/JPEybhWtOnDpmrp99mAJHM6tH48Pd1HjRNHWjn6bnh0nXWjwANXX1ZEe+8ggCNg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/icon": "^12.6.0",
-        "@leafygreen-ui/lib": "^13.6.1",
-        "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/polymorphic": "^2.0.0",
-        "@leafygreen-ui/tokens": "^2.9.0"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
-      }
-    },
-    "node_modules/@leafygreen-ui/code/node_modules/@leafygreen-ui/typography/node_modules/@leafygreen-ui/icon": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-      "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/code/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@leafygreen-ui/confirmation-modal": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/confirmation-modal/-/confirmation-modal-4.0.10.tgz",
-      "integrity": "sha512-shnFII39bPmFuhWl4wZJn5eAok3GhxrUyffjDVZV7JsWNVJftZeYtqao/YAePgytr6Gwpc+7FcZSzwXk2RWwzw==",
-      "dev": true,
-      "dependencies": {
-        "@leafygreen-ui/button": "^20.2.1",
-        "@leafygreen-ui/emotion": "^4.0.4",
-        "@leafygreen-ui/icon": "^11.17.0",
-        "@leafygreen-ui/modal": "^15.0.3",
-        "@leafygreen-ui/palette": "^4.0.3",
-        "@leafygreen-ui/text-input": "^12.1.14",
-        "@leafygreen-ui/tokens": "^2.1.1",
-        "@leafygreen-ui/typography": "^16.5.1"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.3"
-      }
-    },
-    "node_modules/@leafygreen-ui/confirmation-modal/node_modules/@leafygreen-ui/button": {
-      "version": "20.3.1",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/button/-/button-20.3.1.tgz",
-      "integrity": "sha512-uyy4o6WhRmwaDBt45qOUs/EC4QB4J36T7Hb7sidGQyetx8BU0VPigR4cnSAes0Ye95KyG5y7y/PgX2+Ab45K1g==",
-      "dev": true,
-      "dependencies": {
-        "@leafygreen-ui/box": "^3.1.4",
-        "@leafygreen-ui/emotion": "^4.0.4",
-        "@leafygreen-ui/lib": "^10.4.0",
-        "@leafygreen-ui/palette": "^4.0.4",
-        "@leafygreen-ui/ripple": "^1.1.9",
-        "@leafygreen-ui/tokens": "^2.1.1",
-        "polished": "^4.2.2"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.4"
-      }
-    },
-    "node_modules/@leafygreen-ui/confirmation-modal/node_modules/@leafygreen-ui/modal": {
-      "version": "15.0.6",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/modal/-/modal-15.0.6.tgz",
-      "integrity": "sha512-GJ4SEwKQ1NU8xm1P/KJvRfCZVD0yZrXtI1xh0Lay/w4wy4XCAYwIUHm2sV2ydrGLd2VeCT1onflJsZDLU6MrOw==",
-      "dev": true,
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^7.7.8",
-        "@leafygreen-ui/icon": "^11.22.1",
-        "@leafygreen-ui/icon-button": "^15.0.16",
-        "@leafygreen-ui/lib": "^10.4.3",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/portal": "^4.1.7",
-        "@leafygreen-ui/tokens": "^2.1.4",
-        "focus-trap-react": "^8.10.0",
-        "polished": "^4.2.2",
-        "prop-types": "^15.8.1",
-        "react-transition-group": "^4.4.1"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.6"
-      }
-    },
-    "node_modules/@leafygreen-ui/confirmation-modal/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/confirmation-modal/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/confirmation-modal/-/confirmation-modal-11.0.1.tgz",
+      "integrity": "sha512-crYjy/qqEb5cMNuh1zdl6X0GN2V3wGSdo6n7qaTnRFlpaI1waWIDCGwhj+GxlyacNKqUHCTuvhU0xafyqX+p6A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
+        "@leafygreen-ui/button": "^25.2.1",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/modal": "^22.0.1",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/text-input": "^16.2.3",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
-    "node_modules/@leafygreen-ui/confirmation-modal/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
+    "node_modules/@leafygreen-ui/copyable": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/copyable/-/copyable-12.0.3.tgz",
+      "integrity": "sha512-BVhRh/HZbOMHIAA1lRzzl6UH1L9Uu2gokq9v1EOTl9/95QdkpYs/lUA/VwKjhYM0RNQPY4rSoWjhqC7HzrN6/A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@leafygreen-ui/button": "^25.2.1",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/tooltip": "^14.3.1",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "clipboard": "^2.0.6",
+        "polished": "^4.2.2"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/descendants": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/descendants/-/descendants-3.1.1.tgz",
+      "integrity": "sha512-A4IdIaUpyzQl7vFdqPxuBuO7GRwx8pFKf4OVQ7v8DXF0qLl508cu1T8oeb5p6elHk8xS3DT/CEVCMrEQt9dDzQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/lib": "^15.7.0",
         "lodash": "^4.17.21"
       },
       "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
-    "node_modules/@leafygreen-ui/confirmation-modal/node_modules/@leafygreen-ui/typography": {
-      "version": "16.5.5",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-16.5.5.tgz",
-      "integrity": "sha512-mErhTYM0C1PZaeADTkp5v/MAS6aEhavWHZ3otHthBSo/zwI5uAYnkreheiYElc66B/0bcOxCikLVkP3zaFnX2A==",
+    "node_modules/@leafygreen-ui/drawer": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/drawer/-/drawer-5.2.3.tgz",
+      "integrity": "sha512-H3lYN0xyZzYUwwl7LaJh75Flmhx7xVC7Q7RITN28aAN+NDIe5LPHbfPusqVs6/lT0Mb39XCYwAqoR5/HQAqSww==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/icon": "^11.22.2",
-        "@leafygreen-ui/lib": "^11.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/polymorphic": "^1.3.6",
-        "@leafygreen-ui/tokens": "^2.1.4"
+        "@leafygreen-ui/button": "^25.2.1",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/resizable": "^0.1.3",
+        "@leafygreen-ui/tabs": "^17.0.11",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/toolbar": "^1.3.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "@lg-tools/test-harnesses": "^0.3.4",
+        "polished": "^4.2.2",
+        "react-intersection-observer": "^8.25.1"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.7"
-      }
-    },
-    "node_modules/@leafygreen-ui/confirmation-modal/node_modules/@leafygreen-ui/typography/node_modules/@leafygreen-ui/lib": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-11.0.0.tgz",
-      "integrity": "sha512-sHkY/MOwRQDc9qAR1awreW0dP+6ELueJJd4JCJmi6XYbdL0wDotFwsWfCwkL+N6cFbE1e+xBQtFLB6T1+58+iQ==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
     "node_modules/@leafygreen-ui/emotion": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-4.0.10.tgz",
-      "integrity": "sha512-6fW0jXce40N+ZtJIomvpROrJar6h1S9TAwHSfHVJmCRB791s5hATxudiD+aE6gqYUL+naiDQc/XKy7I3LUK+hA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-5.2.0.tgz",
+      "integrity": "sha512-Sov+2tDy4ahGsRR8/KOV8Zzx+5fvVAj7Smyc1brgzE8ocXnOiwahQQ1wVvthAXS91iXPpnuNA5KL6Qzh3jNfQw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.1.3",
+        "@emotion/react": "^11.14.0",
         "@emotion/server": "^11.4.0"
       }
     },
     "node_modules/@leafygreen-ui/form-field": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/form-field/-/form-field-0.3.2.tgz",
-      "integrity": "sha512-s3aLK0NzYcMIjQUs5WHihpjH7QI19sH4BW1pRvWlA2T48NLy3gAtayZo8+Y+EsNCtu91Kc1qK705WHzx8i+Wnw==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/form-field/-/form-field-4.0.9.tgz",
+      "integrity": "sha512-lbFkP1Hh0cwUxPsatGjSCcDGt4nqDrJ5jWozwhljWbdQF74H9LG+HdVr9FALiLHeDm+47NbmTUQj+hOl4DD5aw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.1.1",
-        "@leafygreen-ui/icon": "^11.27.1",
-        "@leafygreen-ui/lib": "^13.2.1",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.3.0",
-        "@leafygreen-ui/typography": "^18.1.0"
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.11"
-      }
-    },
-    "node_modules/@leafygreen-ui/form-field/node_modules/@leafygreen-ui/hooks": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-      "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/lib": "^14.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/form-field/node_modules/@leafygreen-ui/hooks/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/form-field/node_modules/@leafygreen-ui/lib": {
-      "version": "13.8.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-      "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/form-field/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/form-field/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/form-field/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/form-field/node_modules/@leafygreen-ui/typography": {
-      "version": "18.4.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-18.4.0.tgz",
-      "integrity": "sha512-2pfoBv6jEPupMzT/rciyP6oN53Fc2h0Nl/uXubSRuFcIDwUAE6CIb3+IjK3UNyQrnOixGU4lWQhxIPTrnyxCpQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/icon": "^12.1.0",
-        "@leafygreen-ui/lib": "^13.4.0",
-        "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/polymorphic": "^1.3.7",
-        "@leafygreen-ui/tokens": "^2.5.2"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
-      }
-    },
-    "node_modules/@leafygreen-ui/form-field/node_modules/@leafygreen-ui/typography/node_modules/@leafygreen-ui/icon": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-      "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "lodash": "^4.17.21"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
     "node_modules/@leafygreen-ui/guide-cue": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/guide-cue/-/guide-cue-4.0.12.tgz",
-      "integrity": "sha512-OhmTuJPSExiAt/5/BB2UmmxywtcpX8Hb1EBjiG9W1vvhWWI2ielHapLvOzRkm1UbFasvzTxLCArW6BbiSbUn5w==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/guide-cue/-/guide-cue-8.2.0.tgz",
+      "integrity": "sha512-YDNcu+DA4aOE9QxI/TujT/v7h0YXz07rQpBcrew+7dIhDp3NcuNLN39SYegz5Gi6br+rhEQh8n7dowBHhVM6iw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/a11y": "^1.4.7",
-        "@leafygreen-ui/button": "^21.0.3",
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^7.7.8",
-        "@leafygreen-ui/icon": "^11.22.1",
-        "@leafygreen-ui/icon-button": "^15.0.16",
-        "@leafygreen-ui/lib": "^10.4.3",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/popover": "^11.0.15",
-        "@leafygreen-ui/tooltip": "^10.0.7",
-        "@leafygreen-ui/typography": "^16.5.4",
-        "focus-trap-react": "^10.0.0",
+        "@leafygreen-ui/a11y": "^3.0.5",
+        "@leafygreen-ui/button": "^25.1.3",
+        "@leafygreen-ui/emotion": "^5.1.0",
+        "@leafygreen-ui/hooks": "^9.3.0",
+        "@leafygreen-ui/icon": "^14.7.1",
+        "@leafygreen-ui/icon-button": "^17.1.4",
+        "@leafygreen-ui/lib": "^15.6.2",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/popover": "^14.3.1",
+        "@leafygreen-ui/tooltip": "^14.3.0",
+        "@leafygreen-ui/typography": "^22.2.3",
+        "focus-trap": "6.9.4",
+        "focus-trap-react": "9.0.2",
         "polished": "^4.2.2"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.6"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
-    },
-    "node_modules/@leafygreen-ui/guide-cue/node_modules/@leafygreen-ui/button": {
-      "version": "21.3.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/button/-/button-21.3.0.tgz",
-      "integrity": "sha512-v9qipsRWHQBN9sC4RNWmJ/PVQCcYZdg9Wa+k9Q6LFjgahI1/6BXYTZOP4wPJQDp2AG6+dx2CF7Rp60ymM+wtLw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/box": "^3.1.9",
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/lib": "^13.4.0",
-        "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/ripple": "^1.1.13",
-        "@leafygreen-ui/tokens": "^2.5.2",
-        "@lg-tools/test-harnesses": "^0.1.2",
-        "polished": "^4.2.2"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
-      }
-    },
-    "node_modules/@leafygreen-ui/guide-cue/node_modules/@leafygreen-ui/button/node_modules/@leafygreen-ui/lib": {
-      "version": "13.8.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-      "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/guide-cue/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/guide-cue/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/guide-cue/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/guide-cue/node_modules/@leafygreen-ui/tooltip": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tooltip/-/tooltip-10.1.0.tgz",
-      "integrity": "sha512-jgrETmJveRDzDtz1qYI18Pkc53XGp/38l10MWPl8mv+/ahCCgNED2idmCjCwJ3/ju14t6ASSzs0SuH1jokNcAA==",
-      "dev": true,
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.0.0",
-        "@leafygreen-ui/icon": "^11.23.0",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/popover": "^11.1.1",
-        "@leafygreen-ui/tokens": "^2.2.0",
-        "@leafygreen-ui/typography": "^18.0.0",
-        "lodash": "^4.17.21",
-        "polished": "^4.2.2"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
-      }
-    },
-    "node_modules/@leafygreen-ui/guide-cue/node_modules/@leafygreen-ui/tooltip/node_modules/@leafygreen-ui/hooks": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-      "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/lib": "^14.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/guide-cue/node_modules/@leafygreen-ui/tooltip/node_modules/@leafygreen-ui/hooks/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/guide-cue/node_modules/@leafygreen-ui/tooltip/node_modules/@leafygreen-ui/lib": {
-      "version": "13.8.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-      "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/guide-cue/node_modules/@leafygreen-ui/tooltip/node_modules/@leafygreen-ui/typography": {
-      "version": "18.4.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-18.4.0.tgz",
-      "integrity": "sha512-2pfoBv6jEPupMzT/rciyP6oN53Fc2h0Nl/uXubSRuFcIDwUAE6CIb3+IjK3UNyQrnOixGU4lWQhxIPTrnyxCpQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/icon": "^12.1.0",
-        "@leafygreen-ui/lib": "^13.4.0",
-        "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/polymorphic": "^1.3.7",
-        "@leafygreen-ui/tokens": "^2.5.2"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
-      }
-    },
-    "node_modules/@leafygreen-ui/guide-cue/node_modules/@leafygreen-ui/tooltip/node_modules/@leafygreen-ui/typography/node_modules/@leafygreen-ui/icon": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-      "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/guide-cue/node_modules/@leafygreen-ui/typography": {
-      "version": "16.5.5",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-16.5.5.tgz",
-      "integrity": "sha512-mErhTYM0C1PZaeADTkp5v/MAS6aEhavWHZ3otHthBSo/zwI5uAYnkreheiYElc66B/0bcOxCikLVkP3zaFnX2A==",
-      "dev": true,
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/icon": "^11.22.2",
-        "@leafygreen-ui/lib": "^11.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/polymorphic": "^1.3.6",
-        "@leafygreen-ui/tokens": "^2.1.4"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.7"
-      }
-    },
-    "node_modules/@leafygreen-ui/guide-cue/node_modules/@leafygreen-ui/typography/node_modules/@leafygreen-ui/lib": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-11.0.0.tgz",
-      "integrity": "sha512-sHkY/MOwRQDc9qAR1awreW0dP+6ELueJJd4JCJmi6XYbdL0wDotFwsWfCwkL+N6cFbE1e+xBQtFLB6T1+58+iQ==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/guide-cue/node_modules/focus-trap": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.4.tgz",
-      "integrity": "sha512-xx560wGBk7seZ6y933idtjJQc1l+ck+pI3sKvhKozdBV1dRZoKhkW5xoCaFv9tQiX5RH1xfSxjuNu6g+lmN/gw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tabbable": "^6.2.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/guide-cue/node_modules/focus-trap-react": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-10.3.1.tgz",
-      "integrity": "sha512-PN4Ya9xf9nyj/Nd9VxBNMuD7IrlRbmaG6POAQ8VLqgtc6IY/Ln1tYakow+UIq4fihYYYFM70/2oyidE6bbiPgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "focus-trap": "^7.6.1",
-        "tabbable": "^6.2.0"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.8.1",
-        "react": ">=16.3.0",
-        "react-dom": ">=16.3.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/guide-cue/node_modules/tabbable": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@leafygreen-ui/hooks": {
-      "version": "7.7.8",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
-      "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-9.3.1.tgz",
+      "integrity": "sha512-KGJa5GoZ/crA1e0MRnJaadqXP5Gyn5VlLBkPyizFTe1dnlrp2OUnNEeb/TWKytT67sewNjOKqjBr0TG5YJQeJQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/tokens": "^4.2.2",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@leafygreen-ui/icon": {
-      "version": "11.29.1",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-11.29.1.tgz",
-      "integrity": "sha512-bCfeJ3mndU5wHayMWfkVWo0NXhPpBpHIG53aox/eRterqLvWg6jWyiuF930MHbyWDNEXC9Qw1WD637kZ93mmog==",
+      "version": "14.9.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-14.9.0.tgz",
+      "integrity": "sha512-moH8z8Qkd0uO03MO2ttpSo+2nkMfFvNvJ1t1Z4a1nUVSg+xE+c6oiwrNyvhUwrTsbSHUAQr9h+Nld1LTsRsVKw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@leafygreen-ui/icon-button": {
-      "version": "15.0.19",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon-button/-/icon-button-15.0.19.tgz",
-      "integrity": "sha512-TXNFHpfuMXIcMQHW/D31GEFby63qhBLyeI5CLL8KQjD5Xom3Q6fqviu/eyXE097jTzQtd1dO/2IIiqyyLRW30g==",
-      "dev": true,
-      "dependencies": {
-        "@leafygreen-ui/a11y": "^1.4.11",
-        "@leafygreen-ui/box": "^3.1.8",
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/icon": "^11.22.2",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.1.4"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
-      }
-    },
-    "node_modules/@leafygreen-ui/icon-button/node_modules/@leafygreen-ui/lib": {
-      "version": "13.8.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-      "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
+      "version": "17.1.5",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon-button/-/icon-button-17.1.5.tgz",
+      "integrity": "sha512-fTxvykvM1mWZ2cFgwBzvuC0WXY1gJ2kyWWRIUOu24eRTJLwoobzhOF1uF6rBm/DOfhcNDh0dsXJfatdj/lqQXA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/icon-button/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/icon-button/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
+        "@leafygreen-ui/a11y": "^3.0.5",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/tokens": "^4.2.2",
         "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/icon-button/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
       },
       "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
     "node_modules/@leafygreen-ui/info-sprinkle": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/info-sprinkle/-/info-sprinkle-1.0.2.tgz",
-      "integrity": "sha512-SWab7+ljlNQQML6f2t2VOnp2JtZjcJ+KcZcVHUikjt7gYnS6+YtK9MEwZOFsLue6IchaJgPNsVA+Fm+e/PjSuQ==",
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/info-sprinkle/-/info-sprinkle-5.0.11.tgz",
+      "integrity": "sha512-ne4CE9xO6tsaac6hhVtKZzjfPXXgLJ//VIShczNc6ibd+pNtDtGg+FkNgcRVkJ2MyXg5qEErqxv5nn+l6eQhtQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/icon": "^11.25.0",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.2.0",
-        "@leafygreen-ui/tooltip": "^11.0.0"
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/tooltip": "^14.3.1"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
-      }
-    },
-    "node_modules/@leafygreen-ui/info-sprinkle/node_modules/@leafygreen-ui/hooks": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-      "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/lib": "^14.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/info-sprinkle/node_modules/@leafygreen-ui/hooks/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/info-sprinkle/node_modules/@leafygreen-ui/lib": {
-      "version": "13.8.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-      "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/info-sprinkle/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/info-sprinkle/node_modules/@leafygreen-ui/polymorphic": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/polymorphic/-/polymorphic-2.0.7.tgz",
-      "integrity": "sha512-MUw76DT7R7msTDjhqAvZs5dqrt5684fAKm+QhpdzKB9ywh3LCdo9syg/Hva72rDa0fRV5i/V6nYEY8zM1N005A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/lib": "^14.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/info-sprinkle/node_modules/@leafygreen-ui/polymorphic/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/info-sprinkle/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/info-sprinkle/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/info-sprinkle/node_modules/@leafygreen-ui/tooltip": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tooltip/-/tooltip-11.1.0.tgz",
-      "integrity": "sha512-nVIirNqBShuj25u9koOPAVYpqGWKSDe/rsdRyPWZLeL9rLfbtZi9Xn44HeDX7brVo+KBkE29Gsuh1Y3J7LN5ng==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/icon": "^12.5.0",
-        "@leafygreen-ui/lib": "^13.5.0",
-        "@leafygreen-ui/palette": "^4.0.9",
-        "@leafygreen-ui/popover": "^11.4.0",
-        "@leafygreen-ui/tokens": "^2.8.0",
-        "@leafygreen-ui/typography": "^19.0.0",
-        "lodash": "^4.17.21",
-        "polished": "^4.2.2"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
-      }
-    },
-    "node_modules/@leafygreen-ui/info-sprinkle/node_modules/@leafygreen-ui/tooltip/node_modules/@leafygreen-ui/icon": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-      "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/info-sprinkle/node_modules/@leafygreen-ui/typography": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-19.3.0.tgz",
-      "integrity": "sha512-pgTRcc4usW/S9nDDzkf5Ac/JPEybhWtOnDpmrp99mAJHM6tH48Pd1HjRNHWjn6bnh0nXWjwANXX1ZEe+8ggCNg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/icon": "^12.6.0",
-        "@leafygreen-ui/lib": "^13.6.1",
-        "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/polymorphic": "^2.0.0",
-        "@leafygreen-ui/tokens": "^2.9.0"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
-      }
-    },
-    "node_modules/@leafygreen-ui/info-sprinkle/node_modules/@leafygreen-ui/typography/node_modules/@leafygreen-ui/icon": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-      "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "lodash": "^4.17.21"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
     "node_modules/@leafygreen-ui/inline-definition": {
-      "version": "6.0.14",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/inline-definition/-/inline-definition-6.0.14.tgz",
-      "integrity": "sha512-vCfSF1Lr8O4sm8f7w9rTflVyJRjF3Tyrtppr9OSfEPTDDlla+tiuSyvrMUty3xfdomc6JEGyumdozvjyU9dFsg==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/inline-definition/-/inline-definition-9.2.1.tgz",
+      "integrity": "sha512-AUDjEvyI9QizDSoew9uqjidoBJ8L88FWPhgzN+ixSo5B4EcwT7Ig52P82thfazdfb2RQUQz0/ajkEnoHFPLy9Q==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tooltip": "^11.0.0"
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/tooltip": "^14.3.1"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
-      }
-    },
-    "node_modules/@leafygreen-ui/inline-definition/node_modules/@leafygreen-ui/hooks": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-      "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/lib": "^14.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/inline-definition/node_modules/@leafygreen-ui/hooks/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/inline-definition/node_modules/@leafygreen-ui/icon": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-      "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/inline-definition/node_modules/@leafygreen-ui/lib": {
-      "version": "13.8.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-      "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/inline-definition/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/inline-definition/node_modules/@leafygreen-ui/polymorphic": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/polymorphic/-/polymorphic-2.0.7.tgz",
-      "integrity": "sha512-MUw76DT7R7msTDjhqAvZs5dqrt5684fAKm+QhpdzKB9ywh3LCdo9syg/Hva72rDa0fRV5i/V6nYEY8zM1N005A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/lib": "^14.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/inline-definition/node_modules/@leafygreen-ui/polymorphic/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/inline-definition/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/inline-definition/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/inline-definition/node_modules/@leafygreen-ui/tooltip": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tooltip/-/tooltip-11.1.0.tgz",
-      "integrity": "sha512-nVIirNqBShuj25u9koOPAVYpqGWKSDe/rsdRyPWZLeL9rLfbtZi9Xn44HeDX7brVo+KBkE29Gsuh1Y3J7LN5ng==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/icon": "^12.5.0",
-        "@leafygreen-ui/lib": "^13.5.0",
-        "@leafygreen-ui/palette": "^4.0.9",
-        "@leafygreen-ui/popover": "^11.4.0",
-        "@leafygreen-ui/tokens": "^2.8.0",
-        "@leafygreen-ui/typography": "^19.0.0",
-        "lodash": "^4.17.21",
-        "polished": "^4.2.2"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
-      }
-    },
-    "node_modules/@leafygreen-ui/inline-definition/node_modules/@leafygreen-ui/typography": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-19.3.0.tgz",
-      "integrity": "sha512-pgTRcc4usW/S9nDDzkf5Ac/JPEybhWtOnDpmrp99mAJHM6tH48Pd1HjRNHWjn6bnh0nXWjwANXX1ZEe+8ggCNg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/icon": "^12.6.0",
-        "@leafygreen-ui/lib": "^13.6.1",
-        "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/polymorphic": "^2.0.0",
-        "@leafygreen-ui/tokens": "^2.9.0"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
     "node_modules/@leafygreen-ui/input-option": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/input-option/-/input-option-1.1.4.tgz",
-      "integrity": "sha512-tti2719MBIId67OwbAnXXm71kqDRGa6Xjiy2cCVWL0au6rYpcm7RXio9J6KZyk4aUvHGu3f6jMNKQgifapvSlw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/input-option/-/input-option-4.1.5.tgz",
+      "integrity": "sha512-cYwx1uVrnev4ZIEYU8k08OAOUwe+dlUVrZh1aRoyXiOYx8LVw3N1C1bKxzW6dgwipPxloQa0RLIOwoqC0qkbQw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/a11y": "^1.4.13",
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/lib": "^13.6.0",
-        "@leafygreen-ui/palette": "^4.0.9",
-        "@leafygreen-ui/polymorphic": "^2.0.0",
-        "@leafygreen-ui/tokens": "^2.9.0",
-        "@leafygreen-ui/typography": "^19.2.0"
+        "@leafygreen-ui/a11y": "^3.0.5",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
-      }
-    },
-    "node_modules/@leafygreen-ui/input-option/node_modules/@leafygreen-ui/icon": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-      "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/input-option/node_modules/@leafygreen-ui/lib": {
-      "version": "13.8.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-      "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/input-option/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/input-option/node_modules/@leafygreen-ui/polymorphic": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/polymorphic/-/polymorphic-2.0.7.tgz",
-      "integrity": "sha512-MUw76DT7R7msTDjhqAvZs5dqrt5684fAKm+QhpdzKB9ywh3LCdo9syg/Hva72rDa0fRV5i/V6nYEY8zM1N005A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/lib": "^14.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/input-option/node_modules/@leafygreen-ui/polymorphic/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/input-option/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/input-option/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/input-option/node_modules/@leafygreen-ui/typography": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-19.3.0.tgz",
-      "integrity": "sha512-pgTRcc4usW/S9nDDzkf5Ac/JPEybhWtOnDpmrp99mAJHM6tH48Pd1HjRNHWjn6bnh0nXWjwANXX1ZEe+8ggCNg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/icon": "^12.6.0",
-        "@leafygreen-ui/lib": "^13.6.1",
-        "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/polymorphic": "^2.0.0",
-        "@leafygreen-ui/tokens": "^2.9.0"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
     "node_modules/@leafygreen-ui/leafygreen-provider": {
-      "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-3.1.11.tgz",
-      "integrity": "sha512-xRwZjchRcvtpbkrLAxuHDl5MPgdi6J7ErVyeeP8k6+y7yTdaaAu8j8bbiacASwpOJdX5Q2XNl2pJ8gzC2PgyRA==",
-      "dev": true,
-      "dependencies": {
-        "@leafygreen-ui/hooks": "^8.1.0",
-        "@leafygreen-ui/lib": "^13.2.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/leafygreen-provider/node_modules/@leafygreen-ui/hooks": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-      "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-5.0.4.tgz",
+      "integrity": "sha512-VDlmjTiIqlITVhq4VKUDq8FLySWnHkTxSV2n1sxOanLNPuatOXjxsPmCkPUBXhmQKk/fBf4yQnDKOwJvkyzE6Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/lib": "^14.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/leafygreen-provider/node_modules/@leafygreen-ui/hooks/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/leafygreen-provider/node_modules/@leafygreen-ui/lib": {
-      "version": "13.8.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-      "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
+        "@leafygreen-ui/hooks": "^9.1.3",
+        "@leafygreen-ui/lib": "^15.3.0",
+        "react-transition-group": "^4.4.5"
       }
     },
     "node_modules/@leafygreen-ui/lib": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-10.4.3.tgz",
-      "integrity": "sha512-p5BtXHeQsvLnnrN0eunPFZeaMtW9z7Mbvm2WOS9lvnAySj8xZp5Vn9Y3XjyYLbPhpGVBhhOAJFP3YMxbP9DKgg==",
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-15.7.0.tgz",
+      "integrity": "sha512-qHv7oN2uN7ywdG9lUN/ayFJzzgJELLgNxIo24m64Sl9c8gSWQeCW+NDj3ukoNVH7ME7QPoULseNd1fElonH8Vg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
+        "lodash": "^4.17.21"
       },
       "peerDependencies": {
-        "react": "^17.0.0"
+        "react": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/loading-indicator": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/loading-indicator/-/loading-indicator-5.1.1.tgz",
+      "integrity": "sha512-ZXAupHOjv3++yo0hiGhHfNC4YjwP9FByrMj6zfjGFGL3WfFb+vvdpqK6/KYSawKyh0HBy7yvpUc6Eibk/APceg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "@lg-tools/test-harnesses": "^0.3.4",
+        "react-lottie-player": "^1.5.6"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
     "node_modules/@leafygreen-ui/logo": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/logo/-/logo-7.0.2.tgz",
-      "integrity": "sha512-VJGIpOFP0I9QSe4HiyiSHhgFBUlU4NibXgbPyeAK60x+i/TEOc4WoXtNfdyB1oSjiVXYTpYPrkKvPrCWbRg1AA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/logo/-/logo-11.1.0.tgz",
+      "integrity": "sha512-UupcGGmtfIXvuXEpJ5h/uvaqExJEXELyxj7VRSAB1JShmaNopRqoNcwfANxtKZ60nFtmBaSz6ix6xc4/gdSK2w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.3",
-        "@leafygreen-ui/lib": "^10.1.0",
-        "@leafygreen-ui/palette": "^3.4.5"
+        "@leafygreen-ui/emotion": "^5.0.3",
+        "@leafygreen-ui/lib": "^15.6.1",
+        "@leafygreen-ui/palette": "^5.0.2"
       }
     },
     "node_modules/@leafygreen-ui/marketing-modal": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/marketing-modal/-/marketing-modal-3.0.10.tgz",
-      "integrity": "sha512-9WGa/HXvdHsdqTuKKXefe2XV+/73rIj8zzMsx0dcUILYxGMllHZDH/X80B1qA39GyqaGX8SLv/g2vmlF7jXbqw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/marketing-modal/-/marketing-modal-8.2.1.tgz",
+      "integrity": "sha512-3G/9f9gMVRbQTl5B7YlTszfQ8MbkuYnpAVVF1Jhu70nmoTnjd01cZ38D4ky2/4t13cApfWY9uIQ/IerNOZV+6A==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/button": "^19.0.0",
-        "@leafygreen-ui/emotion": "^4.0.3",
-        "@leafygreen-ui/modal": "^12.0.0",
-        "@leafygreen-ui/palette": "^3.4.4",
-        "@leafygreen-ui/tokens": "^1.3.4",
-        "@leafygreen-ui/typography": "^15.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/marketing-modal/node_modules/@leafygreen-ui/modal": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/modal/-/modal-12.0.1.tgz",
-      "integrity": "sha512-GIJGf4ys2n8TuU8rFEHa0juv3gE1JBf395v3gDNmimVZr/zkDTgcK6t8vWJ7PbCH9nX9s4BWUI7Ng6w2h7qTZw==",
-      "dev": true,
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.3",
-        "@leafygreen-ui/hooks": "^7.3.3",
-        "@leafygreen-ui/icon": "^11.12.1",
-        "@leafygreen-ui/icon-button": "^15.0.1",
-        "@leafygreen-ui/lib": "^10.0.0",
-        "@leafygreen-ui/palette": "^3.4.4",
-        "@leafygreen-ui/portal": "^4.0.7",
-        "@leafygreen-ui/tokens": "^1.4.0",
-        "facepaint": "^1.2.1",
-        "focus-trap-react": "^8.10.0",
-        "polished": "^4.2.2",
-        "prop-types": "^15.8.1",
-        "react-transition-group": "^4.4.1"
+        "@leafygreen-ui/button": "^25.2.1",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/modal": "^22.0.1",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.0"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
     "node_modules/@leafygreen-ui/menu": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/menu/-/menu-19.0.4.tgz",
-      "integrity": "sha512-baTyt2sAAKNQQGd8GihYQOWeWZq1hr9isOcRxEkl73h6a3D1JeKsje6gHCR8d/heSpVDkFQf9+yL0Jxp3rExgw==",
+      "version": "33.2.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/menu/-/menu-33.2.1.tgz",
+      "integrity": "sha512-nCcWKgEgEgJj1AYPmoF79NqtwsupMhaFhDvr8ITESOsP+ihlttpX4eTtl09SzM2Bj8ghQR+l8mXuc0xxYC16tw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/box": "^3.1.1",
-        "@leafygreen-ui/emotion": "^4.0.3",
-        "@leafygreen-ui/hooks": "^7.3.3",
-        "@leafygreen-ui/icon": "^11.12.4",
-        "@leafygreen-ui/icon-button": "^15.0.4",
-        "@leafygreen-ui/lib": "^10.0.0",
-        "@leafygreen-ui/palette": "^3.4.7",
-        "@leafygreen-ui/popover": "^11.0.4",
-        "@leafygreen-ui/tokens": "^2.0.0",
+        "@leafygreen-ui/descendants": "^3.1.0",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/input-option": "^4.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/popover": "^14.3.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
         "lodash": "^4.17.21",
-        "react-transition-group": "^4.4.1"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/menu/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/menu/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/menu/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/modal": {
-      "version": "14.0.5",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/modal/-/modal-14.0.5.tgz",
-      "integrity": "sha512-7zrBZSdf4P8OWeUxxFRLgSZhh/V7REbkXJrpqb/JK2fclU161ZeT2SLLdFKfnjQqf4n3eOVrlDsxy8xwwZ769Q==",
-      "dev": true,
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.4",
-        "@leafygreen-ui/hooks": "^7.7.1",
-        "@leafygreen-ui/icon": "^11.13.1",
-        "@leafygreen-ui/icon-button": "^15.0.9",
-        "@leafygreen-ui/lib": "^10.3.2",
-        "@leafygreen-ui/palette": "^4.0.3",
-        "@leafygreen-ui/portal": "^4.1.1",
-        "@leafygreen-ui/tokens": "^2.0.2",
-        "focus-trap-react": "^8.10.0",
-        "polished": "^4.2.2",
-        "prop-types": "^15.8.1",
-        "react-transition-group": "^4.4.1"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/modal/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/modal/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/modal/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/palette": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-3.4.7.tgz",
-      "integrity": "sha512-AsvPlbvF7CERiZbAQR8hy3lAJ2/rieXI3cO0jsOwV8ztDqYNotKAdLujyr/NviudrRUenYiXrLizIKVlSPUMuA==",
-      "dev": true
-    },
-    "node_modules/@leafygreen-ui/pipeline": {
-      "version": "5.0.17",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/pipeline/-/pipeline-5.0.17.tgz",
-      "integrity": "sha512-peTDNz/xhVvh/M8zhJ5u488xBz8zCGjwKdhWzNvSX2r2u3Kg+kfVo40zmNUedBgbgWJDCkiroKzr12rDpxPEMw==",
-      "dev": true,
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.0.1",
-        "@leafygreen-ui/icon": "^11.25.0",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.2.0",
-        "@leafygreen-ui/tooltip": "^11.0.0",
-        "react-intersection-observer": "^8.25.1"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
-      }
-    },
-    "node_modules/@leafygreen-ui/pipeline/node_modules/@leafygreen-ui/hooks": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-      "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/lib": "^14.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/pipeline/node_modules/@leafygreen-ui/hooks/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/pipeline/node_modules/@leafygreen-ui/lib": {
-      "version": "13.8.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-      "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/pipeline/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/pipeline/node_modules/@leafygreen-ui/polymorphic": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/polymorphic/-/polymorphic-2.0.7.tgz",
-      "integrity": "sha512-MUw76DT7R7msTDjhqAvZs5dqrt5684fAKm+QhpdzKB9ywh3LCdo9syg/Hva72rDa0fRV5i/V6nYEY8zM1N005A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/lib": "^14.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/pipeline/node_modules/@leafygreen-ui/polymorphic/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/pipeline/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/pipeline/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/pipeline/node_modules/@leafygreen-ui/tooltip": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tooltip/-/tooltip-11.1.0.tgz",
-      "integrity": "sha512-nVIirNqBShuj25u9koOPAVYpqGWKSDe/rsdRyPWZLeL9rLfbtZi9Xn44HeDX7brVo+KBkE29Gsuh1Y3J7LN5ng==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/icon": "^12.5.0",
-        "@leafygreen-ui/lib": "^13.5.0",
-        "@leafygreen-ui/palette": "^4.0.9",
-        "@leafygreen-ui/popover": "^11.4.0",
-        "@leafygreen-ui/tokens": "^2.8.0",
-        "@leafygreen-ui/typography": "^19.0.0",
-        "lodash": "^4.17.21",
-        "polished": "^4.2.2"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
-      }
-    },
-    "node_modules/@leafygreen-ui/pipeline/node_modules/@leafygreen-ui/tooltip/node_modules/@leafygreen-ui/icon": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-      "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/pipeline/node_modules/@leafygreen-ui/typography": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-19.3.0.tgz",
-      "integrity": "sha512-pgTRcc4usW/S9nDDzkf5Ac/JPEybhWtOnDpmrp99mAJHM6tH48Pd1HjRNHWjn6bnh0nXWjwANXX1ZEe+8ggCNg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/icon": "^12.6.0",
-        "@leafygreen-ui/lib": "^13.6.1",
-        "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/polymorphic": "^2.0.0",
-        "@leafygreen-ui/tokens": "^2.9.0"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
-      }
-    },
-    "node_modules/@leafygreen-ui/pipeline/node_modules/@leafygreen-ui/typography/node_modules/@leafygreen-ui/icon": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-      "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/polymorphic": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/polymorphic/-/polymorphic-1.3.7.tgz",
-      "integrity": "sha512-Tr2TmpS0YFJ3hGNbVWQpeseJRo4kTrVumVlZ4aF4hId1JYDzF0TU5JJO40v+brhbgnKsyBu7+Rvz6ExY1NcKew==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/popover": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/popover/-/popover-11.4.0.tgz",
-      "integrity": "sha512-hSr3zbbWOCUuhByR5ncFJTkXxFfA7o2QjVjDXKLVPPn9Gh7+sYRLe87mTQWs9m8fbRx9O4Uk7Vq0R9U4A77dxw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/lib": "^13.5.0",
-        "@leafygreen-ui/portal": "^5.1.1",
-        "@leafygreen-ui/tokens": "^2.8.0",
-        "@types/react-transition-group": "^4.4.5",
+        "polished": "^4.3.1",
         "react-transition-group": "^4.4.5"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
-    "node_modules/@leafygreen-ui/popover/node_modules/@leafygreen-ui/hooks": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-      "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
+    "node_modules/@leafygreen-ui/modal": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/modal/-/modal-22.0.1.tgz",
+      "integrity": "sha512-hBKBPDr/btuiA1xqVe1aCxxdFucxzJOh8dT2tvzrvReVJtDvTe2RrdZjHoLX6dCX2E+876euCh3cMpuMgWeUyw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/lib": "^14.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/popover/node_modules/@leafygreen-ui/hooks/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@lg-tools/test-harnesses": "^0.3.4",
+        "polished": "^4.2.2"
       },
       "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
-    "node_modules/@leafygreen-ui/popover/node_modules/@leafygreen-ui/lib": {
-      "version": "13.8.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-      "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/popover/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
+    "node_modules/@leafygreen-ui/palette": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-5.0.2.tgz",
+      "integrity": "sha512-+PrfGeJSv4goxm/vKpfJJDOP7t/uElj+14K8jiIyu3qR3TcFRIZ5h1VMvICTUgqvRc8W+xIZYQwsLa2XCu2lvw==",
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/@leafygreen-ui/popover/node_modules/@leafygreen-ui/portal": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/portal/-/portal-5.1.1.tgz",
-      "integrity": "sha512-8wvNdLxO3hWY7u5rf1ndYCJJ85TB6XpKp+dl7sQPoLnkq8HXd4GqnFXYwvGQp/pf3ts/Dp5FmZ/9dljkktnzQg==",
+    "node_modules/@leafygreen-ui/pipeline": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/pipeline/-/pipeline-8.0.10.tgz",
+      "integrity": "sha512-yjd/Jv07HEdmGe+V8yMzl2589Mv81UQ19EiAvUlkFzLNH66zVMI7r/E55/rrsBodk7cRJfCdjcWXzs1ed8/OfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/lib": "^13.3.0"
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/tooltip": "^14.3.1",
+        "react-intersection-observer": "^8.25.1"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/polymorphic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/polymorphic/-/polymorphic-3.1.0.tgz",
+      "integrity": "sha512-5fbXD6ExTmMScvODuipfB1Ti/Dvoaxxg+daSftqXfNQlEkEnd5cPnezOOl1LMsu2xUoZT6NXsFgukZYsmXEVpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/lib": "^15.4.0",
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@leafygreen-ui/popover": {
+      "version": "14.3.2",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/popover/-/popover-14.3.2.tgz",
+      "integrity": "sha512-2+qXbiGUcCS1xLzY4lUlZdM4iDXFgrJry8J7MzgzN2JpHIIDJUVz+rycqZiXJnnq7NSd3emRoiviKOGxXGywbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@floating-ui/react": "^0.26.28",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/portal": "^7.1.0",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@types/react-transition-group": "^4.4.5",
+        "lodash": "^4.17.21",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/portal": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/portal/-/portal-7.1.0.tgz",
+      "integrity": "sha512-wCldB70m/NtlIeVRxi5S/U74W6jxQScqptI2I4+7RweBquBfxIg1SipHXqMC+Zo3aL+s/fCMuFKNlLuwGWu8MA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/hooks": "^9.2.0",
+        "@leafygreen-ui/lib": "^15.6.1"
       },
       "peerDependencies": {
         "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/@leafygreen-ui/popover/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
+    "node_modules/@leafygreen-ui/progress-bar": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/progress-bar/-/progress-bar-1.0.8.tgz",
+      "integrity": "sha512-NY1B9AQIqMnutkE0JujjvAU+EeWBQqmSrPZZxWtgA2oIHme1OlXce6cGJT766Ks1UNe6rP6A0xIq4mntBb4Y9Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
+        "@leafygreen-ui/a11y": "^3.0.5",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "@lg-tools/test-harnesses": "^0.3.4",
+        "lodash": "^4.17.21",
         "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/popover/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
       },
       "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/portal": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/portal/-/portal-4.1.7.tgz",
-      "integrity": "sha512-P2lgxhRk7uB7N7ourOupa22pH7G/wTZb1RxYVUl4yNNzXRZ0IhXdt+R1aPPGOfy1pG/m/hHJ3Wf+zVwWaN0vGQ==",
-      "dev": true,
-      "dependencies": {
-        "@leafygreen-ui/hooks": "^7.7.8",
-        "@leafygreen-ui/lib": "^10.4.3"
-      },
-      "peerDependencies": {
-        "react-dom": "^17.0.0"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
     "node_modules/@leafygreen-ui/radio-box-group": {
-      "version": "12.0.16",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/radio-box-group/-/radio-box-group-12.0.16.tgz",
-      "integrity": "sha512-3jTprIrHO87oUsZCGn+FNkK7/clER+yTLV9GKt13rYlpy429hRs1c9EwNHfhT50DPhENhIIc/XYNMpWTDuWyBg==",
+      "version": "15.0.11",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/radio-box-group/-/radio-box-group-15.0.11.tgz",
+      "integrity": "sha512-BVG9sokWt/yGI4BD7WHKGkD4gayoxWMskZ1HWNA1IWEnkb1F7VFBbVDsa4k0XXlOzxxMBnIdAFo7s6Je2vhI5A==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.0.0",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.2.0"
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
-      }
-    },
-    "node_modules/@leafygreen-ui/radio-box-group/node_modules/@leafygreen-ui/hooks": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-      "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/lib": "^14.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/radio-box-group/node_modules/@leafygreen-ui/hooks/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/radio-box-group/node_modules/@leafygreen-ui/lib": {
-      "version": "13.8.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-      "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/radio-box-group/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/radio-box-group/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/radio-box-group/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
     "node_modules/@leafygreen-ui/radio-group": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/radio-group/-/radio-group-10.2.4.tgz",
-      "integrity": "sha512-Jd54mKopU9rp7YDlnG/Aw+C3bSvE7CpVzJ9UFAgvWQP2FbqTIE5uDRibYipcf1R3AiOTVOm2H5i9xmHi+bi1xQ==",
+      "version": "13.0.12",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/radio-group/-/radio-group-13.0.12.tgz",
+      "integrity": "sha512-Mggusg9KRWh75sP92Zi1FiMC1mxnphCYwkuNranjnIMas8fmUkJTFHopLYKp73eA3SuVmU5zTWpregFdxTIWIA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.0.0",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.2.0",
-        "@leafygreen-ui/typography": "^18.0.0"
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
-    "node_modules/@leafygreen-ui/radio-group/node_modules/@leafygreen-ui/hooks": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-      "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
+    "node_modules/@leafygreen-ui/resizable": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/resizable/-/resizable-0.1.3.tgz",
+      "integrity": "sha512-hGpRUvqMLsfpqUgAFP5rTgY3viwHP9T8fe0eBL3sbShezvbuLNO9qSVZYQVGg7VNC4wg3reJ1aSQxjn1XYe5Nw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/lib": "^14.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/radio-group/node_modules/@leafygreen-ui/hooks/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/radio-group/node_modules/@leafygreen-ui/icon": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-      "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/radio-group/node_modules/@leafygreen-ui/lib": {
-      "version": "13.8.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-      "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/radio-group/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/radio-group/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/radio-group/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/radio-group/node_modules/@leafygreen-ui/typography": {
-      "version": "18.4.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-18.4.0.tgz",
-      "integrity": "sha512-2pfoBv6jEPupMzT/rciyP6oN53Fc2h0Nl/uXubSRuFcIDwUAE6CIb3+IjK3UNyQrnOixGU4lWQhxIPTrnyxCpQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/icon": "^12.1.0",
-        "@leafygreen-ui/lib": "^13.4.0",
-        "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/polymorphic": "^1.3.7",
-        "@leafygreen-ui/tokens": "^2.5.2"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
+        "@leafygreen-ui/emotion": "^5.0.3",
+        "@leafygreen-ui/lib": "^15.4.0",
+        "@leafygreen-ui/palette": "^5.0.2"
       }
     },
     "node_modules/@leafygreen-ui/ripple": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/ripple/-/ripple-1.1.18.tgz",
-      "integrity": "sha512-GWdQWbxJ3dP/BRIufLs/zB6BeLuxWnhR9YJNr25nlWc3qeC30WdJqsd8ULaQzZBupxA9UsnfY9+tRRVXh1LbMg==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/ripple/-/ripple-2.0.7.tgz",
+      "integrity": "sha512-+Ixyb5deA5S+tbLQl4Iad/JWVQhYLeET6tstzYmE/sk6YfJWDyWH8CYVJ3Q9wdZXBJlXoZAi1Vy4ff4x9GSXGA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/tokens": "^2.12.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/ripple/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/ripple/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/ripple/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
+        "@leafygreen-ui/tokens": "^4.0.0"
       }
     },
     "node_modules/@leafygreen-ui/search-input": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/search-input/-/search-input-2.1.3.tgz",
-      "integrity": "sha512-rZMzt7jQ/ogTL5AOAYMpdzpi/mAGvWUH68BWT9fizyxtleJv8owPuinE4D/mKlvgmBq7HtJ27tAQmIUBPkJbRw==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/search-input/-/search-input-6.1.3.tgz",
+      "integrity": "sha512-225f7UpILMcaY8vVKdjm/xLQcsAsa775+SYSbB3OGFlscwATtoNNhdk6XDeXI6gb4fSAxu0RPm8e/ODZEuunig==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/a11y": "^1.4.11",
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.1.1",
-        "@leafygreen-ui/icon": "^11.24.0",
-        "@leafygreen-ui/icon-button": "^15.0.19",
-        "@leafygreen-ui/input-option": "^1.0.13",
-        "@leafygreen-ui/lib": "^13.2.1",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/polymorphic": "^1.3.6",
-        "@leafygreen-ui/popover": "^11.1.1",
-        "@leafygreen-ui/tokens": "^2.3.0",
-        "@leafygreen-ui/typography": "^18.0.0",
+        "@leafygreen-ui/a11y": "^3.0.5",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/input-option": "^4.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/popover": "^14.3.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
         "lodash": "^4.17.21",
         "polished": "^4.2.2"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
-      }
-    },
-    "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/hooks": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-      "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/lib": "^14.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/hooks/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/lib": {
-      "version": "13.8.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-      "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/typography": {
-      "version": "18.4.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-18.4.0.tgz",
-      "integrity": "sha512-2pfoBv6jEPupMzT/rciyP6oN53Fc2h0Nl/uXubSRuFcIDwUAE6CIb3+IjK3UNyQrnOixGU4lWQhxIPTrnyxCpQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/icon": "^12.1.0",
-        "@leafygreen-ui/lib": "^13.4.0",
-        "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/polymorphic": "^1.3.7",
-        "@leafygreen-ui/tokens": "^2.5.2"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
-      }
-    },
-    "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/typography/node_modules/@leafygreen-ui/icon": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-      "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "lodash": "^4.17.21"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
     "node_modules/@leafygreen-ui/segmented-control": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/segmented-control/-/segmented-control-7.0.5.tgz",
-      "integrity": "sha512-ar0+gKg7ClTz+YK7TnaWq9bY0y7TazGxxR/vjPTAO/LRgg6drP/nmycU8Q3UqsL2LPJqRscKTcIPv9lSNl6eEw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/segmented-control/-/segmented-control-11.1.0.tgz",
+      "integrity": "sha512-TbMFGY3Lt8lEETuiA/CyaBxhcEos1xxyUzoEaImnvrS2Os0RL4WA03CWjeTvuPJ7z2RfBJ7kEte2jeNDgn+E+Q==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/box": "^3.1.1",
-        "@leafygreen-ui/emotion": "^4.0.3",
-        "@leafygreen-ui/hooks": "^7.7.0",
-        "@leafygreen-ui/icon": "^11.12.7",
-        "@leafygreen-ui/lib": "^10.3.1",
-        "@leafygreen-ui/palette": "^4.0.1",
-        "@leafygreen-ui/tokens": "^2.0.1",
-        "@leafygreen-ui/typography": "^16.2.0",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
         "lodash": "^4.17.21",
         "polished": "^4.2.2"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.1"
-      }
-    },
-    "node_modules/@leafygreen-ui/segmented-control/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/segmented-control/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/segmented-control/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/segmented-control/node_modules/@leafygreen-ui/typography": {
-      "version": "16.5.5",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-16.5.5.tgz",
-      "integrity": "sha512-mErhTYM0C1PZaeADTkp5v/MAS6aEhavWHZ3otHthBSo/zwI5uAYnkreheiYElc66B/0bcOxCikLVkP3zaFnX2A==",
-      "dev": true,
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/icon": "^11.22.2",
-        "@leafygreen-ui/lib": "^11.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/polymorphic": "^1.3.6",
-        "@leafygreen-ui/tokens": "^2.1.4"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.7"
-      }
-    },
-    "node_modules/@leafygreen-ui/segmented-control/node_modules/@leafygreen-ui/typography/node_modules/@leafygreen-ui/lib": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-11.0.0.tgz",
-      "integrity": "sha512-sHkY/MOwRQDc9qAR1awreW0dP+6ELueJJd4JCJmi6XYbdL0wDotFwsWfCwkL+N6cFbE1e+xBQtFLB6T1+58+iQ==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
     "node_modules/@leafygreen-ui/select": {
-      "version": "10.3.18",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/select/-/select-10.3.18.tgz",
-      "integrity": "sha512-YJkO15Clg72D5RX0V4Ea6+IozftIbHUREAb7Gs/sYFEAESIuT6u/rmhhqOBZHtWmc/yNVgcFYDPJHXWYVzYV+w==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/select/-/select-17.1.0.tgz",
+      "integrity": "sha512-HA9pe8snzpQC5OtuXPjKKOdDI4EC4ZeG9rk8hx+YXQcA6+Racg+h5R2r/vfOrv8/xThiJdO7jgiZ0/RwgkQsZg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/button": "^21.0.7",
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.0.0",
-        "@leafygreen-ui/icon": "^11.23.0",
-        "@leafygreen-ui/lib": "^12.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/popover": "^11.0.18",
-        "@leafygreen-ui/tokens": "^2.2.0",
-        "@leafygreen-ui/typography": "^17.0.1",
+        "@leafygreen-ui/button": "^25.2.1",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/form-field": "^4.0.9",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.9.0",
+        "@leafygreen-ui/input-option": "^4.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/popover": "^14.3.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "@lg-tools/test-harnesses": "^0.3.4",
         "@types/react-is": "^18.0.0",
         "lodash": "^4.17.21",
         "polished": "^4.1.3",
         "react-is": "^18.0.1"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.9"
-      }
-    },
-    "node_modules/@leafygreen-ui/select/node_modules/@leafygreen-ui/button": {
-      "version": "21.3.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/button/-/button-21.3.0.tgz",
-      "integrity": "sha512-v9qipsRWHQBN9sC4RNWmJ/PVQCcYZdg9Wa+k9Q6LFjgahI1/6BXYTZOP4wPJQDp2AG6+dx2CF7Rp60ymM+wtLw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/box": "^3.1.9",
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/lib": "^13.4.0",
-        "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/ripple": "^1.1.13",
-        "@leafygreen-ui/tokens": "^2.5.2",
-        "@lg-tools/test-harnesses": "^0.1.2",
-        "polished": "^4.2.2"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
-      }
-    },
-    "node_modules/@leafygreen-ui/select/node_modules/@leafygreen-ui/button/node_modules/@leafygreen-ui/lib": {
-      "version": "13.8.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-      "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/select/node_modules/@leafygreen-ui/hooks": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-      "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/lib": "^14.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/select/node_modules/@leafygreen-ui/hooks/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/select/node_modules/@leafygreen-ui/lib": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-12.0.0.tgz",
-      "integrity": "sha512-nhaxi4oBesnizxO0YK7XwcmiLL9U5QuN7lkZdWGDdmoJgNNL+aRju4W5vmZc7vcazSHfr3gAL+NFAGaAuopyRA==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/select/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/select/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/select/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/select/node_modules/@leafygreen-ui/typography": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-17.0.2.tgz",
-      "integrity": "sha512-wx+kk5VNMOCTenrIG2AcgAKHt9TiLhSTirZARv0J6l4VOgnO+Mkbh3sqd4mk0EOBCAFmsBR3WqwQh00JXU8Htw==",
-      "dev": true,
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/icon": "^11.22.2",
-        "@leafygreen-ui/lib": "^12.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/polymorphic": "^1.3.6",
-        "@leafygreen-ui/tokens": "^2.1.4"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.9"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
     "node_modules/@leafygreen-ui/select/node_modules/react-is": {
@@ -6238,784 +4298,507 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@leafygreen-ui/table": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/table/-/table-10.0.3.tgz",
-      "integrity": "sha512-JuoUkcFvE/oV7qt0tIeXHQPehHGMSp4YCbm4JaWq76ExdUhP6lPP5nv/sfMsBPk1ICGkeOxMYcVHXi0e67XGWA==",
-      "dev": true,
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.3",
-        "@leafygreen-ui/hooks": "^7.5.0",
-        "@leafygreen-ui/icon": "^11.12.5",
-        "@leafygreen-ui/icon-button": "^15.0.7",
-        "@leafygreen-ui/lib": "^10.2.2",
-        "@leafygreen-ui/palette": "^4.0.0",
-        "@leafygreen-ui/tokens": "^2.0.1",
-        "@leafygreen-ui/typography": "^16.1.0",
-        "lodash": "^4.17.21",
-        "polished": "^4.2.2",
-        "react-transition-group": "^4.4.1"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.1"
-      }
-    },
-    "node_modules/@leafygreen-ui/table/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/table/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
+    "node_modules/@leafygreen-ui/skeleton-loader": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/skeleton-loader/-/skeleton-loader-3.0.11.tgz",
+      "integrity": "sha512-jJYdlrQRZDqwBFMIbHTSr5q1h7K9MdS7u4RDrkWoVk5StKGX9brXFLGGSVFWogGMby4vIqRFoeLZLlO/YLO1NA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/table/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
+        "@leafygreen-ui/a11y": "^3.0.5",
+        "@leafygreen-ui/card": "^13.3.1",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
         "lodash": "^4.17.21"
       },
       "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
-    "node_modules/@leafygreen-ui/table/node_modules/@leafygreen-ui/typography": {
-      "version": "16.5.5",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-16.5.5.tgz",
-      "integrity": "sha512-mErhTYM0C1PZaeADTkp5v/MAS6aEhavWHZ3otHthBSo/zwI5uAYnkreheiYElc66B/0bcOxCikLVkP3zaFnX2A==",
+    "node_modules/@leafygreen-ui/split-button": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/split-button/-/split-button-6.3.1.tgz",
+      "integrity": "sha512-BcBNKbl2ZLCCfAq0UnUmhhATwgtd31RNDwc3CVIB+tfseZYVlGUMfV4qmaDLeackXhnLEZEDZWmdmezxcQ6A4A==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/icon": "^11.22.2",
-        "@leafygreen-ui/lib": "^11.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/polymorphic": "^1.3.6",
-        "@leafygreen-ui/tokens": "^2.1.4"
+        "@leafygreen-ui/button": "^25.2.1",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/menu": "^33.2.1",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/tokens": "^4.2.2"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.7"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
-    "node_modules/@leafygreen-ui/table/node_modules/@leafygreen-ui/typography/node_modules/@leafygreen-ui/lib": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-11.0.0.tgz",
-      "integrity": "sha512-sHkY/MOwRQDc9qAR1awreW0dP+6ELueJJd4JCJmi6XYbdL0wDotFwsWfCwkL+N6cFbE1e+xBQtFLB6T1+58+iQ==",
+    "node_modules/@leafygreen-ui/table": {
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/table/-/table-15.2.3.tgz",
+      "integrity": "sha512-T0YY6jdE92sgqa6OyDugRMMdto884CIKa1Fzud2oD8tOmTqENqhD7nC1+JsPEa3VKXFxsNtKbTfRmLMWJMPoVg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@storybook/csf": "^0.1.0",
+        "@leafygreen-ui/checkbox": "^18.1.5",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "@lg-tools/test-harnesses": "^0.3.4",
+        "@tanstack/react-table": "^8.20.5",
+        "@tanstack/react-virtual": "^3.10.7",
         "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
+        "polished": "^4.2.2",
+        "react-fast-compare": "3.2.2",
+        "react-intersection-observer": "^8.25.1"
       },
       "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
     "node_modules/@leafygreen-ui/tabs": {
-      "version": "11.1.13",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tabs/-/tabs-11.1.13.tgz",
-      "integrity": "sha512-n771tkjfSMa/P3Y7QwqwTKIbiyaHZeRXg8jYDSLcC9DKphng0LyRBfItzMApqpU5HPpU75SIxCMixMh03eW9pw==",
+      "version": "17.0.11",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tabs/-/tabs-17.0.11.tgz",
+      "integrity": "sha512-dC+RMjkJh66Y4w00Y00g+1Bl3oT7m+paJSd1KwhvBVz0zus0vNAAz5XkJcCQvL8+WesPVjrX22ZdBlkaKQGvYA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/a11y": "^1.4.11",
-        "@leafygreen-ui/box": "^3.1.8",
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.0.1",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/portal": "^5.0.3",
-        "@leafygreen-ui/tokens": "^2.2.0",
-        "@leafygreen-ui/typography": "^18.0.1"
+        "@leafygreen-ui/a11y": "^3.0.5",
+        "@leafygreen-ui/descendants": "^3.1.0",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "@lg-tools/test-harnesses": "^0.3.4"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
-      }
-    },
-    "node_modules/@leafygreen-ui/tabs/node_modules/@leafygreen-ui/hooks": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-      "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/lib": "^14.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/tabs/node_modules/@leafygreen-ui/hooks/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/tabs/node_modules/@leafygreen-ui/icon": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-      "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/tabs/node_modules/@leafygreen-ui/lib": {
-      "version": "13.8.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-      "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/tabs/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/tabs/node_modules/@leafygreen-ui/portal": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/portal/-/portal-5.1.1.tgz",
-      "integrity": "sha512-8wvNdLxO3hWY7u5rf1ndYCJJ85TB6XpKp+dl7sQPoLnkq8HXd4GqnFXYwvGQp/pf3ts/Dp5FmZ/9dljkktnzQg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/lib": "^13.3.0"
-      },
-      "peerDependencies": {
-        "react-dom": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/tabs/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/tabs/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/tabs/node_modules/@leafygreen-ui/typography": {
-      "version": "18.4.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-18.4.0.tgz",
-      "integrity": "sha512-2pfoBv6jEPupMzT/rciyP6oN53Fc2h0Nl/uXubSRuFcIDwUAE6CIb3+IjK3UNyQrnOixGU4lWQhxIPTrnyxCpQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/icon": "^12.1.0",
-        "@leafygreen-ui/lib": "^13.4.0",
-        "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/polymorphic": "^1.3.7",
-        "@leafygreen-ui/tokens": "^2.5.2"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
     "node_modules/@leafygreen-ui/text-area": {
-      "version": "8.0.21",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/text-area/-/text-area-8.0.21.tgz",
-      "integrity": "sha512-1gzzGt3dvNWzT3mhOrmjs3oKt+wruGs6Yq3Ij0gYwEzosSQc81dNwlPimN5S1Lzsu5aCbn4cgaQPuYi47QcLcw==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/text-area/-/text-area-12.1.5.tgz",
+      "integrity": "sha512-bp3j0i+sQf2796lkN6TSJuoV2RMF0sgHJ9vmLN6Ij5ARA7FL7QZbDODTehMtFD3UZk5+6Kl9dEvcYtlfRaqfnQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.0.0",
-        "@leafygreen-ui/icon": "^11.27.0",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.2.0",
-        "@leafygreen-ui/typography": "^18.0.0"
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/form-field": "^4.0.9",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "@lg-tools/test-harnesses": "^0.3.4"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
-      }
-    },
-    "node_modules/@leafygreen-ui/text-area/node_modules/@leafygreen-ui/hooks": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-      "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/lib": "^14.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/text-area/node_modules/@leafygreen-ui/hooks/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/text-area/node_modules/@leafygreen-ui/lib": {
-      "version": "13.8.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-      "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/text-area/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/text-area/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/text-area/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/text-area/node_modules/@leafygreen-ui/typography": {
-      "version": "18.4.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-18.4.0.tgz",
-      "integrity": "sha512-2pfoBv6jEPupMzT/rciyP6oN53Fc2h0Nl/uXubSRuFcIDwUAE6CIb3+IjK3UNyQrnOixGU4lWQhxIPTrnyxCpQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/icon": "^12.1.0",
-        "@leafygreen-ui/lib": "^13.4.0",
-        "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/polymorphic": "^1.3.7",
-        "@leafygreen-ui/tokens": "^2.5.2"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
-      }
-    },
-    "node_modules/@leafygreen-ui/text-area/node_modules/@leafygreen-ui/typography/node_modules/@leafygreen-ui/icon": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-      "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "lodash": "^4.17.21"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
     "node_modules/@leafygreen-ui/text-input": {
-      "version": "12.1.25",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/text-input/-/text-input-12.1.25.tgz",
-      "integrity": "sha512-fAL890AgYnIz89xCi9mFD2ocAqbfIx4fNxcOULzXCfz6sqUUfLwaIFPLuqArptginTfq2HPJ47g1NF2vvZhS1g==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/text-input/-/text-input-16.2.3.tgz",
+      "integrity": "sha512-Jbbbov2aTlE2ucuddTLF5IK68jWPwqmTEzwz/LVl9En7Jc4ksEIUZK+Bs0gRMIj6t/ppgwQlSfcoi9MQjZjHpg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/form-field": "^0.3.0",
-        "@leafygreen-ui/hooks": "^8.1.0",
-        "@leafygreen-ui/icon": "^11.27.1",
-        "@leafygreen-ui/lib": "^13.2.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.2.0",
-        "@leafygreen-ui/typography": "^18.1.0"
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/form-field": "^4.0.9",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "@lg-tools/test-harnesses": "^0.3.4"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.11"
-      }
-    },
-    "node_modules/@leafygreen-ui/text-input/node_modules/@leafygreen-ui/hooks": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-      "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/lib": "^14.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/text-input/node_modules/@leafygreen-ui/hooks/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/text-input/node_modules/@leafygreen-ui/lib": {
-      "version": "13.8.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-      "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/text-input/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/text-input/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/text-input/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/text-input/node_modules/@leafygreen-ui/typography": {
-      "version": "18.4.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-18.4.0.tgz",
-      "integrity": "sha512-2pfoBv6jEPupMzT/rciyP6oN53Fc2h0Nl/uXubSRuFcIDwUAE6CIb3+IjK3UNyQrnOixGU4lWQhxIPTrnyxCpQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/icon": "^12.1.0",
-        "@leafygreen-ui/lib": "^13.4.0",
-        "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/polymorphic": "^1.3.7",
-        "@leafygreen-ui/tokens": "^2.5.2"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
-      }
-    },
-    "node_modules/@leafygreen-ui/text-input/node_modules/@leafygreen-ui/typography/node_modules/@leafygreen-ui/icon": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-      "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "lodash": "^4.17.21"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
     "node_modules/@leafygreen-ui/toast": {
-      "version": "6.1.20",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/toast/-/toast-6.1.20.tgz",
-      "integrity": "sha512-6b9yBuEfgRI4+P0UF0pInL15HznkdfY5Vd8x0eiIelcCvZMnbW17UNeXS8ZAr3h3PQg5ETuOasUPOxs0LadSBA==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/toast/-/toast-8.1.3.tgz",
+      "integrity": "sha512-rds7bCY1GRul+2omciMoaI1lbVqAdorIMPhAQ22kq0HuYSivZnoY0owBI2ye3OfdG6Naf+AEOsHDJ/Y6H94d7A==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.1.1",
-        "@leafygreen-ui/icon": "^11.27.1",
-        "@leafygreen-ui/icon-button": "^15.0.19",
-        "@leafygreen-ui/lib": "^13.2.1",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/portal": "^5.0.3",
-        "@leafygreen-ui/tokens": "^2.3.0",
-        "@leafygreen-ui/typography": "^18.1.0",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/portal": "^7.1.0",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
         "lodash": "^4.17.21",
         "polished": "^4.2.2",
         "react-transition-group": "^4.4.5"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.11"
-      }
-    },
-    "node_modules/@leafygreen-ui/toast/node_modules/@leafygreen-ui/hooks": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-      "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/lib": "^14.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/toast/node_modules/@leafygreen-ui/hooks/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/toast/node_modules/@leafygreen-ui/lib": {
-      "version": "13.8.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-      "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/toast/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/toast/node_modules/@leafygreen-ui/portal": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/portal/-/portal-5.1.1.tgz",
-      "integrity": "sha512-8wvNdLxO3hWY7u5rf1ndYCJJ85TB6XpKp+dl7sQPoLnkq8HXd4GqnFXYwvGQp/pf3ts/Dp5FmZ/9dljkktnzQg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/lib": "^13.3.0"
-      },
-      "peerDependencies": {
-        "react-dom": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/toast/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/toast/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/toast/node_modules/@leafygreen-ui/typography": {
-      "version": "18.4.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-18.4.0.tgz",
-      "integrity": "sha512-2pfoBv6jEPupMzT/rciyP6oN53Fc2h0Nl/uXubSRuFcIDwUAE6CIb3+IjK3UNyQrnOixGU4lWQhxIPTrnyxCpQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/icon": "^12.1.0",
-        "@leafygreen-ui/lib": "^13.4.0",
-        "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/polymorphic": "^1.3.7",
-        "@leafygreen-ui/tokens": "^2.5.2"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
-      }
-    },
-    "node_modules/@leafygreen-ui/toast/node_modules/@leafygreen-ui/typography/node_modules/@leafygreen-ui/icon": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-      "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "lodash": "^4.17.21"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
     "node_modules/@leafygreen-ui/toggle": {
-      "version": "10.0.17",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/toggle/-/toggle-10.0.17.tgz",
-      "integrity": "sha512-EUo7kxMMNH+rv8dVJCqyi7zGRPCgiiw+cGXgMa2dI2u1MJQHqGdnNFeQSIJE48jDBpJZfIfMxyryN5lpR3ziHg==",
-      "dev": true,
-      "dependencies": {
-        "@leafygreen-ui/a11y": "^1.4.11",
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/icon": "^11.22.2",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.1.4"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
-      }
-    },
-    "node_modules/@leafygreen-ui/toggle/node_modules/@leafygreen-ui/lib": {
-      "version": "13.8.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-      "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/toggle/-/toggle-12.1.5.tgz",
+      "integrity": "sha512-+exS86dWnZs2TqulXZSzs7hkPrXmxqIeJDSHaunzLtpuYO0fiDDBMZvghhWAFmvPCUN63fh95NXWFUjaJQgC1g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
+        "@leafygreen-ui/a11y": "^3.0.5",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@lg-tools/test-harnesses": "^0.3.4"
       },
       "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/toggle/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/toggle/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/toggle/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
     "node_modules/@leafygreen-ui/tokens": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-1.4.1.tgz",
-      "integrity": "sha512-ap9IdpQy+wg8IG9rJbWZB9F9zihhixClz68UFcwJMbDqcvxcqRPBvRpkbqiJdAPwOSrbYZfrHSGEtdJk9bzZAg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-4.2.2.tgz",
+      "integrity": "sha512-7E31JJ3ASrS5hJ7RxUA/ax+/nBLmNGwJb0AR8tlQsTHeipVeFwQEyWrxHxFTBv3Qyu3qk4L1n52LDuKFkbuENA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/palette": "^3.4.5"
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2"
+      }
+    },
+    "node_modules/@leafygreen-ui/toolbar": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/toolbar/-/toolbar-1.3.2.tgz",
+      "integrity": "sha512-S74SYJPAaniKJJ/9ZbhnywPaNCK7wOkutaUKRBlVzvI0/DhISFfEytrTn/v2c2o0RoRdYe751gUjuYInkCWaNQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/descendants": "^3.1.0",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/tooltip": "^14.3.1",
+        "@lg-chat/chat-button": "^0.2.2",
+        "@lg-tools/test-harnesses": "^0.3.4"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
     "node_modules/@leafygreen-ui/tooltip": {
-      "version": "9.1.8",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tooltip/-/tooltip-9.1.8.tgz",
-      "integrity": "sha512-bqLF0z4L19y253nmRoQSs4U1O7OGSCf46e1N7xBCbenlZVMLN4MSk0EQdpmDmXqMkopLOomVQAy/17guV6YULA==",
+      "version": "14.3.2",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tooltip/-/tooltip-14.3.2.tgz",
+      "integrity": "sha512-YMIvpVSM/vnZPnAtlbXfx3fyOhwMWZs8R1GLHp3q9i+JpoQ696cg3jepnjqHc2Hu2AUH/g4fMrql5raw8WHk8Q==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.4",
-        "@leafygreen-ui/hooks": "^7.7.1",
-        "@leafygreen-ui/icon": "^11.13.1",
-        "@leafygreen-ui/lib": "^10.3.3",
-        "@leafygreen-ui/palette": "^4.0.4",
-        "@leafygreen-ui/popover": "^11.0.8",
-        "@leafygreen-ui/tokens": "^2.0.3",
-        "@leafygreen-ui/typography": "^16.3.0",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.9.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/popover": "^14.3.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
         "lodash": "^4.17.21",
         "polished": "^4.2.2"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/tooltip/node_modules/@leafygreen-ui/palette": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-      "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@leafygreen-ui/tooltip/node_modules/@leafygreen-ui/tokens": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-      "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.10",
-        "@leafygreen-ui/lib": "^14.1.0",
-        "@leafygreen-ui/palette": "^4.1.4",
-        "polished": "^4.2.2"
-      }
-    },
-    "node_modules/@leafygreen-ui/tooltip/node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-      "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/tooltip/node_modules/@leafygreen-ui/typography": {
-      "version": "16.5.5",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-16.5.5.tgz",
-      "integrity": "sha512-mErhTYM0C1PZaeADTkp5v/MAS6aEhavWHZ3otHthBSo/zwI5uAYnkreheiYElc66B/0bcOxCikLVkP3zaFnX2A==",
-      "dev": true,
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/icon": "^11.22.2",
-        "@leafygreen-ui/lib": "^11.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/polymorphic": "^1.3.6",
-        "@leafygreen-ui/tokens": "^2.1.4"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.7"
-      }
-    },
-    "node_modules/@leafygreen-ui/tooltip/node_modules/@leafygreen-ui/typography/node_modules/@leafygreen-ui/lib": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-11.0.0.tgz",
-      "integrity": "sha512-sHkY/MOwRQDc9qAR1awreW0dP+6ELueJJd4JCJmi6XYbdL0wDotFwsWfCwkL+N6cFbE1e+xBQtFLB6T1+58+iQ==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
       }
     },
     "node_modules/@leafygreen-ui/typography": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-15.3.0.tgz",
-      "integrity": "sha512-JmdCGHvFpX0/KyB42zcAjo5ViBKuoIL74MQwN25neWgWAg19Q4VMPrTm+hnysqaPW0ntCwRayexbWnTI+XPD+Q==",
+      "version": "22.2.4",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-22.2.4.tgz",
+      "integrity": "sha512-ffMvuuANOWPbuWwJQcn257YROMT2WJwLV+xlG2l8UH3Gb5ldxiTJAdKqtXIshLjmkrRwv2O7ylHBXsHPMYjUjA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/box": "^3.1.1",
-        "@leafygreen-ui/emotion": "^4.0.3",
-        "@leafygreen-ui/icon": "^11.12.3",
-        "@leafygreen-ui/lib": "^10.0.0",
-        "@leafygreen-ui/palette": "^3.4.6",
-        "@leafygreen-ui/tokens": "^1.4.1"
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/tokens": "^4.2.2"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.0"
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
+      }
+    },
+    "node_modules/@lg-chat/chat-button": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@lg-chat/chat-button/-/chat-button-0.2.2.tgz",
+      "integrity": "sha512-yCCOPnbYbOeUQ+/vQCGUmdZZJHEeGapn0uH48zf87B7YIQbpC7VBDwmO0XXSb8/+YnpssIioeJWzEZt2bDsWZw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/avatar": "^3.3.0",
+        "@leafygreen-ui/button": "^25.2.1",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@lg-tools/test-harnesses": "^0.3.4"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
+      }
+    },
+    "node_modules/@lg-chat/chat-window": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@lg-chat/chat-window/-/chat-window-6.0.2.tgz",
+      "integrity": "sha512-v0h9iCDP9OVcP42XXG/R5ZNsiTPEZgSrbYgK7tPiX7bPKJc+DtOPy2Gc3+hMQLHdnr1/4Rptq96SnVdmVrbv8A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@lg-chat/title-bar": "^5.0.2",
+        "react-keyed-flatten-children": "^2.2.1"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0",
+        "@lg-chat/leafygreen-chat-provider": "^6.0.0"
+      }
+    },
+    "node_modules/@lg-chat/input-bar": {
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/@lg-chat/input-bar/-/input-bar-12.2.2.tgz",
+      "integrity": "sha512-Yv6RrgBv599Yd34BxaE66Pa5tvFqg8BYf+cS8ZKIXjjClOaW6lRCm5lUMgrTaTAZn3ajdL6D6RqB9oKrNuDBbQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/avatar": "^3.3.0",
+        "@leafygreen-ui/banner": "^10.2.5",
+        "@leafygreen-ui/button": "^25.2.1",
+        "@leafygreen-ui/compound-component": "^0.3.0",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/input-option": "^4.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/popover": "^14.3.2",
+        "@leafygreen-ui/search-input": "^6.1.3",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "lodash": "^4.17.21",
+        "react-keyed-flatten-children": "^1.3.0",
+        "react-textarea-autosize": "^8.5.9"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0",
+        "@lg-chat/leafygreen-chat-provider": "^6.0.0"
+      }
+    },
+    "node_modules/@lg-chat/input-bar/node_modules/react-keyed-flatten-children": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-keyed-flatten-children/-/react-keyed-flatten-children-1.3.0.tgz",
+      "integrity": "sha512-qB7A6n+NHU0x88qTZGAJw6dsqwI941jcRPBB640c/CyWqjPQQ+YUmXOuzPziuHb7iqplM3xksWAbGYwkQT0tXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^16.8.6"
+      },
+      "peerDependencies": {
+        "react": ">=15.0.0"
+      }
+    },
+    "node_modules/@lg-chat/leafygreen-chat-provider": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@lg-chat/leafygreen-chat-provider/-/leafygreen-chat-provider-6.0.0.tgz",
+      "integrity": "sha512-zhvqAPpHX0VVOvrsVKs7H37ImIEOGuTLarULXEW4dwglKGqhbagmdN2UEje++wDAD/JqnAYEaQYzrPFH2EIgWQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@lg-chat/lg-markdown": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@lg-chat/lg-markdown/-/lg-markdown-5.0.3.tgz",
+      "integrity": "sha512-zqbCIe1S1BcKEO6RcU1d1mntRC6huIJhzhL/8oJsFP4EpfZu0xi3xh7PK4/wPJv0E7oznHPfnUC9AAxL3jytaw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/code": "^20.2.7",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "react-markdown": "^8.0.7"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
+      }
+    },
+    "node_modules/@lg-chat/message": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@lg-chat/message/-/message-12.0.0.tgz",
+      "integrity": "sha512-ZVz6L4Ju8U1zByQLDEYJfOWKzJUCVraiuw/GrcR0fG+xIjkT572oZ7P3EYzSnNPxpMLl46/ovSwlXrd6faSNTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/badge": "^10.2.4",
+        "@leafygreen-ui/banner": "^10.2.5",
+        "@leafygreen-ui/button": "^25.2.1",
+        "@leafygreen-ui/chip": "^4.2.1",
+        "@leafygreen-ui/compound-component": "^0.3.0",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/loading-indicator": "^5.1.1",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/tooltip": "^14.3.1",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "@lg-chat/lg-markdown": "^5.0.3",
+        "@lg-chat/message-feedback": "^9.0.2",
+        "@lg-chat/message-rating": "^7.1.2",
+        "@lg-chat/rich-links": "^4.0.8"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0",
+        "@lg-chat/leafygreen-chat-provider": "^6.0.0"
+      }
+    },
+    "node_modules/@lg-chat/message-feedback": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@lg-chat/message-feedback/-/message-feedback-9.0.2.tgz",
+      "integrity": "sha512-Q7L4WNxmcmNZ/tqun863UX0jn8P3N9jYlLW/pXiPORG2v2HeG27U+I+yaFNoZOFYvBR2hlRXm1qnkvd+Z4N/PQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/button": "^25.2.1",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/text-area": "^12.1.5",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0",
+        "@lg-chat/leafygreen-chat-provider": "^6.0.0"
+      }
+    },
+    "node_modules/@lg-chat/message-prompts": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@lg-chat/message-prompts/-/message-prompts-4.2.2.tgz",
+      "integrity": "sha512-JBf5ns7tkk9Xx2GvLQQ0V8gNGPYX4fwjkl5FgQV2kBEgEC80DihfE6OdxyZQ4OwRWOrWL4wTlSXCmbsaLBh9PA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/tooltip": "^14.3.1",
+        "@leafygreen-ui/typography": "^22.2.4"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
+      }
+    },
+    "node_modules/@lg-chat/message-rating": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@lg-chat/message-rating/-/message-rating-7.1.2.tgz",
+      "integrity": "sha512-WyFwsDQrLZzZupjNnIJp9QRNKCDRjR0CtQ8r5TX7swx0lg1iTkRu7p56bTXbZYfV2loB6VyqHzWfcqrKrtyl9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/tooltip": "^14.3.1"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0",
+        "@lg-chat/leafygreen-chat-provider": "^6.0.0"
+      }
+    },
+    "node_modules/@lg-chat/rich-links": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@lg-chat/rich-links/-/rich-links-4.0.8.tgz",
+      "integrity": "sha512-Iu5XHywEmlSU86VpzzGys0h0CvlLXBnFyC7q0V6K9SF2WNq1e4iMAICsFBDkIoK/+dbMw2tUrXCzQHgoTy59Ww==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/card": "^13.3.1",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0"
+      }
+    },
+    "node_modules/@lg-chat/title-bar": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@lg-chat/title-bar/-/title-bar-5.0.2.tgz",
+      "integrity": "sha512-iB2G2oZr0XMz1uyrKgfvpGljg0THxqhIFkyjttg7X5sgAdvYtp9VBbgChz5COsMEHsecip5XwDIfTVbZADQvBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/badge": "^10.2.4",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^5.0.0 || ^4.0.0 || ^3.2.0",
+        "@lg-chat/leafygreen-chat-provider": "^6.0.0"
       }
     },
     "node_modules/@lg-tools/test-harnesses": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@lg-tools/test-harnesses/-/test-harnesses-0.1.4.tgz",
-      "integrity": "sha512-3CbuBu28tgn919mHTWFwyKiHnrg78h3kOT1uIrYTlJzUJ8V8tcFXSCTlOYhn+8iQSlbG3dHVSbOcZmfSXDFohA==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@lg-tools/test-harnesses/-/test-harnesses-0.3.4.tgz",
+      "integrity": "sha512-JfJj2LSMe5vTSDQoLxWUHx2r4wUgKqU1UrgqjvNYM7iebXE0JCE7RvLiEg5SnsRO8xXQbEMjgISErmCDR4DS7Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7027,71 +4810,105 @@
       "link": true
     },
     "node_modules/@mongodb-js/compass-components": {
-      "version": "1.21.3",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-components/-/compass-components-1.21.3.tgz",
-      "integrity": "sha512-unbvUMZf1ylj4pU6Uv5Zqz3gYvkMEDf/Umnh7y88R9CWOUIXRfdY2f05ZPRekgNeNrTXxX91LmwHLH1fRJKMDw==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-components/-/compass-components-1.68.0.tgz",
+      "integrity": "sha512-lt/IikfkHJybD+eSJugMqv6Q+rVPBhVrnjKjvcUcFHQrJ5S5/g/XRdKT7ZTZuBLLS4sgVLnWysMiGlltpv23sQ==",
       "dev": true,
+      "license": "SSPL",
       "dependencies": {
         "@dnd-kit/core": "^6.0.7",
         "@dnd-kit/sortable": "^7.0.2",
         "@dnd-kit/utilities": "^3.2.1",
-        "@emotion/css": "^11.11.2",
-        "@leafygreen-ui/badge": "^8.0.1",
-        "@leafygreen-ui/banner": "^7.0.1",
-        "@leafygreen-ui/button": "^19.0.3",
-        "@leafygreen-ui/card": "^9.0.2",
-        "@leafygreen-ui/checkbox": "^12.0.8",
-        "@leafygreen-ui/code": "^14.1.0",
-        "@leafygreen-ui/confirmation-modal": "^4.0.1",
-        "@leafygreen-ui/emotion": "^4.0.3",
-        "@leafygreen-ui/guide-cue": "^4.0.0",
-        "@leafygreen-ui/hooks": "^7.3.3",
-        "@leafygreen-ui/icon": "^11.21.0",
-        "@leafygreen-ui/icon-button": "^15.0.3",
-        "@leafygreen-ui/info-sprinkle": "^1.0.0",
-        "@leafygreen-ui/inline-definition": "^6.0.0",
-        "@leafygreen-ui/leafygreen-provider": "^3.1.0",
-        "@leafygreen-ui/lib": "^10.0.0",
-        "@leafygreen-ui/logo": "^7.0.0",
-        "@leafygreen-ui/marketing-modal": "^3.0.10",
-        "@leafygreen-ui/menu": "^19.0.1",
-        "@leafygreen-ui/modal": "^14.0.0",
-        "@leafygreen-ui/palette": "^3.4.6",
-        "@leafygreen-ui/pipeline": "^5.0.1",
-        "@leafygreen-ui/popover": "^11.0.1",
-        "@leafygreen-ui/portal": "^4.0.7",
-        "@leafygreen-ui/radio-box-group": "^12.0.5",
-        "@leafygreen-ui/radio-group": "^10.1.1",
-        "@leafygreen-ui/search-input": "^2.0.3",
-        "@leafygreen-ui/segmented-control": "^7.0.0",
-        "@leafygreen-ui/select": "^10.1.0",
-        "@leafygreen-ui/table": "^10.0.2",
-        "@leafygreen-ui/tabs": "^11.0.1",
-        "@leafygreen-ui/text-area": "^8.0.1",
-        "@leafygreen-ui/text-input": "^12.1.1",
-        "@leafygreen-ui/toast": "^6.1.3",
-        "@leafygreen-ui/toggle": "^10.0.2",
-        "@leafygreen-ui/tokens": "^1.4.1",
-        "@leafygreen-ui/tooltip": "^9.0.2",
-        "@leafygreen-ui/typography": "^15.2.0",
+        "@leafygreen-ui/avatar": "^3.3.0",
+        "@leafygreen-ui/badge": "^10.2.4",
+        "@leafygreen-ui/banner": "^10.2.5",
+        "@leafygreen-ui/button": "^25.2.1",
+        "@leafygreen-ui/card": "^13.3.1",
+        "@leafygreen-ui/checkbox": "^18.1.5",
+        "@leafygreen-ui/chip": "^4.2.1",
+        "@leafygreen-ui/code": "^20.2.7",
+        "@leafygreen-ui/combobox": "^12.5.1",
+        "@leafygreen-ui/confirmation-modal": "^11.0.1",
+        "@leafygreen-ui/copyable": "^12.0.3",
+        "@leafygreen-ui/drawer": "^5.2.3",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/guide-cue": "^8.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.9.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/info-sprinkle": "^5.0.11",
+        "@leafygreen-ui/input-option": "^4.1.5",
+        "@leafygreen-ui/leafygreen-provider": "^5.0.4",
+        "@leafygreen-ui/logo": "^11.1.0",
+        "@leafygreen-ui/marketing-modal": "^8.2.1",
+        "@leafygreen-ui/menu": "^33.2.1",
+        "@leafygreen-ui/modal": "^22.0.1",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/pipeline": "^8.0.10",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/popover": "^14.3.2",
+        "@leafygreen-ui/portal": "^7.1.0",
+        "@leafygreen-ui/progress-bar": "^1.0.8",
+        "@leafygreen-ui/radio-box-group": "^15.0.11",
+        "@leafygreen-ui/radio-group": "^13.0.12",
+        "@leafygreen-ui/search-input": "^6.1.3",
+        "@leafygreen-ui/segmented-control": "^11.1.0",
+        "@leafygreen-ui/select": "^17.0.3",
+        "@leafygreen-ui/skeleton-loader": "^3.0.11",
+        "@leafygreen-ui/split-button": "^6.3.1",
+        "@leafygreen-ui/table": "^15.2.3",
+        "@leafygreen-ui/tabs": "^17.0.11",
+        "@leafygreen-ui/text-area": "^12.1.5",
+        "@leafygreen-ui/text-input": "^16.2.3",
+        "@leafygreen-ui/toast": "^8.1.3",
+        "@leafygreen-ui/toggle": "^12.1.5",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/tooltip": "^14.3.1",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "@lg-chat/chat-window": "^6.0.2",
+        "@lg-chat/input-bar": "^12.2.2",
+        "@lg-chat/leafygreen-chat-provider": "^6.0.0",
+        "@lg-chat/message": "^12.0.0",
+        "@lg-chat/message-prompts": "^4.2.2",
+        "@mongodb-js/compass-context-menu": "^0.3.15",
+        "@mongodb-js/diagramming": "^2.4.1",
         "@react-aria/interactions": "^3.9.1",
-        "@react-aria/tooltip": "^3.2.1",
         "@react-aria/utils": "^3.13.1",
         "@react-aria/visually-hidden": "^3.3.1",
-        "@react-stately/tooltip": "^3.0.5",
-        "bson": "^6.2.0",
-        "focus-trap-react": "^8.4.2",
-        "hadron-document": "^8.4.7",
-        "hadron-type-checker": "^7.1.1",
+        "bson": "^7.2.0",
+        "focus-trap-react": "^9.0.2",
+        "hadron-document": "^8.11.8",
+        "hadron-type-checker": "^7.5.8",
         "is-electron-renderer": "^2.0.1",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
+        "mongodb-query-parser": "^4.7.14",
+        "mongodb-query-util": "^2.6.8",
         "polished": "^4.2.2",
-        "prop-types": "^15.7.2",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2",
         "react-hotkeys-hook": "^4.3.7",
         "react-intersection-observer": "^8.34.0",
+        "react-virtualized-auto-sizer": "^1.0.6",
         "react-window": "^1.8.6"
-      },
-      "peerDependencies": {
+      }
+    },
+    "node_modules/@mongodb-js/compass-components/node_modules/bson": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.2.tgz",
+      "integrity": "sha512-1w0ra+ho1cuE+w8jzwgzTFIimFtCfZeCoOsvIPQg6uyFCsp8M29U7bNNf5GrFh88TXbYg1g3TyKUGpd6O7q6zA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@mongodb-js/compass-context-menu": {
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-context-menu/-/compass-context-menu-0.3.15.tgz",
+      "integrity": "sha512-ZCGagfRMA2xZrXq5nhlpxsFd4mVS5tljIQa45RQbWmmVMbpegVWsR51PtQk3ng0DJg0cLw1cCvyVbuwb7Vexfg==",
+      "dev": true,
+      "license": "SSPL",
+      "dependencies": {
         "react": "^17.0.2"
       }
     },
@@ -7330,6 +5147,90 @@
     "node_modules/@mongodb-js/devtools-scripts": {
       "resolved": "scripts",
       "link": true
+    },
+    "node_modules/@mongodb-js/diagramming": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/diagramming/-/diagramming-2.4.1.tgz",
+      "integrity": "sha512-AzPMacmzTOF7EVJ53GCwC/BJd8Pmw4RQEyOc/K2vN+IFeQ0HnOuNLlmGK3HvXy+qbkjjnfwMocQF9t1SEVZmHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.0",
+        "@leafygreen-ui/icon": "^14.3.0",
+        "@leafygreen-ui/inline-definition": "^9.0.5",
+        "@leafygreen-ui/leafygreen-provider": "^5.0.2",
+        "@leafygreen-ui/palette": "^5.0.0",
+        "@leafygreen-ui/select": "^16.2.0",
+        "@leafygreen-ui/tokens": "^3.2.1",
+        "@leafygreen-ui/tooltip": "^14.2.1",
+        "@leafygreen-ui/typography": "^22.1.0",
+        "@xyflow/react": "12.5.1",
+        "d3-path": "^3.1.0",
+        "elkjs": "^0.11.0",
+        "react": "17.0.2",
+        "react-dom": "17.0.2"
+      }
+    },
+    "node_modules/@mongodb-js/diagramming/node_modules/@leafygreen-ui/select": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/select/-/select-16.3.0.tgz",
+      "integrity": "sha512-/UP9NO4HKyOmN8fac8DFQnW2ia/O/odp5LPxehymvRPSSgDGzTBoVK8JPocayEZHTO+kLRjmiJm6QaQ09xmhRQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/button": "^25.1.2",
+        "@leafygreen-ui/emotion": "^5.1.0",
+        "@leafygreen-ui/form-field": "^4.0.6",
+        "@leafygreen-ui/hooks": "^9.2.2",
+        "@leafygreen-ui/icon": "^14.6.1",
+        "@leafygreen-ui/input-option": "^4.1.2",
+        "@leafygreen-ui/lib": "^15.6.2",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/popover": "^14.3.0",
+        "@leafygreen-ui/tokens": "^4.0.0",
+        "@leafygreen-ui/typography": "^22.2.0",
+        "@lg-tools/test-harnesses": "^0.3.4",
+        "@types/react-is": "^18.0.0",
+        "lodash": "^4.17.21",
+        "polished": "^4.1.3",
+        "react-is": "^18.0.1"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": ">=3.2.0"
+      }
+    },
+    "node_modules/@mongodb-js/diagramming/node_modules/@leafygreen-ui/select/node_modules/@leafygreen-ui/tokens": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-4.2.2.tgz",
+      "integrity": "sha512-7E31JJ3ASrS5hJ7RxUA/ax+/nBLmNGwJb0AR8tlQsTHeipVeFwQEyWrxHxFTBv3Qyu3qk4L1n52LDuKFkbuENA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2"
+      }
+    },
+    "node_modules/@mongodb-js/diagramming/node_modules/@leafygreen-ui/tokens": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-3.2.4.tgz",
+      "integrity": "sha512-Bd11x/ext/vVozd/HL+AD8LbL71Z6B6VbtQ/+qLqoX8qHMsJt7VWL0CmmGs5NVHh3v5sAlfT5DYbB9uhwVM8Qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/emotion": "^5.0.2",
+        "@leafygreen-ui/lib": "^15.3.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "polished": "^4.2.2"
+      }
+    },
+    "node_modules/@mongodb-js/diagramming/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@mongodb-js/dl-center": {
       "resolved": "packages/dl-center",
@@ -9374,22 +7275,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@react-aria/focus": {
-      "version": "3.16.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.16.1.tgz",
-      "integrity": "sha512-3ZEYc+hWqDQX7fA54ZOTkED8OGXs9+K9fYmjD1IdjZJAJS/2/AJ95PgIQ29zBkl9D9TAi4Nb3tJ/3+H/02UzoA==",
-      "dev": true,
-      "dependencies": {
-        "@react-aria/interactions": "^3.21.0",
-        "@react-aria/utils": "^3.23.1",
-        "@react-types/shared": "^3.22.0",
-        "@swc/helpers": "^0.5.0",
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
     "node_modules/@react-aria/interactions": {
       "version": "3.21.0",
       "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.21.0.tgz",
@@ -9415,24 +7300,6 @@
       },
       "engines": {
         "node": ">= 12"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/tooltip": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/tooltip/-/tooltip-3.7.1.tgz",
-      "integrity": "sha512-2lf72hIw3gfQLvKU9SHkh3a/CP8GJ3MbKlPq8x0gX7444zaYII/UDqIkde1TiR2fB71I/MqKSOx6mg28B9lj4w==",
-      "dev": true,
-      "dependencies": {
-        "@react-aria/focus": "^3.16.1",
-        "@react-aria/interactions": "^3.21.0",
-        "@react-aria/utils": "^3.23.1",
-        "@react-stately/tooltip": "^3.4.6",
-        "@react-types/shared": "^3.22.0",
-        "@react-types/tooltip": "^3.4.6",
-        "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
@@ -9469,34 +7336,6 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
-    "node_modules/@react-stately/overlays": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.4.tgz",
-      "integrity": "sha512-tHEaoAGpE9dSnsskqLPVKum59yGteoSqsniTopodM+miQozbpPlSjdiQnzGLroy5Afx5OZYClE616muNHUILXA==",
-      "dev": true,
-      "dependencies": {
-        "@react-stately/utils": "^3.9.0",
-        "@react-types/overlays": "^3.8.4",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/tooltip": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@react-stately/tooltip/-/tooltip-3.4.6.tgz",
-      "integrity": "sha512-uL93bmsXf+OOgpKLPEKfpDH4z+MK2CuqlqVxx7rshN0vjWOSoezE5nzwgee90+RpDrLNNNWTNa7n+NkDRpI1jA==",
-      "dev": true,
-      "dependencies": {
-        "@react-stately/overlays": "^3.6.4",
-        "@react-types/tooltip": "^3.4.6",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
     "node_modules/@react-stately/utils": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.9.0.tgz",
@@ -9509,36 +7348,11 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
-    "node_modules/@react-types/overlays": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.8.4.tgz",
-      "integrity": "sha512-pfgNlQnbF6RB/R2oSxyqAP3Uzz0xE/k5q4n5gUeCDNLjY5qxFHGE8xniZZ503nZYw6VBa9XMN1efDOKQyeiO0w==",
-      "dev": true,
-      "dependencies": {
-        "@react-types/shared": "^3.22.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
     "node_modules/@react-types/shared": {
       "version": "3.22.0",
       "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.22.0.tgz",
       "integrity": "sha512-yVOekZWbtSmmiThGEIARbBpnmUIuePFlLyctjvCbgJgGhz8JnEJOipLQ/a4anaWfzAgzSceQP8j/K+VOOePleA==",
       "dev": true,
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-types/tooltip": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@react-types/tooltip/-/tooltip-3.4.6.tgz",
-      "integrity": "sha512-RaZewdER7ZcsNL99RhVHs8kSLyzIBkwc0W6eFZrxST2MD9J5GzkVWRhIiqtFOd5U1aYnxdJ6woq72Ef+le6Vfw==",
-      "dev": true,
-      "dependencies": {
-        "@react-types/overlays": "^3.8.4",
-        "@react-types/shared": "^3.22.0"
-      },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
@@ -9865,27 +7679,6 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
-    "node_modules/@storybook/csf": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.2.tgz",
-      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-      "dev": true,
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@storybook/csf/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@swc/helpers": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.6.tgz",
@@ -9911,6 +7704,70 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.9.tgz",
+      "integrity": "sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.7.tgz",
+      "integrity": "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -10153,6 +8010,61 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
@@ -10210,7 +8122,8 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@types/facepaint/-/facepaint-1.2.5.tgz",
       "integrity": "sha512-fi9kvwtC3IQ6Y3QVDkYEZsqEcetAdWD0zqqk8pEHlDXWkgS2WzolWN8Z5PGPT7YJ7ga71CCI0fVKVnVKqV+P6Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/glob": {
       "version": "7.2.0",
@@ -10222,12 +8135,23 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hast": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
+      "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
     "node_modules/@types/highlight.js": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-10.1.0.tgz",
       "integrity": "sha512-77hF2dGBsOgnvZll1vymYiNUtqJ8cJfXPD6GG/2M0aLRc29PkvB7Au6sIDjIEFcSICBhCh2+Pyq6WSRS7LUm6A==",
       "deprecated": "This is a stub types definition. highlight.js provides its own type definitions, so you do not need this installed.",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "highlight.js": "*"
       }
@@ -10288,6 +8212,16 @@
       "dev": true,
       "dependencies": {
         "@types/lodash": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
+      "integrity": "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2"
       }
     },
     "node_modules/@types/memory-pager": {
@@ -10442,20 +8376,33 @@
       }
     },
     "node_modules/@types/react-is": {
-      "version": "18.2.4",
-      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-18.2.4.tgz",
-      "integrity": "sha512-wBc7HgmbCcrvw0fZjxbgz/xrrlZKzEqmABBMeSvpTvdm25u6KI6xdIi9pRE2G0C1Lw5ETFdcn4UbYZ4/rpqUYw==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-zts4lhQn5ia0cF/y2+3V6Riu0MAfez9/LJYavdM8TvcVl+S91A/7VWxyBT8hbRuWspmuCaiGI0F41OJYGrKhRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/react": "*"
+        "@types/react": "^18"
+      }
+    },
+    "node_modules/@types/react-is/node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-transition-group": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
-      "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
       "dev": true,
-      "dependencies": {
+      "license": "MIT",
+      "peerDependencies": {
         "@types/react": "*"
       }
     },
@@ -10617,6 +8564,13 @@
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.2.tgz",
       "integrity": "sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g==",
       "dev": true
+    },
+    "node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
@@ -11478,6 +9432,38 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
+    "node_modules/@xyflow/react": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.5.1.tgz",
+      "integrity": "sha512-jMKQVqGwCz0x6pUyvxTIuCMbyehfua7CfEEWDj29zQSHigQpCy0/5d8aOmZrqK4cwur/pVHLQomT6Rm10gXfHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.53",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.53.tgz",
+      "integrity": "sha512-QTWieiTtvNYyQAz1fxpzgtUGXNpnhfh6vvZa7dFWpWS2KOz6bEHODo/DTK3s07lDu0Bq0Db5lx/5M5mNjb9VDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
@@ -12114,6 +10100,17 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/balanced-match": {
@@ -13034,6 +11031,17 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chardet": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
@@ -13148,6 +11156,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -13223,6 +11238,7 @@
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
       "integrity": "sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "good-listener": "^1.2.2",
         "select": "^1.1.2",
@@ -13429,6 +11445,17 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/commander": {
@@ -13881,10 +11908,11 @@
       "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw=="
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/d": {
       "version": "1.0.1",
@@ -13894,6 +11922,130 @@
       "dependencies": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/damerau-levenshtein": {
@@ -14045,6 +12197,20 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/decompress": {
       "version": "4.2.1",
@@ -14430,7 +12596,8 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
       "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/delegates": {
       "version": "1.0.0",
@@ -14560,6 +12727,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -14657,6 +12834,7 @@
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
       "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
@@ -14905,6 +13083,13 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.339.tgz",
       "integrity": "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg==",
       "license": "ISC"
+    },
+    "node_modules/elkjs": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.11.1.tgz",
+      "integrity": "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==",
+      "dev": true,
+      "license": "EPL-2.0"
     },
     "node_modules/email-validator": {
       "version": "2.0.4",
@@ -16381,6 +14566,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -16420,7 +14612,8 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/facepaint/-/facepaint-1.2.1.tgz",
       "integrity": "sha512-oNvBekbhsm/0PNSOWca5raHNAi6dG960Bx6LJgxDPNF59WpuspgQ17bN5MKwOr7JcFdQYc7StW3VZ28DBZLavQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -16747,23 +14940,40 @@
       "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.9.4.tgz",
       "integrity": "sha512-v2NTsZe2FF59Y+sDykKY+XjqZ0cPfhq/hikWVL88BqLivnNiEffAsac6rP6H45ff9wG9LL5ToiDqrLEP9GX9mw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tabbable": "^5.3.3"
       }
     },
     "node_modules/focus-trap-react": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-8.11.3.tgz",
-      "integrity": "sha512-y126gMYuB1aVYiEZSP6/v9bAfVmAIUVixanhcoMelkz7bOh+l0c3h05CEHC8S63ztxdRI2AAPS9AsTat6jlDeQ==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-9.0.2.tgz",
+      "integrity": "sha512-ZwhO5by6KG5r3dy48Lk00A1/0zNYw1Z3RZTN6O6kgAPsWFcwTFszOcQ1dLSfM8pIxpS/ttc7wTttJowjVT3jpg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "focus-trap": "^6.9.4"
+        "focus-trap": "^6.9.4",
+        "tabbable": "^5.3.3"
       },
       "peerDependencies": {
         "prop-types": "^15.8.1",
-        "react": ">=16.0.0",
-        "react-dom": ">=16.0.0"
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
       }
+    },
+    "node_modules/focus-trap-react/node_modules/tabbable": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
+      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/focus-trap/node_modules/tabbable": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
+      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -17794,6 +16004,7 @@
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "delegate": "^3.1.2"
       }
@@ -17854,26 +16065,48 @@
       }
     },
     "node_modules/hadron-document": {
-      "version": "8.4.7",
-      "resolved": "https://registry.npmjs.org/hadron-document/-/hadron-document-8.4.7.tgz",
-      "integrity": "sha512-6nxghzGKDvRJ91XtNaAn6VYgJThhhD5ohwhGua4w7sCa524+PkasAUS7EOLWGcp5tlWP+mAyBlVtUf/r4XruGw==",
+      "version": "8.11.8",
+      "resolved": "https://registry.npmjs.org/hadron-document/-/hadron-document-8.11.8.tgz",
+      "integrity": "sha512-vQuCWmeuesIjvG3jufITL6WA4Lw53TJE7VGiHXONZdX7qQDJoYvmentXem5EiNYumb1upqcvwlVb40iSGEcKxQ==",
       "dev": true,
+      "license": "SSPL",
       "dependencies": {
-        "bson": "^6.2.0",
-        "debug": "^4.2.0",
+        "bson": "^7.2.0",
         "eventemitter3": "^4.0.0",
-        "hadron-type-checker": "^7.1.1",
-        "lodash": "^4.17.21"
+        "hadron-type-checker": "^7.5.8",
+        "lodash": "^4.18.1",
+        "mongodb": "^7.1.1"
+      }
+    },
+    "node_modules/hadron-document/node_modules/bson": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.2.tgz",
+      "integrity": "sha512-1w0ra+ho1cuE+w8jzwgzTFIimFtCfZeCoOsvIPQg6uyFCsp8M29U7bNNf5GrFh88TXbYg1g3TyKUGpd6O7q6zA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/hadron-type-checker": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/hadron-type-checker/-/hadron-type-checker-7.1.1.tgz",
-      "integrity": "sha512-fkCf7ryFhWlag0GYG3FNuOuyO5/ty9Rnj39k+PApxkvXGhyZawAHxT711Hx2ICihX/TKxtYtXfeOhs6Xet/HGQ==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/hadron-type-checker/-/hadron-type-checker-7.5.8.tgz",
+      "integrity": "sha512-GFXUSS5zLaWZCFNKzKvtlD0sOxtw0AXRzBka8UXUHzVeVVT2hAfhuRGdmnxUvQTVSmFNWoc/g+pjN19PGiI8SA==",
       "dev": true,
+      "license": "SSPL",
       "dependencies": {
-        "bson": "^6.2.0",
-        "lodash": "^4.17.21"
+        "bson": "^7.2.0",
+        "lodash": "^4.18.1"
+      }
+    },
+    "node_modules/hadron-type-checker/node_modules/bson": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.2.tgz",
+      "integrity": "sha512-1w0ra+ho1cuE+w8jzwgzTFIimFtCfZeCoOsvIPQg6uyFCsp8M29U7bNNf5GrFh88TXbYg1g3TyKUGpd6O7q6zA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/handlebars": {
@@ -18039,6 +16272,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz",
+      "integrity": "sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -18061,6 +16305,7 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.5.1.tgz",
       "integrity": "sha512-LKzHqnxr4CrD2YsNoIf/o5nJ09j4yi/GcH5BnYz9UnVpZdS4ucMgvP61TDty5xJcFGRjnH4DpujkS9bHT3hq0Q==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -18069,7 +16314,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/highlightjs-graphql/-/highlightjs-graphql-1.0.2.tgz",
       "integrity": "sha512-jShTftpKQDwMXc+7OHOpHXRYSweT08EO2YOIcLbwU00e9yuwJMYXGLF1eiDO0aUPeQU4/5EjAh5HtPt3ly7rvg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -18618,6 +16864,13 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/inquirer": {
       "version": "12.9.6",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.9.6.tgz",
@@ -18733,13 +16986,14 @@
       "dev": true
     },
     "node_modules/is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -18831,6 +17085,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/is-builtin-module": {
@@ -21093,6 +19371,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lottie-web": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/lottie-web/-/lottie-web-5.13.0.tgz",
+      "integrity": "sha512-+gfBXl6sxXMPe8tKQm7qzLnUy5DUPJPKIyRHwtpCpyUEYjHYRJC/5gjUvdkuO2c3JllrPtHXH5UJJK8LRYl5yQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/loupe": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
@@ -21279,6 +19564,82 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-definitions": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-5.1.2.tgz",
+      "integrity": "sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "unist-util-visit": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
+      "integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "mdast-util-to-string": "^3.1.0",
+        "micromark": "^3.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-decode-string": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.3.0.tgz",
+      "integrity": "sha512-pits93r8PhnIoU4Vy9bjW39M2jJ6/tdHyja9rrot9uujkN7UTU9SDnE6WNJz/IGyQk3XHX6yNNtrBH6cQzm8Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/mdast": "^3.0.0",
+        "mdast-util-definitions": "^5.0.0",
+        "micromark-util-sanitize-uri": "^1.1.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-generated": "^2.0.0",
+        "unist-util-position": "^4.0.0",
+        "unist-util-visit": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
+      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/media-typer": {
@@ -21519,6 +19880,469 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/micromark": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
+      "integrity": "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-core-commonmark": "^1.0.1",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-combine-extensions": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz",
+      "integrity": "sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-factory-destination": "^1.0.0",
+        "micromark-factory-label": "^1.0.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-factory-title": "^1.0.0",
+        "micromark-factory-whitespace": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-classify-character": "^1.0.0",
+        "micromark-util-html-tag-name": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.1.0.tgz",
+      "integrity": "sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.1.0.tgz",
+      "integrity": "sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
+      "integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.1.0.tgz",
+      "integrity": "sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.1.0.tgz",
+      "integrity": "sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+      "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.1.0.tgz",
+      "integrity": "sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.1.0.tgz",
+      "integrity": "sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.1.0.tgz",
+      "integrity": "sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz",
+      "integrity": "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz",
+      "integrity": "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz",
+      "integrity": "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.2.0.tgz",
+      "integrity": "sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.1.0.tgz",
+      "integrity": "sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.1.0.tgz",
+      "integrity": "sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz",
+      "integrity": "sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.1.0.tgz",
+      "integrity": "sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+      "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+      "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -21985,6 +20809,28 @@
       "resolved": "packages/query-parser",
       "link": true
     },
+    "node_modules/mongodb-query-util": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/mongodb-query-util/-/mongodb-query-util-2.6.8.tgz",
+      "integrity": "sha512-P5o9NVury4g7JElaYsL7BBeF7RyFuh34CZGbTsiwScW1B/w4QdE9d0ADZXbFKRUu90/owMpEFHXGBqg23gyqdw==",
+      "dev": true,
+      "license": "SSPL",
+      "dependencies": {
+        "bson": "^7.2.0",
+        "hadron-type-checker": "^7.5.8",
+        "lodash": "^4.18.1"
+      }
+    },
+    "node_modules/mongodb-query-util/node_modules/bson": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.2.tgz",
+      "integrity": "sha512-1w0ra+ho1cuE+w8jzwgzTFIimFtCfZeCoOsvIPQg6uyFCsp8M29U7bNNf5GrFh88TXbYg1g3TyKUGpd6O7q6zA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/mongodb-redact": {
       "resolved": "packages/mongodb-redact",
       "link": true
@@ -22162,6 +21008,16 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
       "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w=="
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -24243,6 +23099,7 @@
       "resolved": "https://registry.npmjs.org/polished/-/polished-4.3.1.tgz",
       "integrity": "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.17.8"
       },
@@ -24561,6 +23418,17 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "node_modules/property-information": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz",
+      "integrity": "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/protocols": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.2.tgz",
@@ -24865,6 +23733,13 @@
         "react": "17.0.2"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/react-hotkeys-hook": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-4.5.0.tgz",
@@ -24880,6 +23755,7 @@
       "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-8.34.0.tgz",
       "integrity": "sha512-TYKh52Zc0Uptp5/b4N91XydfSGKubEhgZRtcg1rhTKABXijc4Sdr1uTp5lJ8TN27jwUsdXxjHXtHa0kPj704sw==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "react": "^15.0.0 || ^16.0.0 || ^17.0.0|| ^18.0.0"
       }
@@ -24888,6 +23764,83 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-keyed-flatten-children": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-keyed-flatten-children/-/react-keyed-flatten-children-2.2.1.tgz",
+      "integrity": "sha512-6yBLVO6suN8c/OcJk1mzIrUHdeEzf5rtRVBhxEXAHO49D7SlJ70cG4xrSJrBIAG7MMeQ+H/T151mM2dRDNnFaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^18.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=15.0.0"
+      }
+    },
+    "node_modules/react-keyed-flatten-children/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-lottie-player": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/react-lottie-player/-/react-lottie-player-1.5.6.tgz",
+      "integrity": "sha512-t0GdTYbml0Ihski8ZPx+1WjpjM/EQlTqTcuGm5yeZGJAgFXTmoqrHbSX8bcREIxrHjibWAyIWnLVUK/iHLcqAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lottie-web": "^5.7.6",
+        "rfdc": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-markdown": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-8.0.7.tgz",
+      "integrity": "sha512-bvWbzG4MtOU62XqBx3Xx+zB2raaFFsq4mYiAzfjXJMEz2sixgeAfraA3tvzULF02ZdOMUOKTBFFaZJDDrq+BJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/prop-types": "^15.0.0",
+        "@types/unist": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^2.0.0",
+        "prop-types": "^15.0.0",
+        "property-information": "^6.0.0",
+        "react-is": "^18.0.0",
+        "remark-parse": "^10.0.0",
+        "remark-rehype": "^10.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-object": "^0.4.0",
+        "unified": "^10.0.0",
+        "unist-util-visit": "^4.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16",
+        "react": ">=16"
+      }
+    },
+    "node_modules/react-markdown/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-shallow-renderer": {
       "version": "16.15.0",
@@ -24901,11 +23854,30 @@
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-textarea-autosize": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
+      "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
       "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",
@@ -24915,6 +23887,17 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-virtualized-auto-sizer": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.26.tgz",
+      "integrity": "sha512-CblNyiNVw2o+hsa5/49NH2ogGxZ+t+3aweRvNSq7TVjDIlwk7ir4lencEg5HxHeSzwNarSkNkiu0qJSOXtxm5A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-window": {
@@ -25235,12 +24218,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
-    },
     "node_modules/regexp.escape": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexp.escape/-/regexp.escape-2.0.1.tgz",
@@ -25326,6 +24303,39 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.2.tgz",
+      "integrity": "sha512-3ydxgHa/ZQzG8LvC7jTXccARYDcRld3VfcgIIFs7bI6vbRSxJJmzgLEIIoYKyrfhaY+ujuWaf/PJiMZXoiCXgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-from-markdown": "^1.0.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-10.1.0.tgz",
+      "integrity": "sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-hast": "^12.1.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/require-directory": {
@@ -25514,6 +24524,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -25742,6 +24759,19 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -25879,7 +24909,8 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
       "integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -26515,6 +25546,17 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
@@ -26944,6 +25986,16 @@
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
       "dev": true
     },
+    "node_modules/style-to-object": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.4.tgz",
+      "integrity": "sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.1.1"
+      }
+    },
     "node_modules/stylis": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
@@ -27000,10 +26052,11 @@
       }
     },
     "node_modules/tabbable": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
-      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==",
-      "dev": true
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.2.1",
@@ -27242,7 +26295,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -27357,6 +26411,17 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/trim-newlines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
@@ -27373,6 +26438,17 @@
       "dev": true,
       "engines": {
         "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-api-utils": {
@@ -27799,6 +26875,39 @@
         "node": ">=4"
       }
     },
+    "node_modules/unified": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "bail": "^2.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unified/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/unique-filename": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-5.0.0.tgz",
@@ -27821,6 +26930,90 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/unist-util-generated": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-2.0.1.tgz",
+      "integrity": "sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-4.0.4.tgz",
+      "integrity": "sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.1.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/universal-user-agent": {
@@ -27906,6 +27099,64 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/use-composed-ref": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
+      "integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-latest": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
+      "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
@@ -27933,6 +27184,35 @@
       "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/uvu": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
+      "integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0",
+        "diff": "^5.0.0",
+        "kleur": "^4.0.3",
+        "sade": "^1.7.3"
+      },
+      "bin": {
+        "uvu": "bin.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/uvu/node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -27965,6 +27245,38 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+      "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+      "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/w3c-xmlserializer": {
@@ -28764,6 +28076,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "packages/aggregation-stage-icons": {
@@ -30854,7 +30195,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@leafygreen-ui/emotion": "^5.2.0",
-        "@mongodb-js/compass-components": "^1.6.0",
+        "@mongodb-js/compass-components": "^1.68.0",
         "@mongodb-js/eslint-config-devtools": "^0.11.8",
         "@mongodb-js/mocha-config-devtools": "^1.1.3",
         "@mongodb-js/prettier-config-devtools": "^1.0.4",
@@ -30869,23 +30210,12 @@
         "eslint": "^7.25.0 || ^8.0.0",
         "gen-esm-wrapper": "^1.1.3",
         "mocha": "^8.4.0",
+        "mongodb-query-parser": "^4.7.16",
         "nyc": "^15.1.0",
         "prettier": "^3.8.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "typescript": "^5.9.3"
-      }
-    },
-    "packages/oidc-http-server-pages/node_modules/@leafygreen-ui/emotion": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-5.2.0.tgz",
-      "integrity": "sha512-Sov+2tDy4ahGsRR8/KOV8Zzx+5fvVAj7Smyc1brgzE8ocXnOiwahQQ1wVvthAXS91iXPpnuNA5KL6Qzh3jNfQw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@emotion/css": "^11.1.3",
-        "@emotion/react": "^11.14.0",
-        "@emotion/server": "^11.4.0"
       }
     },
     "packages/oidc-http-server-pages/node_modules/@types/sinon-chai": {
@@ -32971,13 +32301,10 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
-      "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
-      "dev": true,
-      "requires": {
-        "regenerator-runtime": "^0.13.4"
-      }
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true
     },
     "@babel/template": {
       "version": "7.28.6",
@@ -33308,6 +32635,15 @@
       "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
       "dev": true
     },
+    "@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "dev": true,
+      "requires": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
     "@emotion/memoize": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
@@ -33360,6 +32696,20 @@
       "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
       "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
       "dev": true
+    },
+    "@emotion/styled": {
+      "version": "11.14.1",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
+      "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/is-prop-valid": "^1.3.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2"
+      }
     },
     "@emotion/unitless": {
       "version": "0.10.0",
@@ -33443,6 +32793,51 @@
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
       "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true
+    },
+    "@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "dev": true,
+      "requires": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "dev": true,
+      "requires": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "@floating-ui/react": {
+      "version": "0.26.28",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
+      "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+      "dev": true,
+      "requires": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.8",
+        "tabbable": "^6.0.0"
+      }
+    },
+    "@floating-ui/react-dom": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+      "dev": true,
+      "requires": {
+        "@floating-ui/dom": "^1.8.0"
+      }
+    },
+    "@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
       "dev": true
     },
     "@humanwhocodes/config-array": {
@@ -33912,403 +33307,139 @@
       }
     },
     "@leafygreen-ui/a11y": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/a11y/-/a11y-1.5.0.tgz",
-      "integrity": "sha512-QKnzWWFsw8FR9+KVqQbgzSGC5T2NcsUI1+6bc6+mNh1HwH8nUctrXj0tjTkrV+Dmab8zdeArUz24ly9eEvl7UA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/a11y/-/a11y-3.0.5.tgz",
+      "integrity": "sha512-HJqDsLCNj4d1RQiifYuhpazZVYgsLZJeEboaQ+UsNhAppV13kdPb2qX7H4RbGmXkalTBzHOkbAYp6vvioSAVdQ==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/lib": "^13.6.1"
-      },
-      "dependencies": {
-        "@leafygreen-ui/hooks": {
-          "version": "8.3.6",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-          "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/lib": "^14.1.0",
-            "lodash": "^4.17.21"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/lib": {
-          "version": "13.8.2",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-          "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-          "dev": true,
-          "requires": {
-            "@storybook/csf": "^0.1.0",
-            "lodash": "^4.17.21",
-            "prop-types": "^15.7.2"
-          }
-        }
+        "@leafygreen-ui/emotion": "^5.0.3",
+        "@leafygreen-ui/hooks": "^9.1.4",
+        "@leafygreen-ui/lib": "^15.4.0"
+      }
+    },
+    "@leafygreen-ui/avatar": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/avatar/-/avatar-3.3.0.tgz",
+      "integrity": "sha512-3x4wx40yB0kl224d7HK9AihwJmaZtQU2K2u6MrzJoG+LNp8ptFJ+tHrR2WFXKn5Heo7sKWW9AbD6DuUQp32MvA==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/logo": "^11.1.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "lodash": "^4.17.21"
       }
     },
     "@leafygreen-ui/badge": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/badge/-/badge-8.1.0.tgz",
-      "integrity": "sha512-lbdjkFQd2Gwl7IeiLJKfDg/jg9rDgdPaAfFtQc0DfO/jDhnXG6eoXwWgxVFkIDvdUv8iZQofgZZcdmo3XtppOA==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/badge/-/badge-10.2.4.tgz",
+      "integrity": "sha512-iWciiIrnmlrSOtgq438x7Tg0mYjLd148LeCNFypGpeiyfecZz3XmfCQM4NAydT2zA7Q65kcX7f+Yt+cuCz8Mqg==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.1.4"
-      },
-      "dependencies": {
-        "@leafygreen-ui/lib": {
-          "version": "13.8.2",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-          "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-          "dev": true,
-          "requires": {
-            "@storybook/csf": "^0.1.0",
-            "lodash": "^4.17.21",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        }
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2"
       }
     },
     "@leafygreen-ui/banner": {
-      "version": "7.0.18",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/banner/-/banner-7.0.18.tgz",
-      "integrity": "sha512-EdH40+L6hrq3y1pPayIHawtQXUp9rzZtziDHlKeuUg2AgsSwfQ3WF48H2IP1ADF9I3npHpwMPsO3wGktEMG8lA==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/banner/-/banner-10.2.5.tgz",
+      "integrity": "sha512-CE3Stz4S00kyDqjhfPutJlxxDDdVuynyT/cWpufxhB+a/RvWktRRZL3o3AKPPBwnwzp5e18p+vzAMAilIJ0s0Q==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/icon": "^11.25.1",
-        "@leafygreen-ui/icon-button": "^15.0.19",
-        "@leafygreen-ui/lib": "^13.1.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.1.4",
-        "@leafygreen-ui/typography": "^18.0.0"
-      },
-      "dependencies": {
-        "@leafygreen-ui/lib": {
-          "version": "13.8.2",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-          "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-          "dev": true,
-          "requires": {
-            "@storybook/csf": "^0.1.0",
-            "lodash": "^4.17.21",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/typography": {
-          "version": "18.4.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-18.4.0.tgz",
-          "integrity": "sha512-2pfoBv6jEPupMzT/rciyP6oN53Fc2h0Nl/uXubSRuFcIDwUAE6CIb3+IjK3UNyQrnOixGU4lWQhxIPTrnyxCpQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/icon": "^12.1.0",
-            "@leafygreen-ui/lib": "^13.4.0",
-            "@leafygreen-ui/palette": "^4.0.10",
-            "@leafygreen-ui/polymorphic": "^1.3.7",
-            "@leafygreen-ui/tokens": "^2.5.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/icon": {
-              "version": "12.9.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-              "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-              "dev": true,
-              "requires": {
-                "@leafygreen-ui/emotion": "^4.0.8",
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        }
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4"
       }
     },
-    "@leafygreen-ui/box": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/box/-/box-3.1.9.tgz",
-      "integrity": "sha512-hY05VQKDVhqqBH/Dz1kxonjQmqrMR9URa3Dw3YgdLbVUd1hMQkoWbplamiE4S4vq2+81SQBgNw53i+/Vd0Cl0g==",
-      "dev": true
-    },
     "@leafygreen-ui/button": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/button/-/button-19.0.4.tgz",
-      "integrity": "sha512-T72lmAHS63cvhyAKaO53tNysL3xDsjnmIoaP0I55eOFOYlEy522U7vf0RMi/BsOePyAJak+x9yZ4uj8AWMCsbg==",
+      "version": "25.2.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/button/-/button-25.2.1.tgz",
+      "integrity": "sha512-hJWf4K1WNCSaM1VWj8obGuMAxnd1/KCORnGNqphjBKS83Nu0XYCWedl6rhwQTkpCDzESQYAExw3KJV+moygB/w==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/box": "^3.1.1",
-        "@leafygreen-ui/emotion": "^4.0.3",
-        "@leafygreen-ui/lib": "^10.0.0",
-        "@leafygreen-ui/palette": "^3.4.7",
-        "@leafygreen-ui/ripple": "^1.1.8",
-        "@leafygreen-ui/tokens": "^2.0.0",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/ripple": "^2.0.7",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@lg-tools/test-harnesses": "^0.3.4",
         "polished": "^4.2.2"
-      },
-      "dependencies": {
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            },
-            "@leafygreen-ui/palette": {
-              "version": "4.1.4",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-              "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-              "dev": true
-            }
-          }
-        }
       }
     },
     "@leafygreen-ui/card": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/card/-/card-9.0.9.tgz",
-      "integrity": "sha512-WeQiYUpWctuM8GWWgze1RuKOta+sXfYMEQPidcSIhTJK/9OKCLI4CfvJoH0vJdDlMKJWeozQh75pmYzSeWDfxA==",
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/card/-/card-13.3.1.tgz",
+      "integrity": "sha512-WkH0VbSqy2y959pVQstF4RFF9T31ps+1gl6c7Y8q5Pzt/GEQoUA4y8DvbInrd0RJwyHsIXMV2bbujiMUrh3tvw==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/box": "^3.1.4",
-        "@leafygreen-ui/emotion": "^4.0.4",
-        "@leafygreen-ui/lib": "^10.4.0",
-        "@leafygreen-ui/palette": "^4.0.3",
-        "@leafygreen-ui/tokens": "^2.1.1",
-        "polished": "^4.2.2"
-      },
-      "dependencies": {
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        }
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/tokens": "^4.2.2"
       }
     },
     "@leafygreen-ui/checkbox": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/checkbox/-/checkbox-12.1.0.tgz",
-      "integrity": "sha512-3KaRyKYb9ghXcJcNRP4ZYXgjP9qIe4Ltc5o1HGh7v3TjRyxjlVJ+RwXE5g2mD43vVs3flemcCZD1nc9FgkMq6A==",
+      "version": "18.1.5",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/checkbox/-/checkbox-18.1.5.tgz",
+      "integrity": "sha512-KTvSdlZPY+gmfCuTrRhM+slyGoILzAuVgoXdanneLVDZiD8W3j3t4z69znCYK/tL1pNLin1FaRkO/kpQAkv/DQ==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/a11y": "^1.4.11",
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.0.0",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.2.0",
-        "@leafygreen-ui/typography": "^18.2.0",
+        "@leafygreen-ui/a11y": "^3.0.5",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "@lg-tools/test-harnesses": "^0.3.4",
         "react-transition-group": "^4.4.5"
-      },
-      "dependencies": {
-        "@leafygreen-ui/hooks": {
-          "version": "8.3.6",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-          "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/lib": "^14.1.0",
-            "lodash": "^4.17.21"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/icon": {
-          "version": "12.9.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-          "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "lodash": "^4.17.21"
-          }
-        },
-        "@leafygreen-ui/lib": {
-          "version": "13.8.2",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-          "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-          "dev": true,
-          "requires": {
-            "@storybook/csf": "^0.1.0",
-            "lodash": "^4.17.21",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/typography": {
-          "version": "18.4.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-18.4.0.tgz",
-          "integrity": "sha512-2pfoBv6jEPupMzT/rciyP6oN53Fc2h0Nl/uXubSRuFcIDwUAE6CIb3+IjK3UNyQrnOixGU4lWQhxIPTrnyxCpQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/icon": "^12.1.0",
-            "@leafygreen-ui/lib": "^13.4.0",
-            "@leafygreen-ui/palette": "^4.0.10",
-            "@leafygreen-ui/polymorphic": "^1.3.7",
-            "@leafygreen-ui/tokens": "^2.5.2"
-          }
-        }
+      }
+    },
+    "@leafygreen-ui/chip": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/chip/-/chip-4.2.1.tgz",
+      "integrity": "sha512-xLnRfz01dNwUWrE5074QjlGolq3XboLAvgJrXR+KCkTyLFExVOMCMXTn5nq4mG5v3rnHB6D3BhOLLDm8euTlxA==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/inline-definition": "^9.2.1",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2"
       }
     },
     "@leafygreen-ui/code": {
-      "version": "14.2.18",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/code/-/code-14.2.18.tgz",
-      "integrity": "sha512-vtAEzURQ/Or8G9vBjsjN4aCWoysHr/Ny/3ewEcLRpz66vkC0kplArdnmG5dVSmklzImU4jKa+QOeM74l3DTHUQ==",
+      "version": "20.2.8",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/code/-/code-20.2.8.tgz",
+      "integrity": "sha512-Y9iaaelKP6I7PZskHMPMkg6K5vszhBOc5AQ5BSNoRIzEnaJdOrB9lCNtPzc1sVyp4kL2ryuYyy2Dcv4HwBVVeA==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/a11y": "^1.4.11",
-        "@leafygreen-ui/button": "^21.0.11",
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.0.0",
-        "@leafygreen-ui/icon": "^11.25.1",
-        "@leafygreen-ui/icon-button": "^15.0.19",
-        "@leafygreen-ui/lib": "^13.1.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/select": "^11.0.1",
-        "@leafygreen-ui/tokens": "^2.2.0",
+        "@leafygreen-ui/a11y": "^3.0.5",
+        "@leafygreen-ui/button": "^25.2.1",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.9.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/select": "^17.1.0",
+        "@leafygreen-ui/skeleton-loader": "^3.0.11",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/tooltip": "^14.3.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "@lg-tools/test-harnesses": "^0.3.4",
         "@types/facepaint": "^1.2.1",
         "@types/highlight.js": "^10.1.0",
         "clipboard": "^2.0.6",
@@ -34317,2076 +33448,528 @@
         "highlightjs-graphql": "^1.0.1",
         "lodash": "^4.17.21",
         "polished": "^4.2.2"
-      },
-      "dependencies": {
-        "@leafygreen-ui/button": {
-          "version": "21.3.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/button/-/button-21.3.0.tgz",
-          "integrity": "sha512-v9qipsRWHQBN9sC4RNWmJ/PVQCcYZdg9Wa+k9Q6LFjgahI1/6BXYTZOP4wPJQDp2AG6+dx2CF7Rp60ymM+wtLw==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/box": "^3.1.9",
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/lib": "^13.4.0",
-            "@leafygreen-ui/palette": "^4.0.10",
-            "@leafygreen-ui/ripple": "^1.1.13",
-            "@leafygreen-ui/tokens": "^2.5.2",
-            "@lg-tools/test-harnesses": "^0.1.2",
-            "polished": "^4.2.2"
-          }
-        },
-        "@leafygreen-ui/hooks": {
-          "version": "8.3.6",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-          "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/lib": "^14.1.0",
-            "lodash": "^4.17.21"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/lib": {
-          "version": "13.8.2",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-          "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-          "dev": true,
-          "requires": {
-            "@storybook/csf": "^0.1.0",
-            "lodash": "^4.17.21",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/polymorphic": {
-          "version": "2.0.7",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/polymorphic/-/polymorphic-2.0.7.tgz",
-          "integrity": "sha512-MUw76DT7R7msTDjhqAvZs5dqrt5684fAKm+QhpdzKB9ywh3LCdo9syg/Hva72rDa0fRV5i/V6nYEY8zM1N005A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/lib": "^14.1.0",
-            "lodash": "^4.17.21"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/select": {
-          "version": "11.3.2",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/select/-/select-11.3.2.tgz",
-          "integrity": "sha512-qPAXYibI4UNX+xW7QdspoT+fg9WfkqTwCsD9j27rTyJZ+pR2BOW5oynG5gKnm0AVPWullms5/SdxiLWai1GxNA==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/button": "^21.2.0",
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/hooks": "^8.1.3",
-            "@leafygreen-ui/icon": "^12.1.0",
-            "@leafygreen-ui/input-option": "^1.1.3",
-            "@leafygreen-ui/lib": "^13.4.0",
-            "@leafygreen-ui/palette": "^4.0.10",
-            "@leafygreen-ui/popover": "^11.3.1",
-            "@leafygreen-ui/tokens": "^2.5.2",
-            "@leafygreen-ui/typography": "^19.0.0",
-            "@lg-tools/test-harnesses": "^0.1.2",
-            "@types/react-is": "^18.0.0",
-            "lodash": "^4.17.21",
-            "polished": "^4.1.3",
-            "react-is": "^18.0.1"
-          },
-          "dependencies": {
-            "@leafygreen-ui/icon": {
-              "version": "12.9.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-              "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-              "dev": true,
-              "requires": {
-                "@leafygreen-ui/emotion": "^4.0.8",
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/typography": {
-          "version": "19.3.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-19.3.0.tgz",
-          "integrity": "sha512-pgTRcc4usW/S9nDDzkf5Ac/JPEybhWtOnDpmrp99mAJHM6tH48Pd1HjRNHWjn6bnh0nXWjwANXX1ZEe+8ggCNg==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/icon": "^12.6.0",
-            "@leafygreen-ui/lib": "^13.6.1",
-            "@leafygreen-ui/palette": "^4.0.10",
-            "@leafygreen-ui/polymorphic": "^2.0.0",
-            "@leafygreen-ui/tokens": "^2.9.0"
-          },
-          "dependencies": {
-            "@leafygreen-ui/icon": {
-              "version": "12.9.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-              "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-              "dev": true,
-              "requires": {
-                "@leafygreen-ui/emotion": "^4.0.8",
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "react-is": {
-          "version": "18.3.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-          "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-          "dev": true
-        }
       }
     },
-    "@leafygreen-ui/confirmation-modal": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/confirmation-modal/-/confirmation-modal-4.0.10.tgz",
-      "integrity": "sha512-shnFII39bPmFuhWl4wZJn5eAok3GhxrUyffjDVZV7JsWNVJftZeYtqao/YAePgytr6Gwpc+7FcZSzwXk2RWwzw==",
+    "@leafygreen-ui/combobox": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/combobox/-/combobox-12.5.1.tgz",
+      "integrity": "sha512-Wf78P44DHq+19b+LLIbFnfF2zTlhuo0kgrCDnm9QcqYwIzyWDHLx2bOQslfpj0Xbm3oFYMIOChnUNK5kHON8Aw==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/button": "^20.2.1",
-        "@leafygreen-ui/emotion": "^4.0.4",
-        "@leafygreen-ui/icon": "^11.17.0",
-        "@leafygreen-ui/modal": "^15.0.3",
-        "@leafygreen-ui/palette": "^4.0.3",
-        "@leafygreen-ui/text-input": "^12.1.14",
-        "@leafygreen-ui/tokens": "^2.1.1",
-        "@leafygreen-ui/typography": "^16.5.1"
-      },
-      "dependencies": {
-        "@leafygreen-ui/button": {
-          "version": "20.3.1",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/button/-/button-20.3.1.tgz",
-          "integrity": "sha512-uyy4o6WhRmwaDBt45qOUs/EC4QB4J36T7Hb7sidGQyetx8BU0VPigR4cnSAes0Ye95KyG5y7y/PgX2+Ab45K1g==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/box": "^3.1.4",
-            "@leafygreen-ui/emotion": "^4.0.4",
-            "@leafygreen-ui/lib": "^10.4.0",
-            "@leafygreen-ui/palette": "^4.0.4",
-            "@leafygreen-ui/ripple": "^1.1.9",
-            "@leafygreen-ui/tokens": "^2.1.1",
-            "polished": "^4.2.2"
-          }
-        },
-        "@leafygreen-ui/modal": {
-          "version": "15.0.6",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/modal/-/modal-15.0.6.tgz",
-          "integrity": "sha512-GJ4SEwKQ1NU8xm1P/KJvRfCZVD0yZrXtI1xh0Lay/w4wy4XCAYwIUHm2sV2ydrGLd2VeCT1onflJsZDLU6MrOw==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.7",
-            "@leafygreen-ui/hooks": "^7.7.8",
-            "@leafygreen-ui/icon": "^11.22.1",
-            "@leafygreen-ui/icon-button": "^15.0.16",
-            "@leafygreen-ui/lib": "^10.4.3",
-            "@leafygreen-ui/palette": "^4.0.7",
-            "@leafygreen-ui/portal": "^4.1.7",
-            "@leafygreen-ui/tokens": "^2.1.4",
-            "focus-trap-react": "^8.10.0",
-            "polished": "^4.2.2",
-            "prop-types": "^15.8.1",
-            "react-transition-group": "^4.4.1"
-          }
-        },
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/typography": {
-          "version": "16.5.5",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-16.5.5.tgz",
-          "integrity": "sha512-mErhTYM0C1PZaeADTkp5v/MAS6aEhavWHZ3otHthBSo/zwI5uAYnkreheiYElc66B/0bcOxCikLVkP3zaFnX2A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.7",
-            "@leafygreen-ui/icon": "^11.22.2",
-            "@leafygreen-ui/lib": "^11.0.0",
-            "@leafygreen-ui/palette": "^4.0.7",
-            "@leafygreen-ui/polymorphic": "^1.3.6",
-            "@leafygreen-ui/tokens": "^2.1.4"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "11.0.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-11.0.0.tgz",
-              "integrity": "sha512-sHkY/MOwRQDc9qAR1awreW0dP+6ELueJJd4JCJmi6XYbdL0wDotFwsWfCwkL+N6cFbE1e+xBQtFLB6T1+58+iQ==",
-              "dev": true,
-              "requires": {
-                "@storybook/csf": "^0.1.0",
-                "lodash": "^4.17.21",
-                "prop-types": "^15.7.2"
-              }
-            }
-          }
-        }
+        "@leafygreen-ui/checkbox": "^18.1.5",
+        "@leafygreen-ui/chip": "^4.2.1",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/form-field": "^4.0.9",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/input-option": "^4.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/popover": "^14.3.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "chalk": "^4.1.2",
+        "lodash": "^4.17.21",
+        "polished": "^4.2.2"
+      }
+    },
+    "@leafygreen-ui/compound-component": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/compound-component/-/compound-component-0.3.0.tgz",
+      "integrity": "sha512-gTso3f6nOHIgz9zCIl7AqO9lhFzGcJHPjuh2IahM27PXBRdNXOdjhx8T0WywC5RLLhHOy7eDXZubkBdiii0qDA==",
+      "dev": true
+    },
+    "@leafygreen-ui/confirmation-modal": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/confirmation-modal/-/confirmation-modal-11.0.1.tgz",
+      "integrity": "sha512-crYjy/qqEb5cMNuh1zdl6X0GN2V3wGSdo6n7qaTnRFlpaI1waWIDCGwhj+GxlyacNKqUHCTuvhU0xafyqX+p6A==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/button": "^25.2.1",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/modal": "^22.0.1",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/text-input": "^16.2.3",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4"
+      }
+    },
+    "@leafygreen-ui/copyable": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/copyable/-/copyable-12.0.3.tgz",
+      "integrity": "sha512-BVhRh/HZbOMHIAA1lRzzl6UH1L9Uu2gokq9v1EOTl9/95QdkpYs/lUA/VwKjhYM0RNQPY4rSoWjhqC7HzrN6/A==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/button": "^25.2.1",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/tooltip": "^14.3.1",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "clipboard": "^2.0.6",
+        "polished": "^4.2.2"
+      }
+    },
+    "@leafygreen-ui/descendants": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/descendants/-/descendants-3.1.1.tgz",
+      "integrity": "sha512-A4IdIaUpyzQl7vFdqPxuBuO7GRwx8pFKf4OVQ7v8DXF0qLl508cu1T8oeb5p6elHk8xS3DT/CEVCMrEQt9dDzQ==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "lodash": "^4.17.21"
+      }
+    },
+    "@leafygreen-ui/drawer": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/drawer/-/drawer-5.2.3.tgz",
+      "integrity": "sha512-H3lYN0xyZzYUwwl7LaJh75Flmhx7xVC7Q7RITN28aAN+NDIe5LPHbfPusqVs6/lT0Mb39XCYwAqoR5/HQAqSww==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/button": "^25.2.1",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/resizable": "^0.1.3",
+        "@leafygreen-ui/tabs": "^17.0.11",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/toolbar": "^1.3.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "@lg-tools/test-harnesses": "^0.3.4",
+        "polished": "^4.2.2",
+        "react-intersection-observer": "^8.25.1"
       }
     },
     "@leafygreen-ui/emotion": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-4.0.10.tgz",
-      "integrity": "sha512-6fW0jXce40N+ZtJIomvpROrJar6h1S9TAwHSfHVJmCRB791s5hATxudiD+aE6gqYUL+naiDQc/XKy7I3LUK+hA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-5.2.0.tgz",
+      "integrity": "sha512-Sov+2tDy4ahGsRR8/KOV8Zzx+5fvVAj7Smyc1brgzE8ocXnOiwahQQ1wVvthAXS91iXPpnuNA5KL6Qzh3jNfQw==",
       "dev": true,
       "requires": {
         "@emotion/css": "^11.1.3",
+        "@emotion/react": "^11.14.0",
         "@emotion/server": "^11.4.0"
       }
     },
     "@leafygreen-ui/form-field": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/form-field/-/form-field-0.3.2.tgz",
-      "integrity": "sha512-s3aLK0NzYcMIjQUs5WHihpjH7QI19sH4BW1pRvWlA2T48NLy3gAtayZo8+Y+EsNCtu91Kc1qK705WHzx8i+Wnw==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/form-field/-/form-field-4.0.9.tgz",
+      "integrity": "sha512-lbFkP1Hh0cwUxPsatGjSCcDGt4nqDrJ5jWozwhljWbdQF74H9LG+HdVr9FALiLHeDm+47NbmTUQj+hOl4DD5aw==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.1.1",
-        "@leafygreen-ui/icon": "^11.27.1",
-        "@leafygreen-ui/lib": "^13.2.1",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.3.0",
-        "@leafygreen-ui/typography": "^18.1.0"
-      },
-      "dependencies": {
-        "@leafygreen-ui/hooks": {
-          "version": "8.3.6",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-          "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/lib": "^14.1.0",
-            "lodash": "^4.17.21"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/lib": {
-          "version": "13.8.2",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-          "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-          "dev": true,
-          "requires": {
-            "@storybook/csf": "^0.1.0",
-            "lodash": "^4.17.21",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/typography": {
-          "version": "18.4.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-18.4.0.tgz",
-          "integrity": "sha512-2pfoBv6jEPupMzT/rciyP6oN53Fc2h0Nl/uXubSRuFcIDwUAE6CIb3+IjK3UNyQrnOixGU4lWQhxIPTrnyxCpQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/icon": "^12.1.0",
-            "@leafygreen-ui/lib": "^13.4.0",
-            "@leafygreen-ui/palette": "^4.0.10",
-            "@leafygreen-ui/polymorphic": "^1.3.7",
-            "@leafygreen-ui/tokens": "^2.5.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/icon": {
-              "version": "12.9.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-              "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-              "dev": true,
-              "requires": {
-                "@leafygreen-ui/emotion": "^4.0.8",
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        }
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4"
       }
     },
     "@leafygreen-ui/guide-cue": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/guide-cue/-/guide-cue-4.0.12.tgz",
-      "integrity": "sha512-OhmTuJPSExiAt/5/BB2UmmxywtcpX8Hb1EBjiG9W1vvhWWI2ielHapLvOzRkm1UbFasvzTxLCArW6BbiSbUn5w==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/guide-cue/-/guide-cue-8.2.0.tgz",
+      "integrity": "sha512-YDNcu+DA4aOE9QxI/TujT/v7h0YXz07rQpBcrew+7dIhDp3NcuNLN39SYegz5Gi6br+rhEQh8n7dowBHhVM6iw==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/a11y": "^1.4.7",
-        "@leafygreen-ui/button": "^21.0.3",
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^7.7.8",
-        "@leafygreen-ui/icon": "^11.22.1",
-        "@leafygreen-ui/icon-button": "^15.0.16",
-        "@leafygreen-ui/lib": "^10.4.3",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/popover": "^11.0.15",
-        "@leafygreen-ui/tooltip": "^10.0.7",
-        "@leafygreen-ui/typography": "^16.5.4",
-        "focus-trap-react": "^10.0.0",
+        "@leafygreen-ui/a11y": "^3.0.5",
+        "@leafygreen-ui/button": "^25.1.3",
+        "@leafygreen-ui/emotion": "^5.1.0",
+        "@leafygreen-ui/hooks": "^9.3.0",
+        "@leafygreen-ui/icon": "^14.7.1",
+        "@leafygreen-ui/icon-button": "^17.1.4",
+        "@leafygreen-ui/lib": "^15.6.2",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/popover": "^14.3.1",
+        "@leafygreen-ui/tooltip": "^14.3.0",
+        "@leafygreen-ui/typography": "^22.2.3",
+        "focus-trap": "6.9.4",
+        "focus-trap-react": "9.0.2",
         "polished": "^4.2.2"
-      },
-      "dependencies": {
-        "@leafygreen-ui/button": {
-          "version": "21.3.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/button/-/button-21.3.0.tgz",
-          "integrity": "sha512-v9qipsRWHQBN9sC4RNWmJ/PVQCcYZdg9Wa+k9Q6LFjgahI1/6BXYTZOP4wPJQDp2AG6+dx2CF7Rp60ymM+wtLw==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/box": "^3.1.9",
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/lib": "^13.4.0",
-            "@leafygreen-ui/palette": "^4.0.10",
-            "@leafygreen-ui/ripple": "^1.1.13",
-            "@leafygreen-ui/tokens": "^2.5.2",
-            "@lg-tools/test-harnesses": "^0.1.2",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "13.8.2",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-              "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-              "dev": true,
-              "requires": {
-                "@storybook/csf": "^0.1.0",
-                "lodash": "^4.17.21",
-                "prop-types": "^15.7.2"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/tooltip": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tooltip/-/tooltip-10.1.0.tgz",
-          "integrity": "sha512-jgrETmJveRDzDtz1qYI18Pkc53XGp/38l10MWPl8mv+/ahCCgNED2idmCjCwJ3/ju14t6ASSzs0SuH1jokNcAA==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.7",
-            "@leafygreen-ui/hooks": "^8.0.0",
-            "@leafygreen-ui/icon": "^11.23.0",
-            "@leafygreen-ui/lib": "^13.0.0",
-            "@leafygreen-ui/palette": "^4.0.7",
-            "@leafygreen-ui/popover": "^11.1.1",
-            "@leafygreen-ui/tokens": "^2.2.0",
-            "@leafygreen-ui/typography": "^18.0.0",
-            "lodash": "^4.17.21",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/hooks": {
-              "version": "8.3.6",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-              "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-              "dev": true,
-              "requires": {
-                "@leafygreen-ui/lib": "^14.1.0",
-                "lodash": "^4.17.21"
-              },
-              "dependencies": {
-                "@leafygreen-ui/lib": {
-                  "version": "14.1.0",
-                  "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-                  "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-                  "dev": true,
-                  "requires": {
-                    "lodash": "^4.17.21"
-                  }
-                }
-              }
-            },
-            "@leafygreen-ui/lib": {
-              "version": "13.8.2",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-              "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-              "dev": true,
-              "requires": {
-                "@storybook/csf": "^0.1.0",
-                "lodash": "^4.17.21",
-                "prop-types": "^15.7.2"
-              }
-            },
-            "@leafygreen-ui/typography": {
-              "version": "18.4.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-18.4.0.tgz",
-              "integrity": "sha512-2pfoBv6jEPupMzT/rciyP6oN53Fc2h0Nl/uXubSRuFcIDwUAE6CIb3+IjK3UNyQrnOixGU4lWQhxIPTrnyxCpQ==",
-              "dev": true,
-              "requires": {
-                "@leafygreen-ui/emotion": "^4.0.8",
-                "@leafygreen-ui/icon": "^12.1.0",
-                "@leafygreen-ui/lib": "^13.4.0",
-                "@leafygreen-ui/palette": "^4.0.10",
-                "@leafygreen-ui/polymorphic": "^1.3.7",
-                "@leafygreen-ui/tokens": "^2.5.2"
-              },
-              "dependencies": {
-                "@leafygreen-ui/icon": {
-                  "version": "12.9.0",
-                  "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-                  "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-                  "dev": true,
-                  "requires": {
-                    "@leafygreen-ui/emotion": "^4.0.8",
-                    "lodash": "^4.17.21"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/typography": {
-          "version": "16.5.5",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-16.5.5.tgz",
-          "integrity": "sha512-mErhTYM0C1PZaeADTkp5v/MAS6aEhavWHZ3otHthBSo/zwI5uAYnkreheiYElc66B/0bcOxCikLVkP3zaFnX2A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.7",
-            "@leafygreen-ui/icon": "^11.22.2",
-            "@leafygreen-ui/lib": "^11.0.0",
-            "@leafygreen-ui/palette": "^4.0.7",
-            "@leafygreen-ui/polymorphic": "^1.3.6",
-            "@leafygreen-ui/tokens": "^2.1.4"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "11.0.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-11.0.0.tgz",
-              "integrity": "sha512-sHkY/MOwRQDc9qAR1awreW0dP+6ELueJJd4JCJmi6XYbdL0wDotFwsWfCwkL+N6cFbE1e+xBQtFLB6T1+58+iQ==",
-              "dev": true,
-              "requires": {
-                "@storybook/csf": "^0.1.0",
-                "lodash": "^4.17.21",
-                "prop-types": "^15.7.2"
-              }
-            }
-          }
-        },
-        "focus-trap": {
-          "version": "7.6.4",
-          "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.4.tgz",
-          "integrity": "sha512-xx560wGBk7seZ6y933idtjJQc1l+ck+pI3sKvhKozdBV1dRZoKhkW5xoCaFv9tQiX5RH1xfSxjuNu6g+lmN/gw==",
-          "dev": true,
-          "requires": {
-            "tabbable": "^6.2.0"
-          }
-        },
-        "focus-trap-react": {
-          "version": "10.3.1",
-          "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-10.3.1.tgz",
-          "integrity": "sha512-PN4Ya9xf9nyj/Nd9VxBNMuD7IrlRbmaG6POAQ8VLqgtc6IY/Ln1tYakow+UIq4fihYYYFM70/2oyidE6bbiPgw==",
-          "dev": true,
-          "requires": {
-            "focus-trap": "^7.6.1",
-            "tabbable": "^6.2.0"
-          }
-        },
-        "tabbable": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-          "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
-          "dev": true
-        }
       }
     },
     "@leafygreen-ui/hooks": {
-      "version": "7.7.8",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
-      "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-9.3.1.tgz",
+      "integrity": "sha512-KGJa5GoZ/crA1e0MRnJaadqXP5Gyn5VlLBkPyizFTe1dnlrp2OUnNEeb/TWKytT67sewNjOKqjBr0TG5YJQeJQ==",
       "dev": true,
       "requires": {
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/tokens": "^4.2.2",
         "lodash": "^4.17.21"
       }
     },
     "@leafygreen-ui/icon": {
-      "version": "11.29.1",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-11.29.1.tgz",
-      "integrity": "sha512-bCfeJ3mndU5wHayMWfkVWo0NXhPpBpHIG53aox/eRterqLvWg6jWyiuF930MHbyWDNEXC9Qw1WD637kZ93mmog==",
+      "version": "14.9.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-14.9.0.tgz",
+      "integrity": "sha512-moH8z8Qkd0uO03MO2ttpSo+2nkMfFvNvJ1t1Z4a1nUVSg+xE+c6oiwrNyvhUwrTsbSHUAQr9h+Nld1LTsRsVKw==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
         "lodash": "^4.17.21"
       }
     },
     "@leafygreen-ui/icon-button": {
-      "version": "15.0.19",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon-button/-/icon-button-15.0.19.tgz",
-      "integrity": "sha512-TXNFHpfuMXIcMQHW/D31GEFby63qhBLyeI5CLL8KQjD5Xom3Q6fqviu/eyXE097jTzQtd1dO/2IIiqyyLRW30g==",
+      "version": "17.1.5",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon-button/-/icon-button-17.1.5.tgz",
+      "integrity": "sha512-fTxvykvM1mWZ2cFgwBzvuC0WXY1gJ2kyWWRIUOu24eRTJLwoobzhOF1uF6rBm/DOfhcNDh0dsXJfatdj/lqQXA==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/a11y": "^1.4.11",
-        "@leafygreen-ui/box": "^3.1.8",
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/icon": "^11.22.2",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.1.4"
-      },
-      "dependencies": {
-        "@leafygreen-ui/lib": {
-          "version": "13.8.2",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-          "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-          "dev": true,
-          "requires": {
-            "@storybook/csf": "^0.1.0",
-            "lodash": "^4.17.21",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        }
+        "@leafygreen-ui/a11y": "^3.0.5",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "polished": "^4.2.2"
       }
     },
     "@leafygreen-ui/info-sprinkle": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/info-sprinkle/-/info-sprinkle-1.0.2.tgz",
-      "integrity": "sha512-SWab7+ljlNQQML6f2t2VOnp2JtZjcJ+KcZcVHUikjt7gYnS6+YtK9MEwZOFsLue6IchaJgPNsVA+Fm+e/PjSuQ==",
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/info-sprinkle/-/info-sprinkle-5.0.11.tgz",
+      "integrity": "sha512-ne4CE9xO6tsaac6hhVtKZzjfPXXgLJ//VIShczNc6ibd+pNtDtGg+FkNgcRVkJ2MyXg5qEErqxv5nn+l6eQhtQ==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/icon": "^11.25.0",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.2.0",
-        "@leafygreen-ui/tooltip": "^11.0.0"
-      },
-      "dependencies": {
-        "@leafygreen-ui/hooks": {
-          "version": "8.3.6",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-          "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/lib": "^14.1.0",
-            "lodash": "^4.17.21"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/lib": {
-          "version": "13.8.2",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-          "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-          "dev": true,
-          "requires": {
-            "@storybook/csf": "^0.1.0",
-            "lodash": "^4.17.21",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/polymorphic": {
-          "version": "2.0.7",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/polymorphic/-/polymorphic-2.0.7.tgz",
-          "integrity": "sha512-MUw76DT7R7msTDjhqAvZs5dqrt5684fAKm+QhpdzKB9ywh3LCdo9syg/Hva72rDa0fRV5i/V6nYEY8zM1N005A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/lib": "^14.1.0",
-            "lodash": "^4.17.21"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/tooltip": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tooltip/-/tooltip-11.1.0.tgz",
-          "integrity": "sha512-nVIirNqBShuj25u9koOPAVYpqGWKSDe/rsdRyPWZLeL9rLfbtZi9Xn44HeDX7brVo+KBkE29Gsuh1Y3J7LN5ng==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/hooks": "^8.1.3",
-            "@leafygreen-ui/icon": "^12.5.0",
-            "@leafygreen-ui/lib": "^13.5.0",
-            "@leafygreen-ui/palette": "^4.0.9",
-            "@leafygreen-ui/popover": "^11.4.0",
-            "@leafygreen-ui/tokens": "^2.8.0",
-            "@leafygreen-ui/typography": "^19.0.0",
-            "lodash": "^4.17.21",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/icon": {
-              "version": "12.9.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-              "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-              "dev": true,
-              "requires": {
-                "@leafygreen-ui/emotion": "^4.0.8",
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/typography": {
-          "version": "19.3.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-19.3.0.tgz",
-          "integrity": "sha512-pgTRcc4usW/S9nDDzkf5Ac/JPEybhWtOnDpmrp99mAJHM6tH48Pd1HjRNHWjn6bnh0nXWjwANXX1ZEe+8ggCNg==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/icon": "^12.6.0",
-            "@leafygreen-ui/lib": "^13.6.1",
-            "@leafygreen-ui/palette": "^4.0.10",
-            "@leafygreen-ui/polymorphic": "^2.0.0",
-            "@leafygreen-ui/tokens": "^2.9.0"
-          },
-          "dependencies": {
-            "@leafygreen-ui/icon": {
-              "version": "12.9.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-              "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-              "dev": true,
-              "requires": {
-                "@leafygreen-ui/emotion": "^4.0.8",
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        }
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/tooltip": "^14.3.1"
       }
     },
     "@leafygreen-ui/inline-definition": {
-      "version": "6.0.14",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/inline-definition/-/inline-definition-6.0.14.tgz",
-      "integrity": "sha512-vCfSF1Lr8O4sm8f7w9rTflVyJRjF3Tyrtppr9OSfEPTDDlla+tiuSyvrMUty3xfdomc6JEGyumdozvjyU9dFsg==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/inline-definition/-/inline-definition-9.2.1.tgz",
+      "integrity": "sha512-AUDjEvyI9QizDSoew9uqjidoBJ8L88FWPhgzN+ixSo5B4EcwT7Ig52P82thfazdfb2RQUQz0/ajkEnoHFPLy9Q==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tooltip": "^11.0.0"
-      },
-      "dependencies": {
-        "@leafygreen-ui/hooks": {
-          "version": "8.3.6",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-          "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/lib": "^14.1.0",
-            "lodash": "^4.17.21"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/icon": {
-          "version": "12.9.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-          "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "lodash": "^4.17.21"
-          }
-        },
-        "@leafygreen-ui/lib": {
-          "version": "13.8.2",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-          "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-          "dev": true,
-          "requires": {
-            "@storybook/csf": "^0.1.0",
-            "lodash": "^4.17.21",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/polymorphic": {
-          "version": "2.0.7",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/polymorphic/-/polymorphic-2.0.7.tgz",
-          "integrity": "sha512-MUw76DT7R7msTDjhqAvZs5dqrt5684fAKm+QhpdzKB9ywh3LCdo9syg/Hva72rDa0fRV5i/V6nYEY8zM1N005A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/lib": "^14.1.0",
-            "lodash": "^4.17.21"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/tooltip": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tooltip/-/tooltip-11.1.0.tgz",
-          "integrity": "sha512-nVIirNqBShuj25u9koOPAVYpqGWKSDe/rsdRyPWZLeL9rLfbtZi9Xn44HeDX7brVo+KBkE29Gsuh1Y3J7LN5ng==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/hooks": "^8.1.3",
-            "@leafygreen-ui/icon": "^12.5.0",
-            "@leafygreen-ui/lib": "^13.5.0",
-            "@leafygreen-ui/palette": "^4.0.9",
-            "@leafygreen-ui/popover": "^11.4.0",
-            "@leafygreen-ui/tokens": "^2.8.0",
-            "@leafygreen-ui/typography": "^19.0.0",
-            "lodash": "^4.17.21",
-            "polished": "^4.2.2"
-          }
-        },
-        "@leafygreen-ui/typography": {
-          "version": "19.3.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-19.3.0.tgz",
-          "integrity": "sha512-pgTRcc4usW/S9nDDzkf5Ac/JPEybhWtOnDpmrp99mAJHM6tH48Pd1HjRNHWjn6bnh0nXWjwANXX1ZEe+8ggCNg==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/icon": "^12.6.0",
-            "@leafygreen-ui/lib": "^13.6.1",
-            "@leafygreen-ui/palette": "^4.0.10",
-            "@leafygreen-ui/polymorphic": "^2.0.0",
-            "@leafygreen-ui/tokens": "^2.9.0"
-          }
-        }
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/tooltip": "^14.3.1"
       }
     },
     "@leafygreen-ui/input-option": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/input-option/-/input-option-1.1.4.tgz",
-      "integrity": "sha512-tti2719MBIId67OwbAnXXm71kqDRGa6Xjiy2cCVWL0au6rYpcm7RXio9J6KZyk4aUvHGu3f6jMNKQgifapvSlw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/input-option/-/input-option-4.1.5.tgz",
+      "integrity": "sha512-cYwx1uVrnev4ZIEYU8k08OAOUwe+dlUVrZh1aRoyXiOYx8LVw3N1C1bKxzW6dgwipPxloQa0RLIOwoqC0qkbQw==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/a11y": "^1.4.13",
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/lib": "^13.6.0",
-        "@leafygreen-ui/palette": "^4.0.9",
-        "@leafygreen-ui/polymorphic": "^2.0.0",
-        "@leafygreen-ui/tokens": "^2.9.0",
-        "@leafygreen-ui/typography": "^19.2.0"
-      },
-      "dependencies": {
-        "@leafygreen-ui/icon": {
-          "version": "12.9.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-          "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "lodash": "^4.17.21"
-          }
-        },
-        "@leafygreen-ui/lib": {
-          "version": "13.8.2",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-          "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-          "dev": true,
-          "requires": {
-            "@storybook/csf": "^0.1.0",
-            "lodash": "^4.17.21",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/polymorphic": {
-          "version": "2.0.7",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/polymorphic/-/polymorphic-2.0.7.tgz",
-          "integrity": "sha512-MUw76DT7R7msTDjhqAvZs5dqrt5684fAKm+QhpdzKB9ywh3LCdo9syg/Hva72rDa0fRV5i/V6nYEY8zM1N005A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/lib": "^14.1.0",
-            "lodash": "^4.17.21"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/typography": {
-          "version": "19.3.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-19.3.0.tgz",
-          "integrity": "sha512-pgTRcc4usW/S9nDDzkf5Ac/JPEybhWtOnDpmrp99mAJHM6tH48Pd1HjRNHWjn6bnh0nXWjwANXX1ZEe+8ggCNg==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/icon": "^12.6.0",
-            "@leafygreen-ui/lib": "^13.6.1",
-            "@leafygreen-ui/palette": "^4.0.10",
-            "@leafygreen-ui/polymorphic": "^2.0.0",
-            "@leafygreen-ui/tokens": "^2.9.0"
-          }
-        }
+        "@leafygreen-ui/a11y": "^3.0.5",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4"
       }
     },
     "@leafygreen-ui/leafygreen-provider": {
-      "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-3.1.11.tgz",
-      "integrity": "sha512-xRwZjchRcvtpbkrLAxuHDl5MPgdi6J7ErVyeeP8k6+y7yTdaaAu8j8bbiacASwpOJdX5Q2XNl2pJ8gzC2PgyRA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-5.0.4.tgz",
+      "integrity": "sha512-VDlmjTiIqlITVhq4VKUDq8FLySWnHkTxSV2n1sxOanLNPuatOXjxsPmCkPUBXhmQKk/fBf4yQnDKOwJvkyzE6Q==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/hooks": "^8.1.0",
-        "@leafygreen-ui/lib": "^13.2.0"
-      },
-      "dependencies": {
-        "@leafygreen-ui/hooks": {
-          "version": "8.3.6",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-          "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/lib": "^14.1.0",
-            "lodash": "^4.17.21"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/lib": {
-          "version": "13.8.2",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-          "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-          "dev": true,
-          "requires": {
-            "@storybook/csf": "^0.1.0",
-            "lodash": "^4.17.21",
-            "prop-types": "^15.7.2"
-          }
-        }
+        "@leafygreen-ui/hooks": "^9.1.3",
+        "@leafygreen-ui/lib": "^15.3.0",
+        "react-transition-group": "^4.4.5"
       }
     },
     "@leafygreen-ui/lib": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-10.4.3.tgz",
-      "integrity": "sha512-p5BtXHeQsvLnnrN0eunPFZeaMtW9z7Mbvm2WOS9lvnAySj8xZp5Vn9Y3XjyYLbPhpGVBhhOAJFP3YMxbP9DKgg==",
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-15.7.0.tgz",
+      "integrity": "sha512-qHv7oN2uN7ywdG9lUN/ayFJzzgJELLgNxIo24m64Sl9c8gSWQeCW+NDj3ukoNVH7ME7QPoULseNd1fElonH8Vg==",
       "dev": true,
       "requires": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
+        "lodash": "^4.17.21"
+      }
+    },
+    "@leafygreen-ui/loading-indicator": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/loading-indicator/-/loading-indicator-5.1.1.tgz",
+      "integrity": "sha512-ZXAupHOjv3++yo0hiGhHfNC4YjwP9FByrMj6zfjGFGL3WfFb+vvdpqK6/KYSawKyh0HBy7yvpUc6Eibk/APceg==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "@lg-tools/test-harnesses": "^0.3.4",
+        "react-lottie-player": "^1.5.6"
       }
     },
     "@leafygreen-ui/logo": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/logo/-/logo-7.0.2.tgz",
-      "integrity": "sha512-VJGIpOFP0I9QSe4HiyiSHhgFBUlU4NibXgbPyeAK60x+i/TEOc4WoXtNfdyB1oSjiVXYTpYPrkKvPrCWbRg1AA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/logo/-/logo-11.1.0.tgz",
+      "integrity": "sha512-UupcGGmtfIXvuXEpJ5h/uvaqExJEXELyxj7VRSAB1JShmaNopRqoNcwfANxtKZ60nFtmBaSz6ix6xc4/gdSK2w==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/emotion": "^4.0.3",
-        "@leafygreen-ui/lib": "^10.1.0",
-        "@leafygreen-ui/palette": "^3.4.5"
+        "@leafygreen-ui/emotion": "^5.0.3",
+        "@leafygreen-ui/lib": "^15.6.1",
+        "@leafygreen-ui/palette": "^5.0.2"
       }
     },
     "@leafygreen-ui/marketing-modal": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/marketing-modal/-/marketing-modal-3.0.10.tgz",
-      "integrity": "sha512-9WGa/HXvdHsdqTuKKXefe2XV+/73rIj8zzMsx0dcUILYxGMllHZDH/X80B1qA39GyqaGX8SLv/g2vmlF7jXbqw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/marketing-modal/-/marketing-modal-8.2.1.tgz",
+      "integrity": "sha512-3G/9f9gMVRbQTl5B7YlTszfQ8MbkuYnpAVVF1Jhu70nmoTnjd01cZ38D4ky2/4t13cApfWY9uIQ/IerNOZV+6A==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/button": "^19.0.0",
-        "@leafygreen-ui/emotion": "^4.0.3",
-        "@leafygreen-ui/modal": "^12.0.0",
-        "@leafygreen-ui/palette": "^3.4.4",
-        "@leafygreen-ui/tokens": "^1.3.4",
-        "@leafygreen-ui/typography": "^15.0.0"
-      },
-      "dependencies": {
-        "@leafygreen-ui/modal": {
-          "version": "12.0.1",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/modal/-/modal-12.0.1.tgz",
-          "integrity": "sha512-GIJGf4ys2n8TuU8rFEHa0juv3gE1JBf395v3gDNmimVZr/zkDTgcK6t8vWJ7PbCH9nX9s4BWUI7Ng6w2h7qTZw==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.3",
-            "@leafygreen-ui/hooks": "^7.3.3",
-            "@leafygreen-ui/icon": "^11.12.1",
-            "@leafygreen-ui/icon-button": "^15.0.1",
-            "@leafygreen-ui/lib": "^10.0.0",
-            "@leafygreen-ui/palette": "^3.4.4",
-            "@leafygreen-ui/portal": "^4.0.7",
-            "@leafygreen-ui/tokens": "^1.4.0",
-            "facepaint": "^1.2.1",
-            "focus-trap-react": "^8.10.0",
-            "polished": "^4.2.2",
-            "prop-types": "^15.8.1",
-            "react-transition-group": "^4.4.1"
-          }
-        }
+        "@leafygreen-ui/button": "^25.2.1",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/modal": "^22.0.1",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4"
       }
     },
     "@leafygreen-ui/menu": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/menu/-/menu-19.0.4.tgz",
-      "integrity": "sha512-baTyt2sAAKNQQGd8GihYQOWeWZq1hr9isOcRxEkl73h6a3D1JeKsje6gHCR8d/heSpVDkFQf9+yL0Jxp3rExgw==",
+      "version": "33.2.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/menu/-/menu-33.2.1.tgz",
+      "integrity": "sha512-nCcWKgEgEgJj1AYPmoF79NqtwsupMhaFhDvr8ITESOsP+ihlttpX4eTtl09SzM2Bj8ghQR+l8mXuc0xxYC16tw==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/box": "^3.1.1",
-        "@leafygreen-ui/emotion": "^4.0.3",
-        "@leafygreen-ui/hooks": "^7.3.3",
-        "@leafygreen-ui/icon": "^11.12.4",
-        "@leafygreen-ui/icon-button": "^15.0.4",
-        "@leafygreen-ui/lib": "^10.0.0",
-        "@leafygreen-ui/palette": "^3.4.7",
-        "@leafygreen-ui/popover": "^11.0.4",
-        "@leafygreen-ui/tokens": "^2.0.0",
+        "@leafygreen-ui/descendants": "^3.1.0",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/input-option": "^4.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/popover": "^14.3.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
         "lodash": "^4.17.21",
-        "react-transition-group": "^4.4.1"
-      },
-      "dependencies": {
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            },
-            "@leafygreen-ui/palette": {
-              "version": "4.1.4",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-              "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-              "dev": true
-            }
-          }
-        }
+        "polished": "^4.3.1",
+        "react-transition-group": "^4.4.5"
       }
     },
     "@leafygreen-ui/modal": {
-      "version": "14.0.5",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/modal/-/modal-14.0.5.tgz",
-      "integrity": "sha512-7zrBZSdf4P8OWeUxxFRLgSZhh/V7REbkXJrpqb/JK2fclU161ZeT2SLLdFKfnjQqf4n3eOVrlDsxy8xwwZ769Q==",
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/modal/-/modal-22.0.1.tgz",
+      "integrity": "sha512-hBKBPDr/btuiA1xqVe1aCxxdFucxzJOh8dT2tvzrvReVJtDvTe2RrdZjHoLX6dCX2E+876euCh3cMpuMgWeUyw==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/emotion": "^4.0.4",
-        "@leafygreen-ui/hooks": "^7.7.1",
-        "@leafygreen-ui/icon": "^11.13.1",
-        "@leafygreen-ui/icon-button": "^15.0.9",
-        "@leafygreen-ui/lib": "^10.3.2",
-        "@leafygreen-ui/palette": "^4.0.3",
-        "@leafygreen-ui/portal": "^4.1.1",
-        "@leafygreen-ui/tokens": "^2.0.2",
-        "focus-trap-react": "^8.10.0",
-        "polished": "^4.2.2",
-        "prop-types": "^15.8.1",
-        "react-transition-group": "^4.4.1"
-      },
-      "dependencies": {
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        }
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@lg-tools/test-harnesses": "^0.3.4",
+        "polished": "^4.2.2"
       }
     },
     "@leafygreen-ui/palette": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-3.4.7.tgz",
-      "integrity": "sha512-AsvPlbvF7CERiZbAQR8hy3lAJ2/rieXI3cO0jsOwV8ztDqYNotKAdLujyr/NviudrRUenYiXrLizIKVlSPUMuA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-5.0.2.tgz",
+      "integrity": "sha512-+PrfGeJSv4goxm/vKpfJJDOP7t/uElj+14K8jiIyu3qR3TcFRIZ5h1VMvICTUgqvRc8W+xIZYQwsLa2XCu2lvw==",
       "dev": true
     },
     "@leafygreen-ui/pipeline": {
-      "version": "5.0.17",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/pipeline/-/pipeline-5.0.17.tgz",
-      "integrity": "sha512-peTDNz/xhVvh/M8zhJ5u488xBz8zCGjwKdhWzNvSX2r2u3Kg+kfVo40zmNUedBgbgWJDCkiroKzr12rDpxPEMw==",
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/pipeline/-/pipeline-8.0.10.tgz",
+      "integrity": "sha512-yjd/Jv07HEdmGe+V8yMzl2589Mv81UQ19EiAvUlkFzLNH66zVMI7r/E55/rrsBodk7cRJfCdjcWXzs1ed8/OfQ==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.0.1",
-        "@leafygreen-ui/icon": "^11.25.0",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.2.0",
-        "@leafygreen-ui/tooltip": "^11.0.0",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/tooltip": "^14.3.1",
         "react-intersection-observer": "^8.25.1"
-      },
-      "dependencies": {
-        "@leafygreen-ui/hooks": {
-          "version": "8.3.6",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-          "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/lib": "^14.1.0",
-            "lodash": "^4.17.21"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/lib": {
-          "version": "13.8.2",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-          "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-          "dev": true,
-          "requires": {
-            "@storybook/csf": "^0.1.0",
-            "lodash": "^4.17.21",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/polymorphic": {
-          "version": "2.0.7",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/polymorphic/-/polymorphic-2.0.7.tgz",
-          "integrity": "sha512-MUw76DT7R7msTDjhqAvZs5dqrt5684fAKm+QhpdzKB9ywh3LCdo9syg/Hva72rDa0fRV5i/V6nYEY8zM1N005A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/lib": "^14.1.0",
-            "lodash": "^4.17.21"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/tooltip": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tooltip/-/tooltip-11.1.0.tgz",
-          "integrity": "sha512-nVIirNqBShuj25u9koOPAVYpqGWKSDe/rsdRyPWZLeL9rLfbtZi9Xn44HeDX7brVo+KBkE29Gsuh1Y3J7LN5ng==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/hooks": "^8.1.3",
-            "@leafygreen-ui/icon": "^12.5.0",
-            "@leafygreen-ui/lib": "^13.5.0",
-            "@leafygreen-ui/palette": "^4.0.9",
-            "@leafygreen-ui/popover": "^11.4.0",
-            "@leafygreen-ui/tokens": "^2.8.0",
-            "@leafygreen-ui/typography": "^19.0.0",
-            "lodash": "^4.17.21",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/icon": {
-              "version": "12.9.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-              "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-              "dev": true,
-              "requires": {
-                "@leafygreen-ui/emotion": "^4.0.8",
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/typography": {
-          "version": "19.3.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-19.3.0.tgz",
-          "integrity": "sha512-pgTRcc4usW/S9nDDzkf5Ac/JPEybhWtOnDpmrp99mAJHM6tH48Pd1HjRNHWjn6bnh0nXWjwANXX1ZEe+8ggCNg==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/icon": "^12.6.0",
-            "@leafygreen-ui/lib": "^13.6.1",
-            "@leafygreen-ui/palette": "^4.0.10",
-            "@leafygreen-ui/polymorphic": "^2.0.0",
-            "@leafygreen-ui/tokens": "^2.9.0"
-          },
-          "dependencies": {
-            "@leafygreen-ui/icon": {
-              "version": "12.9.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-              "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-              "dev": true,
-              "requires": {
-                "@leafygreen-ui/emotion": "^4.0.8",
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        }
       }
     },
     "@leafygreen-ui/polymorphic": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/polymorphic/-/polymorphic-1.3.7.tgz",
-      "integrity": "sha512-Tr2TmpS0YFJ3hGNbVWQpeseJRo4kTrVumVlZ4aF4hId1JYDzF0TU5JJO40v+brhbgnKsyBu7+Rvz6ExY1NcKew==",
-      "dev": true
-    },
-    "@leafygreen-ui/popover": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/popover/-/popover-11.4.0.tgz",
-      "integrity": "sha512-hSr3zbbWOCUuhByR5ncFJTkXxFfA7o2QjVjDXKLVPPn9Gh7+sYRLe87mTQWs9m8fbRx9O4Uk7Vq0R9U4A77dxw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/polymorphic/-/polymorphic-3.1.0.tgz",
+      "integrity": "sha512-5fbXD6ExTmMScvODuipfB1Ti/Dvoaxxg+daSftqXfNQlEkEnd5cPnezOOl1LMsu2xUoZT6NXsFgukZYsmXEVpQ==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/lib": "^13.5.0",
-        "@leafygreen-ui/portal": "^5.1.1",
-        "@leafygreen-ui/tokens": "^2.8.0",
+        "@leafygreen-ui/lib": "^15.4.0",
+        "lodash": "^4.17.21"
+      }
+    },
+    "@leafygreen-ui/popover": {
+      "version": "14.3.2",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/popover/-/popover-14.3.2.tgz",
+      "integrity": "sha512-2+qXbiGUcCS1xLzY4lUlZdM4iDXFgrJry8J7MzgzN2JpHIIDJUVz+rycqZiXJnnq7NSd3emRoiviKOGxXGywbw==",
+      "dev": true,
+      "requires": {
+        "@floating-ui/react": "^0.26.28",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/portal": "^7.1.0",
+        "@leafygreen-ui/tokens": "^4.2.2",
         "@types/react-transition-group": "^4.4.5",
+        "lodash": "^4.17.21",
         "react-transition-group": "^4.4.5"
-      },
-      "dependencies": {
-        "@leafygreen-ui/hooks": {
-          "version": "8.3.6",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-          "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/lib": "^14.1.0",
-            "lodash": "^4.17.21"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/lib": {
-          "version": "13.8.2",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-          "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-          "dev": true,
-          "requires": {
-            "@storybook/csf": "^0.1.0",
-            "lodash": "^4.17.21",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/portal": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/portal/-/portal-5.1.1.tgz",
-          "integrity": "sha512-8wvNdLxO3hWY7u5rf1ndYCJJ85TB6XpKp+dl7sQPoLnkq8HXd4GqnFXYwvGQp/pf3ts/Dp5FmZ/9dljkktnzQg==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/hooks": "^8.1.3",
-            "@leafygreen-ui/lib": "^13.3.0"
-          }
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        }
       }
     },
     "@leafygreen-ui/portal": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/portal/-/portal-4.1.7.tgz",
-      "integrity": "sha512-P2lgxhRk7uB7N7ourOupa22pH7G/wTZb1RxYVUl4yNNzXRZ0IhXdt+R1aPPGOfy1pG/m/hHJ3Wf+zVwWaN0vGQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/portal/-/portal-7.1.0.tgz",
+      "integrity": "sha512-wCldB70m/NtlIeVRxi5S/U74W6jxQScqptI2I4+7RweBquBfxIg1SipHXqMC+Zo3aL+s/fCMuFKNlLuwGWu8MA==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/hooks": "^7.7.8",
-        "@leafygreen-ui/lib": "^10.4.3"
+        "@leafygreen-ui/hooks": "^9.2.0",
+        "@leafygreen-ui/lib": "^15.6.1"
+      }
+    },
+    "@leafygreen-ui/progress-bar": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/progress-bar/-/progress-bar-1.0.8.tgz",
+      "integrity": "sha512-NY1B9AQIqMnutkE0JujjvAU+EeWBQqmSrPZZxWtgA2oIHme1OlXce6cGJT766Ks1UNe6rP6A0xIq4mntBb4Y9Q==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/a11y": "^3.0.5",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "@lg-tools/test-harnesses": "^0.3.4",
+        "lodash": "^4.17.21",
+        "polished": "^4.2.2"
       }
     },
     "@leafygreen-ui/radio-box-group": {
-      "version": "12.0.16",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/radio-box-group/-/radio-box-group-12.0.16.tgz",
-      "integrity": "sha512-3jTprIrHO87oUsZCGn+FNkK7/clER+yTLV9GKt13rYlpy429hRs1c9EwNHfhT50DPhENhIIc/XYNMpWTDuWyBg==",
+      "version": "15.0.11",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/radio-box-group/-/radio-box-group-15.0.11.tgz",
+      "integrity": "sha512-BVG9sokWt/yGI4BD7WHKGkD4gayoxWMskZ1HWNA1IWEnkb1F7VFBbVDsa4k0XXlOzxxMBnIdAFo7s6Je2vhI5A==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.0.0",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.2.0"
-      },
-      "dependencies": {
-        "@leafygreen-ui/hooks": {
-          "version": "8.3.6",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-          "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/lib": "^14.1.0",
-            "lodash": "^4.17.21"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/lib": {
-          "version": "13.8.2",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-          "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-          "dev": true,
-          "requires": {
-            "@storybook/csf": "^0.1.0",
-            "lodash": "^4.17.21",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        }
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2"
       }
     },
     "@leafygreen-ui/radio-group": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/radio-group/-/radio-group-10.2.4.tgz",
-      "integrity": "sha512-Jd54mKopU9rp7YDlnG/Aw+C3bSvE7CpVzJ9UFAgvWQP2FbqTIE5uDRibYipcf1R3AiOTVOm2H5i9xmHi+bi1xQ==",
+      "version": "13.0.12",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/radio-group/-/radio-group-13.0.12.tgz",
+      "integrity": "sha512-Mggusg9KRWh75sP92Zi1FiMC1mxnphCYwkuNranjnIMas8fmUkJTFHopLYKp73eA3SuVmU5zTWpregFdxTIWIA==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.0.0",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.2.0",
-        "@leafygreen-ui/typography": "^18.0.0"
-      },
-      "dependencies": {
-        "@leafygreen-ui/hooks": {
-          "version": "8.3.6",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-          "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/lib": "^14.1.0",
-            "lodash": "^4.17.21"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/icon": {
-          "version": "12.9.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-          "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "lodash": "^4.17.21"
-          }
-        },
-        "@leafygreen-ui/lib": {
-          "version": "13.8.2",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-          "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-          "dev": true,
-          "requires": {
-            "@storybook/csf": "^0.1.0",
-            "lodash": "^4.17.21",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/typography": {
-          "version": "18.4.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-18.4.0.tgz",
-          "integrity": "sha512-2pfoBv6jEPupMzT/rciyP6oN53Fc2h0Nl/uXubSRuFcIDwUAE6CIb3+IjK3UNyQrnOixGU4lWQhxIPTrnyxCpQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/icon": "^12.1.0",
-            "@leafygreen-ui/lib": "^13.4.0",
-            "@leafygreen-ui/palette": "^4.0.10",
-            "@leafygreen-ui/polymorphic": "^1.3.7",
-            "@leafygreen-ui/tokens": "^2.5.2"
-          }
-        }
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4"
+      }
+    },
+    "@leafygreen-ui/resizable": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/resizable/-/resizable-0.1.3.tgz",
+      "integrity": "sha512-hGpRUvqMLsfpqUgAFP5rTgY3viwHP9T8fe0eBL3sbShezvbuLNO9qSVZYQVGg7VNC4wg3reJ1aSQxjn1XYe5Nw==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/emotion": "^5.0.3",
+        "@leafygreen-ui/lib": "^15.4.0",
+        "@leafygreen-ui/palette": "^5.0.2"
       }
     },
     "@leafygreen-ui/ripple": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/ripple/-/ripple-1.1.18.tgz",
-      "integrity": "sha512-GWdQWbxJ3dP/BRIufLs/zB6BeLuxWnhR9YJNr25nlWc3qeC30WdJqsd8ULaQzZBupxA9UsnfY9+tRRVXh1LbMg==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/ripple/-/ripple-2.0.7.tgz",
+      "integrity": "sha512-+Ixyb5deA5S+tbLQl4Iad/JWVQhYLeET6tstzYmE/sk6YfJWDyWH8CYVJ3Q9wdZXBJlXoZAi1Vy4ff4x9GSXGA==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/tokens": "^2.12.0"
-      },
-      "dependencies": {
-        "@leafygreen-ui/lib": {
-          "version": "14.1.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-          "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.21"
-          }
-        },
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          }
-        }
+        "@leafygreen-ui/tokens": "^4.0.0"
       }
     },
     "@leafygreen-ui/search-input": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/search-input/-/search-input-2.1.3.tgz",
-      "integrity": "sha512-rZMzt7jQ/ogTL5AOAYMpdzpi/mAGvWUH68BWT9fizyxtleJv8owPuinE4D/mKlvgmBq7HtJ27tAQmIUBPkJbRw==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/search-input/-/search-input-6.1.3.tgz",
+      "integrity": "sha512-225f7UpILMcaY8vVKdjm/xLQcsAsa775+SYSbB3OGFlscwATtoNNhdk6XDeXI6gb4fSAxu0RPm8e/ODZEuunig==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/a11y": "^1.4.11",
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.1.1",
-        "@leafygreen-ui/icon": "^11.24.0",
-        "@leafygreen-ui/icon-button": "^15.0.19",
-        "@leafygreen-ui/input-option": "^1.0.13",
-        "@leafygreen-ui/lib": "^13.2.1",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/polymorphic": "^1.3.6",
-        "@leafygreen-ui/popover": "^11.1.1",
-        "@leafygreen-ui/tokens": "^2.3.0",
-        "@leafygreen-ui/typography": "^18.0.0",
+        "@leafygreen-ui/a11y": "^3.0.5",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/input-option": "^4.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/popover": "^14.3.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
         "lodash": "^4.17.21",
         "polished": "^4.2.2"
-      },
-      "dependencies": {
-        "@leafygreen-ui/hooks": {
-          "version": "8.3.6",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-          "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/lib": "^14.1.0",
-            "lodash": "^4.17.21"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/lib": {
-          "version": "13.8.2",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-          "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-          "dev": true,
-          "requires": {
-            "@storybook/csf": "^0.1.0",
-            "lodash": "^4.17.21",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/typography": {
-          "version": "18.4.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-18.4.0.tgz",
-          "integrity": "sha512-2pfoBv6jEPupMzT/rciyP6oN53Fc2h0Nl/uXubSRuFcIDwUAE6CIb3+IjK3UNyQrnOixGU4lWQhxIPTrnyxCpQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/icon": "^12.1.0",
-            "@leafygreen-ui/lib": "^13.4.0",
-            "@leafygreen-ui/palette": "^4.0.10",
-            "@leafygreen-ui/polymorphic": "^1.3.7",
-            "@leafygreen-ui/tokens": "^2.5.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/icon": {
-              "version": "12.9.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-              "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-              "dev": true,
-              "requires": {
-                "@leafygreen-ui/emotion": "^4.0.8",
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        }
       }
     },
     "@leafygreen-ui/segmented-control": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/segmented-control/-/segmented-control-7.0.5.tgz",
-      "integrity": "sha512-ar0+gKg7ClTz+YK7TnaWq9bY0y7TazGxxR/vjPTAO/LRgg6drP/nmycU8Q3UqsL2LPJqRscKTcIPv9lSNl6eEw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/segmented-control/-/segmented-control-11.1.0.tgz",
+      "integrity": "sha512-TbMFGY3Lt8lEETuiA/CyaBxhcEos1xxyUzoEaImnvrS2Os0RL4WA03CWjeTvuPJ7z2RfBJ7kEte2jeNDgn+E+Q==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/box": "^3.1.1",
-        "@leafygreen-ui/emotion": "^4.0.3",
-        "@leafygreen-ui/hooks": "^7.7.0",
-        "@leafygreen-ui/icon": "^11.12.7",
-        "@leafygreen-ui/lib": "^10.3.1",
-        "@leafygreen-ui/palette": "^4.0.1",
-        "@leafygreen-ui/tokens": "^2.0.1",
-        "@leafygreen-ui/typography": "^16.2.0",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
         "lodash": "^4.17.21",
         "polished": "^4.2.2"
-      },
-      "dependencies": {
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/typography": {
-          "version": "16.5.5",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-16.5.5.tgz",
-          "integrity": "sha512-mErhTYM0C1PZaeADTkp5v/MAS6aEhavWHZ3otHthBSo/zwI5uAYnkreheiYElc66B/0bcOxCikLVkP3zaFnX2A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.7",
-            "@leafygreen-ui/icon": "^11.22.2",
-            "@leafygreen-ui/lib": "^11.0.0",
-            "@leafygreen-ui/palette": "^4.0.7",
-            "@leafygreen-ui/polymorphic": "^1.3.6",
-            "@leafygreen-ui/tokens": "^2.1.4"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "11.0.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-11.0.0.tgz",
-              "integrity": "sha512-sHkY/MOwRQDc9qAR1awreW0dP+6ELueJJd4JCJmi6XYbdL0wDotFwsWfCwkL+N6cFbE1e+xBQtFLB6T1+58+iQ==",
-              "dev": true,
-              "requires": {
-                "@storybook/csf": "^0.1.0",
-                "lodash": "^4.17.21",
-                "prop-types": "^15.7.2"
-              }
-            }
-          }
-        }
       }
     },
     "@leafygreen-ui/select": {
-      "version": "10.3.18",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/select/-/select-10.3.18.tgz",
-      "integrity": "sha512-YJkO15Clg72D5RX0V4Ea6+IozftIbHUREAb7Gs/sYFEAESIuT6u/rmhhqOBZHtWmc/yNVgcFYDPJHXWYVzYV+w==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/select/-/select-17.1.0.tgz",
+      "integrity": "sha512-HA9pe8snzpQC5OtuXPjKKOdDI4EC4ZeG9rk8hx+YXQcA6+Racg+h5R2r/vfOrv8/xThiJdO7jgiZ0/RwgkQsZg==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/button": "^21.0.7",
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.0.0",
-        "@leafygreen-ui/icon": "^11.23.0",
-        "@leafygreen-ui/lib": "^12.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/popover": "^11.0.18",
-        "@leafygreen-ui/tokens": "^2.2.0",
-        "@leafygreen-ui/typography": "^17.0.1",
+        "@leafygreen-ui/button": "^25.2.1",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/form-field": "^4.0.9",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.9.0",
+        "@leafygreen-ui/input-option": "^4.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/popover": "^14.3.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "@lg-tools/test-harnesses": "^0.3.4",
         "@types/react-is": "^18.0.0",
         "lodash": "^4.17.21",
         "polished": "^4.1.3",
         "react-is": "^18.0.1"
       },
       "dependencies": {
-        "@leafygreen-ui/button": {
-          "version": "21.3.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/button/-/button-21.3.0.tgz",
-          "integrity": "sha512-v9qipsRWHQBN9sC4RNWmJ/PVQCcYZdg9Wa+k9Q6LFjgahI1/6BXYTZOP4wPJQDp2AG6+dx2CF7Rp60ymM+wtLw==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/box": "^3.1.9",
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/lib": "^13.4.0",
-            "@leafygreen-ui/palette": "^4.0.10",
-            "@leafygreen-ui/ripple": "^1.1.13",
-            "@leafygreen-ui/tokens": "^2.5.2",
-            "@lg-tools/test-harnesses": "^0.1.2",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "13.8.2",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-              "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-              "dev": true,
-              "requires": {
-                "@storybook/csf": "^0.1.0",
-                "lodash": "^4.17.21",
-                "prop-types": "^15.7.2"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/hooks": {
-          "version": "8.3.6",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-          "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/lib": "^14.1.0",
-            "lodash": "^4.17.21"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/lib": {
-          "version": "12.0.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-12.0.0.tgz",
-          "integrity": "sha512-nhaxi4oBesnizxO0YK7XwcmiLL9U5QuN7lkZdWGDdmoJgNNL+aRju4W5vmZc7vcazSHfr3gAL+NFAGaAuopyRA==",
-          "dev": true,
-          "requires": {
-            "@storybook/csf": "^0.1.0",
-            "lodash": "^4.17.21",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/typography": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-17.0.2.tgz",
-          "integrity": "sha512-wx+kk5VNMOCTenrIG2AcgAKHt9TiLhSTirZARv0J6l4VOgnO+Mkbh3sqd4mk0EOBCAFmsBR3WqwQh00JXU8Htw==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.7",
-            "@leafygreen-ui/icon": "^11.22.2",
-            "@leafygreen-ui/lib": "^12.0.0",
-            "@leafygreen-ui/palette": "^4.0.7",
-            "@leafygreen-ui/polymorphic": "^1.3.6",
-            "@leafygreen-ui/tokens": "^2.1.4"
-          }
-        },
         "react-is": {
           "version": "18.3.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -36395,684 +33978,413 @@
         }
       }
     },
-    "@leafygreen-ui/table": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/table/-/table-10.0.3.tgz",
-      "integrity": "sha512-JuoUkcFvE/oV7qt0tIeXHQPehHGMSp4YCbm4JaWq76ExdUhP6lPP5nv/sfMsBPk1ICGkeOxMYcVHXi0e67XGWA==",
+    "@leafygreen-ui/skeleton-loader": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/skeleton-loader/-/skeleton-loader-3.0.11.tgz",
+      "integrity": "sha512-jJYdlrQRZDqwBFMIbHTSr5q1h7K9MdS7u4RDrkWoVk5StKGX9brXFLGGSVFWogGMby4vIqRFoeLZLlO/YLO1NA==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/emotion": "^4.0.3",
-        "@leafygreen-ui/hooks": "^7.5.0",
-        "@leafygreen-ui/icon": "^11.12.5",
-        "@leafygreen-ui/icon-button": "^15.0.7",
-        "@leafygreen-ui/lib": "^10.2.2",
-        "@leafygreen-ui/palette": "^4.0.0",
-        "@leafygreen-ui/tokens": "^2.0.1",
-        "@leafygreen-ui/typography": "^16.1.0",
+        "@leafygreen-ui/a11y": "^3.0.5",
+        "@leafygreen-ui/card": "^13.3.1",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "lodash": "^4.17.21"
+      }
+    },
+    "@leafygreen-ui/split-button": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/split-button/-/split-button-6.3.1.tgz",
+      "integrity": "sha512-BcBNKbl2ZLCCfAq0UnUmhhATwgtd31RNDwc3CVIB+tfseZYVlGUMfV4qmaDLeackXhnLEZEDZWmdmezxcQ6A4A==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/button": "^25.2.1",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/menu": "^33.2.1",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/tokens": "^4.2.2"
+      }
+    },
+    "@leafygreen-ui/table": {
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/table/-/table-15.2.3.tgz",
+      "integrity": "sha512-T0YY6jdE92sgqa6OyDugRMMdto884CIKa1Fzud2oD8tOmTqENqhD7nC1+JsPEa3VKXFxsNtKbTfRmLMWJMPoVg==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/checkbox": "^18.1.5",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "@lg-tools/test-harnesses": "^0.3.4",
+        "@tanstack/react-table": "^8.20.5",
+        "@tanstack/react-virtual": "^3.10.7",
         "lodash": "^4.17.21",
         "polished": "^4.2.2",
-        "react-transition-group": "^4.4.1"
-      },
-      "dependencies": {
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/typography": {
-          "version": "16.5.5",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-16.5.5.tgz",
-          "integrity": "sha512-mErhTYM0C1PZaeADTkp5v/MAS6aEhavWHZ3otHthBSo/zwI5uAYnkreheiYElc66B/0bcOxCikLVkP3zaFnX2A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.7",
-            "@leafygreen-ui/icon": "^11.22.2",
-            "@leafygreen-ui/lib": "^11.0.0",
-            "@leafygreen-ui/palette": "^4.0.7",
-            "@leafygreen-ui/polymorphic": "^1.3.6",
-            "@leafygreen-ui/tokens": "^2.1.4"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "11.0.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-11.0.0.tgz",
-              "integrity": "sha512-sHkY/MOwRQDc9qAR1awreW0dP+6ELueJJd4JCJmi6XYbdL0wDotFwsWfCwkL+N6cFbE1e+xBQtFLB6T1+58+iQ==",
-              "dev": true,
-              "requires": {
-                "@storybook/csf": "^0.1.0",
-                "lodash": "^4.17.21",
-                "prop-types": "^15.7.2"
-              }
-            }
-          }
-        }
+        "react-fast-compare": "3.2.2",
+        "react-intersection-observer": "^8.25.1"
       }
     },
     "@leafygreen-ui/tabs": {
-      "version": "11.1.13",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tabs/-/tabs-11.1.13.tgz",
-      "integrity": "sha512-n771tkjfSMa/P3Y7QwqwTKIbiyaHZeRXg8jYDSLcC9DKphng0LyRBfItzMApqpU5HPpU75SIxCMixMh03eW9pw==",
+      "version": "17.0.11",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tabs/-/tabs-17.0.11.tgz",
+      "integrity": "sha512-dC+RMjkJh66Y4w00Y00g+1Bl3oT7m+paJSd1KwhvBVz0zus0vNAAz5XkJcCQvL8+WesPVjrX22ZdBlkaKQGvYA==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/a11y": "^1.4.11",
-        "@leafygreen-ui/box": "^3.1.8",
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.0.1",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/portal": "^5.0.3",
-        "@leafygreen-ui/tokens": "^2.2.0",
-        "@leafygreen-ui/typography": "^18.0.1"
-      },
-      "dependencies": {
-        "@leafygreen-ui/hooks": {
-          "version": "8.3.6",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-          "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/lib": "^14.1.0",
-            "lodash": "^4.17.21"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/icon": {
-          "version": "12.9.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-          "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "lodash": "^4.17.21"
-          }
-        },
-        "@leafygreen-ui/lib": {
-          "version": "13.8.2",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-          "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-          "dev": true,
-          "requires": {
-            "@storybook/csf": "^0.1.0",
-            "lodash": "^4.17.21",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/portal": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/portal/-/portal-5.1.1.tgz",
-          "integrity": "sha512-8wvNdLxO3hWY7u5rf1ndYCJJ85TB6XpKp+dl7sQPoLnkq8HXd4GqnFXYwvGQp/pf3ts/Dp5FmZ/9dljkktnzQg==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/hooks": "^8.1.3",
-            "@leafygreen-ui/lib": "^13.3.0"
-          }
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/typography": {
-          "version": "18.4.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-18.4.0.tgz",
-          "integrity": "sha512-2pfoBv6jEPupMzT/rciyP6oN53Fc2h0Nl/uXubSRuFcIDwUAE6CIb3+IjK3UNyQrnOixGU4lWQhxIPTrnyxCpQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/icon": "^12.1.0",
-            "@leafygreen-ui/lib": "^13.4.0",
-            "@leafygreen-ui/palette": "^4.0.10",
-            "@leafygreen-ui/polymorphic": "^1.3.7",
-            "@leafygreen-ui/tokens": "^2.5.2"
-          }
-        }
+        "@leafygreen-ui/a11y": "^3.0.5",
+        "@leafygreen-ui/descendants": "^3.1.0",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "@lg-tools/test-harnesses": "^0.3.4"
       }
     },
     "@leafygreen-ui/text-area": {
-      "version": "8.0.21",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/text-area/-/text-area-8.0.21.tgz",
-      "integrity": "sha512-1gzzGt3dvNWzT3mhOrmjs3oKt+wruGs6Yq3Ij0gYwEzosSQc81dNwlPimN5S1Lzsu5aCbn4cgaQPuYi47QcLcw==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/text-area/-/text-area-12.1.5.tgz",
+      "integrity": "sha512-bp3j0i+sQf2796lkN6TSJuoV2RMF0sgHJ9vmLN6Ij5ARA7FL7QZbDODTehMtFD3UZk5+6Kl9dEvcYtlfRaqfnQ==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.0.0",
-        "@leafygreen-ui/icon": "^11.27.0",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.2.0",
-        "@leafygreen-ui/typography": "^18.0.0"
-      },
-      "dependencies": {
-        "@leafygreen-ui/hooks": {
-          "version": "8.3.6",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-          "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/lib": "^14.1.0",
-            "lodash": "^4.17.21"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/lib": {
-          "version": "13.8.2",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-          "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-          "dev": true,
-          "requires": {
-            "@storybook/csf": "^0.1.0",
-            "lodash": "^4.17.21",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/typography": {
-          "version": "18.4.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-18.4.0.tgz",
-          "integrity": "sha512-2pfoBv6jEPupMzT/rciyP6oN53Fc2h0Nl/uXubSRuFcIDwUAE6CIb3+IjK3UNyQrnOixGU4lWQhxIPTrnyxCpQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/icon": "^12.1.0",
-            "@leafygreen-ui/lib": "^13.4.0",
-            "@leafygreen-ui/palette": "^4.0.10",
-            "@leafygreen-ui/polymorphic": "^1.3.7",
-            "@leafygreen-ui/tokens": "^2.5.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/icon": {
-              "version": "12.9.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-              "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-              "dev": true,
-              "requires": {
-                "@leafygreen-ui/emotion": "^4.0.8",
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        }
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/form-field": "^4.0.9",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "@lg-tools/test-harnesses": "^0.3.4"
       }
     },
     "@leafygreen-ui/text-input": {
-      "version": "12.1.25",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/text-input/-/text-input-12.1.25.tgz",
-      "integrity": "sha512-fAL890AgYnIz89xCi9mFD2ocAqbfIx4fNxcOULzXCfz6sqUUfLwaIFPLuqArptginTfq2HPJ47g1NF2vvZhS1g==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/text-input/-/text-input-16.2.3.tgz",
+      "integrity": "sha512-Jbbbov2aTlE2ucuddTLF5IK68jWPwqmTEzwz/LVl9En7Jc4ksEIUZK+Bs0gRMIj6t/ppgwQlSfcoi9MQjZjHpg==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/form-field": "^0.3.0",
-        "@leafygreen-ui/hooks": "^8.1.0",
-        "@leafygreen-ui/icon": "^11.27.1",
-        "@leafygreen-ui/lib": "^13.2.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.2.0",
-        "@leafygreen-ui/typography": "^18.1.0"
-      },
-      "dependencies": {
-        "@leafygreen-ui/hooks": {
-          "version": "8.3.6",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-          "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/lib": "^14.1.0",
-            "lodash": "^4.17.21"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/lib": {
-          "version": "13.8.2",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-          "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-          "dev": true,
-          "requires": {
-            "@storybook/csf": "^0.1.0",
-            "lodash": "^4.17.21",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/typography": {
-          "version": "18.4.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-18.4.0.tgz",
-          "integrity": "sha512-2pfoBv6jEPupMzT/rciyP6oN53Fc2h0Nl/uXubSRuFcIDwUAE6CIb3+IjK3UNyQrnOixGU4lWQhxIPTrnyxCpQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/icon": "^12.1.0",
-            "@leafygreen-ui/lib": "^13.4.0",
-            "@leafygreen-ui/palette": "^4.0.10",
-            "@leafygreen-ui/polymorphic": "^1.3.7",
-            "@leafygreen-ui/tokens": "^2.5.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/icon": {
-              "version": "12.9.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-              "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-              "dev": true,
-              "requires": {
-                "@leafygreen-ui/emotion": "^4.0.8",
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        }
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/form-field": "^4.0.9",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "@lg-tools/test-harnesses": "^0.3.4"
       }
     },
     "@leafygreen-ui/toast": {
-      "version": "6.1.20",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/toast/-/toast-6.1.20.tgz",
-      "integrity": "sha512-6b9yBuEfgRI4+P0UF0pInL15HznkdfY5Vd8x0eiIelcCvZMnbW17UNeXS8ZAr3h3PQg5ETuOasUPOxs0LadSBA==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/toast/-/toast-8.1.3.tgz",
+      "integrity": "sha512-rds7bCY1GRul+2omciMoaI1lbVqAdorIMPhAQ22kq0HuYSivZnoY0owBI2ye3OfdG6Naf+AEOsHDJ/Y6H94d7A==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.1.1",
-        "@leafygreen-ui/icon": "^11.27.1",
-        "@leafygreen-ui/icon-button": "^15.0.19",
-        "@leafygreen-ui/lib": "^13.2.1",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/portal": "^5.0.3",
-        "@leafygreen-ui/tokens": "^2.3.0",
-        "@leafygreen-ui/typography": "^18.1.0",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/portal": "^7.1.0",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
         "lodash": "^4.17.21",
         "polished": "^4.2.2",
         "react-transition-group": "^4.4.5"
-      },
-      "dependencies": {
-        "@leafygreen-ui/hooks": {
-          "version": "8.3.6",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.3.6.tgz",
-          "integrity": "sha512-6Sgo0irgcsmvWbV29OeJXdlEehTu5ZokONkyl3Op5jb3d3HSoaESk86w3qL3XP2vMmfn6KxE8vp5dC2nlBII+A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/lib": "^14.1.0",
-            "lodash": "^4.17.21"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/lib": {
-          "version": "13.8.2",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-          "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-          "dev": true,
-          "requires": {
-            "@storybook/csf": "^0.1.0",
-            "lodash": "^4.17.21",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/portal": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/portal/-/portal-5.1.1.tgz",
-          "integrity": "sha512-8wvNdLxO3hWY7u5rf1ndYCJJ85TB6XpKp+dl7sQPoLnkq8HXd4GqnFXYwvGQp/pf3ts/Dp5FmZ/9dljkktnzQg==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/hooks": "^8.1.3",
-            "@leafygreen-ui/lib": "^13.3.0"
-          }
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/typography": {
-          "version": "18.4.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-18.4.0.tgz",
-          "integrity": "sha512-2pfoBv6jEPupMzT/rciyP6oN53Fc2h0Nl/uXubSRuFcIDwUAE6CIb3+IjK3UNyQrnOixGU4lWQhxIPTrnyxCpQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/icon": "^12.1.0",
-            "@leafygreen-ui/lib": "^13.4.0",
-            "@leafygreen-ui/palette": "^4.0.10",
-            "@leafygreen-ui/polymorphic": "^1.3.7",
-            "@leafygreen-ui/tokens": "^2.5.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/icon": {
-              "version": "12.9.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
-              "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
-              "dev": true,
-              "requires": {
-                "@leafygreen-ui/emotion": "^4.0.8",
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        }
       }
     },
     "@leafygreen-ui/toggle": {
-      "version": "10.0.17",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/toggle/-/toggle-10.0.17.tgz",
-      "integrity": "sha512-EUo7kxMMNH+rv8dVJCqyi7zGRPCgiiw+cGXgMa2dI2u1MJQHqGdnNFeQSIJE48jDBpJZfIfMxyryN5lpR3ziHg==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/toggle/-/toggle-12.1.5.tgz",
+      "integrity": "sha512-+exS86dWnZs2TqulXZSzs7hkPrXmxqIeJDSHaunzLtpuYO0fiDDBMZvghhWAFmvPCUN63fh95NXWFUjaJQgC1g==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/a11y": "^1.4.11",
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/icon": "^11.22.2",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.1.4"
-      },
-      "dependencies": {
-        "@leafygreen-ui/lib": {
-          "version": "13.8.2",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.8.2.tgz",
-          "integrity": "sha512-UxtZauF0rsB2dT0dsFYadcs9qa22Wk3PJaSXOCoI8BRPxyV8H4H6B+FQuFjCeLpKWFYOGLee9di3Xsqd4ewa8Q==",
-          "dev": true,
-          "requires": {
-            "@storybook/csf": "^0.1.0",
-            "lodash": "^4.17.21",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        }
+        "@leafygreen-ui/a11y": "^3.0.5",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@lg-tools/test-harnesses": "^0.3.4"
       }
     },
     "@leafygreen-ui/tokens": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-1.4.1.tgz",
-      "integrity": "sha512-ap9IdpQy+wg8IG9rJbWZB9F9zihhixClz68UFcwJMbDqcvxcqRPBvRpkbqiJdAPwOSrbYZfrHSGEtdJk9bzZAg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-4.2.2.tgz",
+      "integrity": "sha512-7E31JJ3ASrS5hJ7RxUA/ax+/nBLmNGwJb0AR8tlQsTHeipVeFwQEyWrxHxFTBv3Qyu3qk4L1n52LDuKFkbuENA==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/palette": "^3.4.5"
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2"
+      }
+    },
+    "@leafygreen-ui/toolbar": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/toolbar/-/toolbar-1.3.2.tgz",
+      "integrity": "sha512-S74SYJPAaniKJJ/9ZbhnywPaNCK7wOkutaUKRBlVzvI0/DhISFfEytrTn/v2c2o0RoRdYe751gUjuYInkCWaNQ==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/descendants": "^3.1.0",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/tooltip": "^14.3.1",
+        "@lg-chat/chat-button": "^0.2.2",
+        "@lg-tools/test-harnesses": "^0.3.4"
       }
     },
     "@leafygreen-ui/tooltip": {
-      "version": "9.1.8",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tooltip/-/tooltip-9.1.8.tgz",
-      "integrity": "sha512-bqLF0z4L19y253nmRoQSs4U1O7OGSCf46e1N7xBCbenlZVMLN4MSk0EQdpmDmXqMkopLOomVQAy/17guV6YULA==",
+      "version": "14.3.2",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tooltip/-/tooltip-14.3.2.tgz",
+      "integrity": "sha512-YMIvpVSM/vnZPnAtlbXfx3fyOhwMWZs8R1GLHp3q9i+JpoQ696cg3jepnjqHc2Hu2AUH/g4fMrql5raw8WHk8Q==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/emotion": "^4.0.4",
-        "@leafygreen-ui/hooks": "^7.7.1",
-        "@leafygreen-ui/icon": "^11.13.1",
-        "@leafygreen-ui/lib": "^10.3.3",
-        "@leafygreen-ui/palette": "^4.0.4",
-        "@leafygreen-ui/popover": "^11.0.8",
-        "@leafygreen-ui/tokens": "^2.0.3",
-        "@leafygreen-ui/typography": "^16.3.0",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.9.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/popover": "^14.3.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
         "lodash": "^4.17.21",
         "polished": "^4.2.2"
+      }
+    },
+    "@leafygreen-ui/typography": {
+      "version": "22.2.4",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-22.2.4.tgz",
+      "integrity": "sha512-ffMvuuANOWPbuWwJQcn257YROMT2WJwLV+xlG2l8UH3Gb5ldxiTJAdKqtXIshLjmkrRwv2O7ylHBXsHPMYjUjA==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/tokens": "^4.2.2"
+      }
+    },
+    "@lg-chat/chat-button": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@lg-chat/chat-button/-/chat-button-0.2.2.tgz",
+      "integrity": "sha512-yCCOPnbYbOeUQ+/vQCGUmdZZJHEeGapn0uH48zf87B7YIQbpC7VBDwmO0XXSb8/+YnpssIioeJWzEZt2bDsWZw==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/avatar": "^3.3.0",
+        "@leafygreen-ui/button": "^25.2.1",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@lg-tools/test-harnesses": "^0.3.4"
+      }
+    },
+    "@lg-chat/chat-window": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@lg-chat/chat-window/-/chat-window-6.0.2.tgz",
+      "integrity": "sha512-v0h9iCDP9OVcP42XXG/R5ZNsiTPEZgSrbYgK7tPiX7bPKJc+DtOPy2Gc3+hMQLHdnr1/4Rptq96SnVdmVrbv8A==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@lg-chat/title-bar": "^5.0.2",
+        "react-keyed-flatten-children": "^2.2.1"
+      }
+    },
+    "@lg-chat/input-bar": {
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/@lg-chat/input-bar/-/input-bar-12.2.2.tgz",
+      "integrity": "sha512-Yv6RrgBv599Yd34BxaE66Pa5tvFqg8BYf+cS8ZKIXjjClOaW6lRCm5lUMgrTaTAZn3ajdL6D6RqB9oKrNuDBbQ==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/avatar": "^3.3.0",
+        "@leafygreen-ui/banner": "^10.2.5",
+        "@leafygreen-ui/button": "^25.2.1",
+        "@leafygreen-ui/compound-component": "^0.3.0",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/input-option": "^4.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/popover": "^14.3.2",
+        "@leafygreen-ui/search-input": "^6.1.3",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "lodash": "^4.17.21",
+        "react-keyed-flatten-children": "^1.3.0",
+        "react-textarea-autosize": "^8.5.9"
       },
       "dependencies": {
-        "@leafygreen-ui/palette": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.4.tgz",
-          "integrity": "sha512-pkNeNzlstEM7ceoLG1mG7PUGunEdUYemKjzVOcaCbNEoyZvX3Lf0KWb8tDmAEloSPdXxMOlO8hoef9JGNdEIcw==",
-          "dev": true
-        },
-        "@leafygreen-ui/tokens": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.12.0.tgz",
-          "integrity": "sha512-qdXNNA8MYU4Pc9l256r7/guGuPCZi7ymyGdIVlYm7cimpk679WBR2RRNSEenLuBz4ENuGZFuyzHeBC/9DH11nQ==",
+        "react-keyed-flatten-children": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/react-keyed-flatten-children/-/react-keyed-flatten-children-1.3.0.tgz",
+          "integrity": "sha512-qB7A6n+NHU0x88qTZGAJw6dsqwI941jcRPBB640c/CyWqjPQQ+YUmXOuzPziuHb7iqplM3xksWAbGYwkQT0tXA==",
           "dev": true,
           "requires": {
-            "@leafygreen-ui/emotion": "^4.0.10",
-            "@leafygreen-ui/lib": "^14.1.0",
-            "@leafygreen-ui/palette": "^4.1.4",
-            "polished": "^4.2.2"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "14.1.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-14.1.0.tgz",
-              "integrity": "sha512-5UqSGClJ6RB+joiq2qftXr+Brq7ivp8E5ztob/nRlWmfOetvZoL/f7RPFmXY0N4u4zrkARxctxPAnbPWqwU8Bg==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.21"
-              }
-            }
-          }
-        },
-        "@leafygreen-ui/typography": {
-          "version": "16.5.5",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-16.5.5.tgz",
-          "integrity": "sha512-mErhTYM0C1PZaeADTkp5v/MAS6aEhavWHZ3otHthBSo/zwI5uAYnkreheiYElc66B/0bcOxCikLVkP3zaFnX2A==",
-          "dev": true,
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.7",
-            "@leafygreen-ui/icon": "^11.22.2",
-            "@leafygreen-ui/lib": "^11.0.0",
-            "@leafygreen-ui/palette": "^4.0.7",
-            "@leafygreen-ui/polymorphic": "^1.3.6",
-            "@leafygreen-ui/tokens": "^2.1.4"
-          },
-          "dependencies": {
-            "@leafygreen-ui/lib": {
-              "version": "11.0.0",
-              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-11.0.0.tgz",
-              "integrity": "sha512-sHkY/MOwRQDc9qAR1awreW0dP+6ELueJJd4JCJmi6XYbdL0wDotFwsWfCwkL+N6cFbE1e+xBQtFLB6T1+58+iQ==",
-              "dev": true,
-              "requires": {
-                "@storybook/csf": "^0.1.0",
-                "lodash": "^4.17.21",
-                "prop-types": "^15.7.2"
-              }
-            }
+            "react-is": "^16.8.6"
           }
         }
       }
     },
-    "@leafygreen-ui/typography": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-15.3.0.tgz",
-      "integrity": "sha512-JmdCGHvFpX0/KyB42zcAjo5ViBKuoIL74MQwN25neWgWAg19Q4VMPrTm+hnysqaPW0ntCwRayexbWnTI+XPD+Q==",
+    "@lg-chat/leafygreen-chat-provider": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@lg-chat/leafygreen-chat-provider/-/leafygreen-chat-provider-6.0.0.tgz",
+      "integrity": "sha512-zhvqAPpHX0VVOvrsVKs7H37ImIEOGuTLarULXEW4dwglKGqhbagmdN2UEje++wDAD/JqnAYEaQYzrPFH2EIgWQ==",
+      "dev": true
+    },
+    "@lg-chat/lg-markdown": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@lg-chat/lg-markdown/-/lg-markdown-5.0.3.tgz",
+      "integrity": "sha512-zqbCIe1S1BcKEO6RcU1d1mntRC6huIJhzhL/8oJsFP4EpfZu0xi3xh7PK4/wPJv0E7oznHPfnUC9AAxL3jytaw==",
       "dev": true,
       "requires": {
-        "@leafygreen-ui/box": "^3.1.1",
-        "@leafygreen-ui/emotion": "^4.0.3",
-        "@leafygreen-ui/icon": "^11.12.3",
-        "@leafygreen-ui/lib": "^10.0.0",
-        "@leafygreen-ui/palette": "^3.4.6",
-        "@leafygreen-ui/tokens": "^1.4.1"
+        "@leafygreen-ui/code": "^20.2.7",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "react-markdown": "^8.0.7"
+      }
+    },
+    "@lg-chat/message": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@lg-chat/message/-/message-12.0.0.tgz",
+      "integrity": "sha512-ZVz6L4Ju8U1zByQLDEYJfOWKzJUCVraiuw/GrcR0fG+xIjkT572oZ7P3EYzSnNPxpMLl46/ovSwlXrd6faSNTQ==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/badge": "^10.2.4",
+        "@leafygreen-ui/banner": "^10.2.5",
+        "@leafygreen-ui/button": "^25.2.1",
+        "@leafygreen-ui/chip": "^4.2.1",
+        "@leafygreen-ui/compound-component": "^0.3.0",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/loading-indicator": "^5.1.1",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/tooltip": "^14.3.1",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "@lg-chat/lg-markdown": "^5.0.3",
+        "@lg-chat/message-feedback": "^9.0.2",
+        "@lg-chat/message-rating": "^7.1.2",
+        "@lg-chat/rich-links": "^4.0.8"
+      }
+    },
+    "@lg-chat/message-feedback": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@lg-chat/message-feedback/-/message-feedback-9.0.2.tgz",
+      "integrity": "sha512-Q7L4WNxmcmNZ/tqun863UX0jn8P3N9jYlLW/pXiPORG2v2HeG27U+I+yaFNoZOFYvBR2hlRXm1qnkvd+Z4N/PQ==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/button": "^25.2.1",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/text-area": "^12.1.5",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4"
+      }
+    },
+    "@lg-chat/message-prompts": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@lg-chat/message-prompts/-/message-prompts-4.2.2.tgz",
+      "integrity": "sha512-JBf5ns7tkk9Xx2GvLQQ0V8gNGPYX4fwjkl5FgQV2kBEgEC80DihfE6OdxyZQ4OwRWOrWL4wTlSXCmbsaLBh9PA==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/tooltip": "^14.3.1",
+        "@leafygreen-ui/typography": "^22.2.4"
+      }
+    },
+    "@lg-chat/message-rating": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@lg-chat/message-rating/-/message-rating-7.1.2.tgz",
+      "integrity": "sha512-WyFwsDQrLZzZupjNnIJp9QRNKCDRjR0CtQ8r5TX7swx0lg1iTkRu7p56bTXbZYfV2loB6VyqHzWfcqrKrtyl9g==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/tooltip": "^14.3.1"
+      }
+    },
+    "@lg-chat/rich-links": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@lg-chat/rich-links/-/rich-links-4.0.8.tgz",
+      "integrity": "sha512-Iu5XHywEmlSU86VpzzGys0h0CvlLXBnFyC7q0V6K9SF2WNq1e4iMAICsFBDkIoK/+dbMw2tUrXCzQHgoTy59Ww==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/card": "^13.3.1",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/icon": "^14.8.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4"
+      }
+    },
+    "@lg-chat/title-bar": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@lg-chat/title-bar/-/title-bar-5.0.2.tgz",
+      "integrity": "sha512-iB2G2oZr0XMz1uyrKgfvpGljg0THxqhIFkyjttg7X5sgAdvYtp9VBbgChz5COsMEHsecip5XwDIfTVbZADQvBw==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/badge": "^10.2.4",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/lib": "^15.7.0",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/typography": "^22.2.4"
       }
     },
     "@lg-tools/test-harnesses": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@lg-tools/test-harnesses/-/test-harnesses-0.1.4.tgz",
-      "integrity": "sha512-3CbuBu28tgn919mHTWFwyKiHnrg78h3kOT1uIrYTlJzUJ8V8tcFXSCTlOYhn+8iQSlbG3dHVSbOcZmfSXDFohA==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@lg-tools/test-harnesses/-/test-harnesses-0.3.4.tgz",
+      "integrity": "sha512-JfJj2LSMe5vTSDQoLxWUHx2r4wUgKqU1UrgqjvNYM7iebXE0JCE7RvLiEg5SnsRO8xXQbEMjgISErmCDR4DS7Q==",
       "dev": true,
       "requires": {
         "@testing-library/dom": "9.3.1"
@@ -37133,69 +34445,102 @@
       }
     },
     "@mongodb-js/compass-components": {
-      "version": "1.21.3",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-components/-/compass-components-1.21.3.tgz",
-      "integrity": "sha512-unbvUMZf1ylj4pU6Uv5Zqz3gYvkMEDf/Umnh7y88R9CWOUIXRfdY2f05ZPRekgNeNrTXxX91LmwHLH1fRJKMDw==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-components/-/compass-components-1.68.0.tgz",
+      "integrity": "sha512-lt/IikfkHJybD+eSJugMqv6Q+rVPBhVrnjKjvcUcFHQrJ5S5/g/XRdKT7ZTZuBLLS4sgVLnWysMiGlltpv23sQ==",
       "dev": true,
       "requires": {
         "@dnd-kit/core": "^6.0.7",
         "@dnd-kit/sortable": "^7.0.2",
         "@dnd-kit/utilities": "^3.2.1",
-        "@emotion/css": "^11.11.2",
-        "@leafygreen-ui/badge": "^8.0.1",
-        "@leafygreen-ui/banner": "^7.0.1",
-        "@leafygreen-ui/button": "^19.0.3",
-        "@leafygreen-ui/card": "^9.0.2",
-        "@leafygreen-ui/checkbox": "^12.0.8",
-        "@leafygreen-ui/code": "^14.1.0",
-        "@leafygreen-ui/confirmation-modal": "^4.0.1",
-        "@leafygreen-ui/emotion": "^4.0.3",
-        "@leafygreen-ui/guide-cue": "^4.0.0",
-        "@leafygreen-ui/hooks": "^7.3.3",
-        "@leafygreen-ui/icon": "^11.21.0",
-        "@leafygreen-ui/icon-button": "^15.0.3",
-        "@leafygreen-ui/info-sprinkle": "^1.0.0",
-        "@leafygreen-ui/inline-definition": "^6.0.0",
-        "@leafygreen-ui/leafygreen-provider": "^3.1.0",
-        "@leafygreen-ui/lib": "^10.0.0",
-        "@leafygreen-ui/logo": "^7.0.0",
-        "@leafygreen-ui/marketing-modal": "^3.0.10",
-        "@leafygreen-ui/menu": "^19.0.1",
-        "@leafygreen-ui/modal": "^14.0.0",
-        "@leafygreen-ui/palette": "^3.4.6",
-        "@leafygreen-ui/pipeline": "^5.0.1",
-        "@leafygreen-ui/popover": "^11.0.1",
-        "@leafygreen-ui/portal": "^4.0.7",
-        "@leafygreen-ui/radio-box-group": "^12.0.5",
-        "@leafygreen-ui/radio-group": "^10.1.1",
-        "@leafygreen-ui/search-input": "^2.0.3",
-        "@leafygreen-ui/segmented-control": "^7.0.0",
-        "@leafygreen-ui/select": "^10.1.0",
-        "@leafygreen-ui/table": "^10.0.2",
-        "@leafygreen-ui/tabs": "^11.0.1",
-        "@leafygreen-ui/text-area": "^8.0.1",
-        "@leafygreen-ui/text-input": "^12.1.1",
-        "@leafygreen-ui/toast": "^6.1.3",
-        "@leafygreen-ui/toggle": "^10.0.2",
-        "@leafygreen-ui/tokens": "^1.4.1",
-        "@leafygreen-ui/tooltip": "^9.0.2",
-        "@leafygreen-ui/typography": "^15.2.0",
+        "@leafygreen-ui/avatar": "^3.3.0",
+        "@leafygreen-ui/badge": "^10.2.4",
+        "@leafygreen-ui/banner": "^10.2.5",
+        "@leafygreen-ui/button": "^25.2.1",
+        "@leafygreen-ui/card": "^13.3.1",
+        "@leafygreen-ui/checkbox": "^18.1.5",
+        "@leafygreen-ui/chip": "^4.2.1",
+        "@leafygreen-ui/code": "^20.2.7",
+        "@leafygreen-ui/combobox": "^12.5.1",
+        "@leafygreen-ui/confirmation-modal": "^11.0.1",
+        "@leafygreen-ui/copyable": "^12.0.3",
+        "@leafygreen-ui/drawer": "^5.2.3",
+        "@leafygreen-ui/emotion": "^5.2.0",
+        "@leafygreen-ui/guide-cue": "^8.2.0",
+        "@leafygreen-ui/hooks": "^9.3.1",
+        "@leafygreen-ui/icon": "^14.9.0",
+        "@leafygreen-ui/icon-button": "^17.1.5",
+        "@leafygreen-ui/info-sprinkle": "^5.0.11",
+        "@leafygreen-ui/input-option": "^4.1.5",
+        "@leafygreen-ui/leafygreen-provider": "^5.0.4",
+        "@leafygreen-ui/logo": "^11.1.0",
+        "@leafygreen-ui/marketing-modal": "^8.2.1",
+        "@leafygreen-ui/menu": "^33.2.1",
+        "@leafygreen-ui/modal": "^22.0.1",
+        "@leafygreen-ui/palette": "^5.0.2",
+        "@leafygreen-ui/pipeline": "^8.0.10",
+        "@leafygreen-ui/polymorphic": "^3.1.0",
+        "@leafygreen-ui/popover": "^14.3.2",
+        "@leafygreen-ui/portal": "^7.1.0",
+        "@leafygreen-ui/progress-bar": "^1.0.8",
+        "@leafygreen-ui/radio-box-group": "^15.0.11",
+        "@leafygreen-ui/radio-group": "^13.0.12",
+        "@leafygreen-ui/search-input": "^6.1.3",
+        "@leafygreen-ui/segmented-control": "^11.1.0",
+        "@leafygreen-ui/select": "^17.0.3",
+        "@leafygreen-ui/skeleton-loader": "^3.0.11",
+        "@leafygreen-ui/split-button": "^6.3.1",
+        "@leafygreen-ui/table": "^15.2.3",
+        "@leafygreen-ui/tabs": "^17.0.11",
+        "@leafygreen-ui/text-area": "^12.1.5",
+        "@leafygreen-ui/text-input": "^16.2.3",
+        "@leafygreen-ui/toast": "^8.1.3",
+        "@leafygreen-ui/toggle": "^12.1.5",
+        "@leafygreen-ui/tokens": "^4.2.2",
+        "@leafygreen-ui/tooltip": "^14.3.1",
+        "@leafygreen-ui/typography": "^22.2.4",
+        "@lg-chat/chat-window": "^6.0.2",
+        "@lg-chat/input-bar": "^12.2.2",
+        "@lg-chat/leafygreen-chat-provider": "^6.0.0",
+        "@lg-chat/message": "^12.0.0",
+        "@lg-chat/message-prompts": "^4.2.2",
+        "@mongodb-js/compass-context-menu": "^0.3.15",
+        "@mongodb-js/diagramming": "^2.4.1",
         "@react-aria/interactions": "^3.9.1",
-        "@react-aria/tooltip": "^3.2.1",
         "@react-aria/utils": "^3.13.1",
         "@react-aria/visually-hidden": "^3.3.1",
-        "@react-stately/tooltip": "^3.0.5",
-        "bson": "^6.2.0",
-        "focus-trap-react": "^8.4.2",
-        "hadron-document": "^8.4.7",
-        "hadron-type-checker": "^7.1.1",
+        "bson": "^7.2.0",
+        "focus-trap-react": "^9.0.2",
+        "hadron-document": "^8.11.8",
+        "hadron-type-checker": "^7.5.8",
         "is-electron-renderer": "^2.0.1",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
+        "mongodb-query-parser": "^4.7.14",
+        "mongodb-query-util": "^2.6.8",
         "polished": "^4.2.2",
-        "prop-types": "^15.7.2",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2",
         "react-hotkeys-hook": "^4.3.7",
         "react-intersection-observer": "^8.34.0",
+        "react-virtualized-auto-sizer": "^1.0.6",
         "react-window": "^1.8.6"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.2.tgz",
+          "integrity": "sha512-1w0ra+ho1cuE+w8jzwgzTFIimFtCfZeCoOsvIPQg6uyFCsp8M29U7bNNf5GrFh88TXbYg1g3TyKUGpd6O7q6zA==",
+          "dev": true
+        }
+      }
+    },
+    "@mongodb-js/compass-context-menu": {
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-context-menu/-/compass-context-menu-0.3.15.tgz",
+      "integrity": "sha512-ZCGagfRMA2xZrXq5nhlpxsFd4mVS5tljIQa45RQbWmmVMbpegVWsR51PtQk3ng0DJg0cLw1cCvyVbuwb7Vexfg==",
+      "dev": true,
+      "requires": {
+        "react": "^17.0.2"
       }
     },
     "@mongodb-js/compass-test-server": {
@@ -37545,6 +34890,86 @@
         "pacote": "^21.3.1",
         "prettier": "^3.8.1",
         "prompts": "^2.4.2"
+      }
+    },
+    "@mongodb-js/diagramming": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/diagramming/-/diagramming-2.4.1.tgz",
+      "integrity": "sha512-AzPMacmzTOF7EVJ53GCwC/BJd8Pmw4RQEyOc/K2vN+IFeQ0HnOuNLlmGK3HvXy+qbkjjnfwMocQF9t1SEVZmHw==",
+      "dev": true,
+      "requires": {
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.0",
+        "@leafygreen-ui/icon": "^14.3.0",
+        "@leafygreen-ui/inline-definition": "^9.0.5",
+        "@leafygreen-ui/leafygreen-provider": "^5.0.2",
+        "@leafygreen-ui/palette": "^5.0.0",
+        "@leafygreen-ui/select": "^16.2.0",
+        "@leafygreen-ui/tokens": "^3.2.1",
+        "@leafygreen-ui/tooltip": "^14.2.1",
+        "@leafygreen-ui/typography": "^22.1.0",
+        "@xyflow/react": "12.5.1",
+        "d3-path": "^3.1.0",
+        "elkjs": "^0.11.0",
+        "react": "17.0.2",
+        "react-dom": "17.0.2"
+      },
+      "dependencies": {
+        "@leafygreen-ui/select": {
+          "version": "16.3.0",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/select/-/select-16.3.0.tgz",
+          "integrity": "sha512-/UP9NO4HKyOmN8fac8DFQnW2ia/O/odp5LPxehymvRPSSgDGzTBoVK8JPocayEZHTO+kLRjmiJm6QaQ09xmhRQ==",
+          "dev": true,
+          "requires": {
+            "@leafygreen-ui/button": "^25.1.2",
+            "@leafygreen-ui/emotion": "^5.1.0",
+            "@leafygreen-ui/form-field": "^4.0.6",
+            "@leafygreen-ui/hooks": "^9.2.2",
+            "@leafygreen-ui/icon": "^14.6.1",
+            "@leafygreen-ui/input-option": "^4.1.2",
+            "@leafygreen-ui/lib": "^15.6.2",
+            "@leafygreen-ui/palette": "^5.0.2",
+            "@leafygreen-ui/popover": "^14.3.0",
+            "@leafygreen-ui/tokens": "^4.0.0",
+            "@leafygreen-ui/typography": "^22.2.0",
+            "@lg-tools/test-harnesses": "^0.3.4",
+            "@types/react-is": "^18.0.0",
+            "lodash": "^4.17.21",
+            "polished": "^4.1.3",
+            "react-is": "^18.0.1"
+          },
+          "dependencies": {
+            "@leafygreen-ui/tokens": {
+              "version": "4.2.2",
+              "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-4.2.2.tgz",
+              "integrity": "sha512-7E31JJ3ASrS5hJ7RxUA/ax+/nBLmNGwJb0AR8tlQsTHeipVeFwQEyWrxHxFTBv3Qyu3qk4L1n52LDuKFkbuENA==",
+              "dev": true,
+              "requires": {
+                "@leafygreen-ui/emotion": "^5.2.0",
+                "@leafygreen-ui/lib": "^15.7.0",
+                "@leafygreen-ui/palette": "^5.0.2"
+              }
+            }
+          }
+        },
+        "@leafygreen-ui/tokens": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-3.2.4.tgz",
+          "integrity": "sha512-Bd11x/ext/vVozd/HL+AD8LbL71Z6B6VbtQ/+qLqoX8qHMsJt7VWL0CmmGs5NVHh3v5sAlfT5DYbB9uhwVM8Qw==",
+          "dev": true,
+          "requires": {
+            "@leafygreen-ui/emotion": "^5.0.2",
+            "@leafygreen-ui/lib": "^15.3.0",
+            "@leafygreen-ui/palette": "^5.0.2",
+            "polished": "^4.2.2"
+          }
+        },
+        "react-is": {
+          "version": "18.3.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+          "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+          "dev": true
+        }
       }
     },
     "@mongodb-js/dl-center": {
@@ -38603,7 +36028,7 @@
       "version": "file:packages/oidc-http-server-pages",
       "requires": {
         "@leafygreen-ui/emotion": "^5.2.0",
-        "@mongodb-js/compass-components": "^1.6.0",
+        "@mongodb-js/compass-components": "^1.68.0",
         "@mongodb-js/eslint-config-devtools": "^0.11.8",
         "@mongodb-js/mocha-config-devtools": "^1.1.3",
         "@mongodb-js/prettier-config-devtools": "^1.0.4",
@@ -38618,6 +36043,7 @@
         "eslint": "^7.25.0 || ^8.0.0",
         "gen-esm-wrapper": "^1.1.3",
         "mocha": "^8.4.0",
+        "mongodb-query-parser": "^4.7.16",
         "nyc": "^15.1.0",
         "prettier": "^3.8.1",
         "react": "^17.0.2",
@@ -38625,17 +36051,6 @@
         "typescript": "^5.9.3"
       },
       "dependencies": {
-        "@leafygreen-ui/emotion": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-5.2.0.tgz",
-          "integrity": "sha512-Sov+2tDy4ahGsRR8/KOV8Zzx+5fvVAj7Smyc1brgzE8ocXnOiwahQQ1wVvthAXS91iXPpnuNA5KL6Qzh3jNfQw==",
-          "dev": true,
-          "requires": {
-            "@emotion/css": "^11.1.3",
-            "@emotion/react": "^11.14.0",
-            "@emotion/server": "^11.4.0"
-          }
-        },
         "@types/sinon-chai": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-4.0.0.tgz",
@@ -40531,19 +37946,6 @@
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "optional": true
     },
-    "@react-aria/focus": {
-      "version": "3.16.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.16.1.tgz",
-      "integrity": "sha512-3ZEYc+hWqDQX7fA54ZOTkED8OGXs9+K9fYmjD1IdjZJAJS/2/AJ95PgIQ29zBkl9D9TAi4Nb3tJ/3+H/02UzoA==",
-      "dev": true,
-      "requires": {
-        "@react-aria/interactions": "^3.21.0",
-        "@react-aria/utils": "^3.23.1",
-        "@react-types/shared": "^3.22.0",
-        "@swc/helpers": "^0.5.0",
-        "clsx": "^2.0.0"
-      }
-    },
     "@react-aria/interactions": {
       "version": "3.21.0",
       "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.21.0.tgz",
@@ -40562,21 +37964,6 @@
       "integrity": "sha512-NqzkLFP8ZVI4GSorS0AYljC13QW2sc8bDqJOkBvkAt3M8gbcAXJWVRGtZBCRscki9RZF+rNlnPdg0G0jYkhJcg==",
       "dev": true,
       "requires": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
-    "@react-aria/tooltip": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/tooltip/-/tooltip-3.7.1.tgz",
-      "integrity": "sha512-2lf72hIw3gfQLvKU9SHkh3a/CP8GJ3MbKlPq8x0gX7444zaYII/UDqIkde1TiR2fB71I/MqKSOx6mg28B9lj4w==",
-      "dev": true,
-      "requires": {
-        "@react-aria/focus": "^3.16.1",
-        "@react-aria/interactions": "^3.21.0",
-        "@react-aria/utils": "^3.23.1",
-        "@react-stately/tooltip": "^3.4.6",
-        "@react-types/shared": "^3.22.0",
-        "@react-types/tooltip": "^3.4.6",
         "@swc/helpers": "^0.5.0"
       }
     },
@@ -40605,28 +37992,6 @@
         "@swc/helpers": "^0.5.0"
       }
     },
-    "@react-stately/overlays": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.4.tgz",
-      "integrity": "sha512-tHEaoAGpE9dSnsskqLPVKum59yGteoSqsniTopodM+miQozbpPlSjdiQnzGLroy5Afx5OZYClE616muNHUILXA==",
-      "dev": true,
-      "requires": {
-        "@react-stately/utils": "^3.9.0",
-        "@react-types/overlays": "^3.8.4",
-        "@swc/helpers": "^0.5.0"
-      }
-    },
-    "@react-stately/tooltip": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@react-stately/tooltip/-/tooltip-3.4.6.tgz",
-      "integrity": "sha512-uL93bmsXf+OOgpKLPEKfpDH4z+MK2CuqlqVxx7rshN0vjWOSoezE5nzwgee90+RpDrLNNNWTNa7n+NkDRpI1jA==",
-      "dev": true,
-      "requires": {
-        "@react-stately/overlays": "^3.6.4",
-        "@react-types/tooltip": "^3.4.6",
-        "@swc/helpers": "^0.5.0"
-      }
-    },
     "@react-stately/utils": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.9.0.tgz",
@@ -40636,30 +38001,11 @@
         "@swc/helpers": "^0.5.0"
       }
     },
-    "@react-types/overlays": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.8.4.tgz",
-      "integrity": "sha512-pfgNlQnbF6RB/R2oSxyqAP3Uzz0xE/k5q4n5gUeCDNLjY5qxFHGE8xniZZ503nZYw6VBa9XMN1efDOKQyeiO0w==",
-      "dev": true,
-      "requires": {
-        "@react-types/shared": "^3.22.0"
-      }
-    },
     "@react-types/shared": {
       "version": "3.22.0",
       "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.22.0.tgz",
       "integrity": "sha512-yVOekZWbtSmmiThGEIARbBpnmUIuePFlLyctjvCbgJgGhz8JnEJOipLQ/a4anaWfzAgzSceQP8j/K+VOOePleA==",
       "dev": true
-    },
-    "@react-types/tooltip": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@react-types/tooltip/-/tooltip-3.4.6.tgz",
-      "integrity": "sha512-RaZewdER7ZcsNL99RhVHs8kSLyzIBkwc0W6eFZrxST2MD9J5GzkVWRhIiqtFOd5U1aYnxdJ6woq72Ef+le6Vfw==",
-      "dev": true,
-      "requires": {
-        "@react-types/overlays": "^3.8.4",
-        "@react-types/shared": "^3.22.0"
-      }
     },
     "@sigstore/bundle": {
       "version": "4.0.0",
@@ -40910,23 +38256,6 @@
         }
       }
     },
-    "@storybook/csf": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.2.tgz",
-      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-      "dev": true,
-      "requires": {
-        "type-fest": "^2.19.0"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-          "dev": true
-        }
-      }
-    },
     "@swc/helpers": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.6.tgz",
@@ -40951,6 +38280,36 @@
       "requires": {
         "defer-to-connect": "^2.0.0"
       }
+    },
+    "@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "dev": true,
+      "requires": {
+        "@tanstack/table-core": "8.21.3"
+      }
+    },
+    "@tanstack/react-virtual": {
+      "version": "3.14.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.9.tgz",
+      "integrity": "sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==",
+      "dev": true,
+      "requires": {
+        "@tanstack/virtual-core": "3.17.7"
+      }
+    },
+    "@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "dev": true
+    },
+    "@tanstack/virtual-core": {
+      "version": "3.17.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.7.tgz",
+      "integrity": "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==",
+      "dev": true
     },
     "@testing-library/dom": {
       "version": "9.3.1",
@@ -41145,6 +38504,55 @@
         "@types/node": "*"
       }
     },
+    "@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "dev": true
+    },
+    "@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "dev": true,
+      "requires": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dev": true,
+      "requires": {
+        "@types/d3-color": "*"
+      }
+    },
+    "@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "dev": true
+    },
+    "@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "dev": true,
+      "requires": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "dev": true,
+      "requires": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "@types/debug": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
@@ -41211,6 +38619,15 @@
         "@types/node": "*"
       }
     },
+    "@types/hast": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
+      "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2"
+      }
+    },
     "@types/highlight.js": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-10.1.0.tgz",
@@ -41274,6 +38691,15 @@
       "dev": true,
       "requires": {
         "@types/lodash": "*"
+      }
+    },
+    "@types/mdast": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
+      "integrity": "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2"
       }
     },
     "@types/memory-pager": {
@@ -41425,22 +38851,31 @@
       }
     },
     "@types/react-is": {
-      "version": "18.2.4",
-      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-18.2.4.tgz",
-      "integrity": "sha512-wBc7HgmbCcrvw0fZjxbgz/xrrlZKzEqmABBMeSvpTvdm25u6KI6xdIi9pRE2G0C1Lw5ETFdcn4UbYZ4/rpqUYw==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-zts4lhQn5ia0cF/y2+3V6Riu0MAfez9/LJYavdM8TvcVl+S91A/7VWxyBT8hbRuWspmuCaiGI0F41OJYGrKhRA==",
       "dev": true,
       "requires": {
-        "@types/react": "*"
+        "@types/react": "^18"
+      },
+      "dependencies": {
+        "@types/react": {
+          "version": "18.3.31",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+          "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+          "dev": true,
+          "requires": {
+            "@types/prop-types": "*",
+            "csstype": "^3.2.2"
+          }
+        }
       }
     },
     "@types/react-transition-group": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
-      "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
-      "dev": true,
-      "requires": {
-        "@types/react": "*"
-      }
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "dev": true
     },
     "@types/regexp.escape": {
       "version": "2.0.0",
@@ -41590,6 +39025,12 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.2.tgz",
       "integrity": "sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g==",
+      "dev": true
+    },
+    "@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "dev": true
     },
     "@types/webidl-conversions": {
@@ -42172,6 +39613,32 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
+    "@xyflow/react": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.5.1.tgz",
+      "integrity": "sha512-jMKQVqGwCz0x6pUyvxTIuCMbyehfua7CfEEWDj29zQSHigQpCy0/5d8aOmZrqK4cwur/pVHLQomT6Rm10gXfHg==",
+      "dev": true,
+      "requires": {
+        "@xyflow/system": "0.0.53",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      }
+    },
+    "@xyflow/system": {
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.53.tgz",
+      "integrity": "sha512-QTWieiTtvNYyQAz1fxpzgtUGXNpnhfh6vvZa7dFWpWS2KOz6bEHODo/DTK3s07lDu0Bq0Db5lx/5M5mNjb9VDQ==",
+      "dev": true,
+      "requires": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
     "@yarnpkg/lockfile": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
@@ -42633,6 +40100,12 @@
       "requires": {
         "@babel/helper-define-polyfill-provider": "^0.6.8"
       }
+    },
+    "bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -43235,6 +40708,12 @@
         "supports-color": "^7.1.0"
       }
     },
+    "character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "dev": true
+    },
     "chardet": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
@@ -43311,6 +40790,12 @@
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
       "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
+      "dev": true
+    },
+    "classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
       "dev": true
     },
     "clean-stack": {
@@ -43532,6 +41017,12 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true
     },
     "commander": {
       "version": "2.20.3",
@@ -43875,9 +41366,9 @@
       }
     },
     "csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true
     },
     "d": {
@@ -43888,6 +41379,87 @@
       "requires": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
+      }
+    },
+    "d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "dev": true
+    },
+    "d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "dev": true
+    },
+    "d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dev": true,
+      "requires": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      }
+    },
+    "d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "dev": true
+    },
+    "d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dev": true,
+      "requires": {
+        "d3-color": "1 - 3"
+      }
+    },
+    "d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "dev": true
+    },
+    "d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "dev": true
+    },
+    "d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "dev": true
+    },
+    "d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dev": true,
+      "requires": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      }
+    },
+    "d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dev": true,
+      "requires": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
       }
     },
     "damerau-levenshtein": {
@@ -43987,6 +41559,15 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
+    },
+    "decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "dev": true,
+      "requires": {
+        "character-entities": "^2.0.0"
+      }
     },
     "decompress": {
       "version": "4.2.1",
@@ -44365,6 +41946,12 @@
       "integrity": "sha512-PwuBojGMQAYbWkMXOY9Pd/NWCDNHVH12pnS7WHqZkTSeMESe4hwnKKRp0yR87g37113x4JPbo/oIvXY+s/f56Q==",
       "dev": true
     },
+    "dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true
+    },
     "destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -44599,6 +42186,12 @@
       "version": "1.5.339",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.339.tgz",
       "integrity": "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg=="
+    },
+    "elkjs": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.11.1.tgz",
+      "integrity": "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==",
+      "dev": true
     },
     "email-validator": {
       "version": "2.0.4",
@@ -45682,6 +43275,12 @@
         }
       }
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
     "extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -45935,15 +43534,32 @@
       "dev": true,
       "requires": {
         "tabbable": "^5.3.3"
+      },
+      "dependencies": {
+        "tabbable": {
+          "version": "5.3.3",
+          "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
+          "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==",
+          "dev": true
+        }
       }
     },
     "focus-trap-react": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-8.11.3.tgz",
-      "integrity": "sha512-y126gMYuB1aVYiEZSP6/v9bAfVmAIUVixanhcoMelkz7bOh+l0c3h05CEHC8S63ztxdRI2AAPS9AsTat6jlDeQ==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-9.0.2.tgz",
+      "integrity": "sha512-ZwhO5by6KG5r3dy48Lk00A1/0zNYw1Z3RZTN6O6kgAPsWFcwTFszOcQ1dLSfM8pIxpS/ttc7wTttJowjVT3jpg==",
       "dev": true,
       "requires": {
-        "focus-trap": "^6.9.4"
+        "focus-trap": "^6.9.4",
+        "tabbable": "^5.3.3"
+      },
+      "dependencies": {
+        "tabbable": {
+          "version": "5.3.3",
+          "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
+          "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==",
+          "dev": true
+        }
       }
     },
     "follow-redirects": {
@@ -46737,26 +44353,42 @@
       "dev": true
     },
     "hadron-document": {
-      "version": "8.4.7",
-      "resolved": "https://registry.npmjs.org/hadron-document/-/hadron-document-8.4.7.tgz",
-      "integrity": "sha512-6nxghzGKDvRJ91XtNaAn6VYgJThhhD5ohwhGua4w7sCa524+PkasAUS7EOLWGcp5tlWP+mAyBlVtUf/r4XruGw==",
+      "version": "8.11.8",
+      "resolved": "https://registry.npmjs.org/hadron-document/-/hadron-document-8.11.8.tgz",
+      "integrity": "sha512-vQuCWmeuesIjvG3jufITL6WA4Lw53TJE7VGiHXONZdX7qQDJoYvmentXem5EiNYumb1upqcvwlVb40iSGEcKxQ==",
       "dev": true,
       "requires": {
-        "bson": "^6.2.0",
-        "debug": "^4.2.0",
+        "bson": "^7.2.0",
         "eventemitter3": "^4.0.0",
-        "hadron-type-checker": "^7.1.1",
-        "lodash": "^4.17.21"
+        "hadron-type-checker": "^7.5.8",
+        "lodash": "^4.18.1",
+        "mongodb": "^7.1.1"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.2.tgz",
+          "integrity": "sha512-1w0ra+ho1cuE+w8jzwgzTFIimFtCfZeCoOsvIPQg6uyFCsp8M29U7bNNf5GrFh88TXbYg1g3TyKUGpd6O7q6zA==",
+          "dev": true
+        }
       }
     },
     "hadron-type-checker": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/hadron-type-checker/-/hadron-type-checker-7.1.1.tgz",
-      "integrity": "sha512-fkCf7ryFhWlag0GYG3FNuOuyO5/ty9Rnj39k+PApxkvXGhyZawAHxT711Hx2ICihX/TKxtYtXfeOhs6Xet/HGQ==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/hadron-type-checker/-/hadron-type-checker-7.5.8.tgz",
+      "integrity": "sha512-GFXUSS5zLaWZCFNKzKvtlD0sOxtw0AXRzBka8UXUHzVeVVT2hAfhuRGdmnxUvQTVSmFNWoc/g+pjN19PGiI8SA==",
       "dev": true,
       "requires": {
-        "bson": "^6.2.0",
-        "lodash": "^4.17.21"
+        "bson": "^7.2.0",
+        "lodash": "^4.18.1"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.2.tgz",
+          "integrity": "sha512-1w0ra+ho1cuE+w8jzwgzTFIimFtCfZeCoOsvIPQg6uyFCsp8M29U7bNNf5GrFh88TXbYg1g3TyKUGpd6O7q6zA==",
+          "dev": true
+        }
       }
     },
     "handlebars": {
@@ -46861,6 +44493,12 @@
       "requires": {
         "function-bind": "^1.1.2"
       }
+    },
+    "hast-util-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz",
+      "integrity": "sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==",
+      "dev": true
     },
     "he": {
       "version": "1.2.0",
@@ -47272,6 +44910,12 @@
         }
       }
     },
+    "inline-style-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==",
+      "dev": true
+    },
     "inquirer": {
       "version": "12.9.6",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.9.6.tgz",
@@ -47358,13 +45002,13 @@
       "dev": true
     },
     "is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       }
     },
     "is-array-buffer": {
@@ -47420,6 +45064,12 @@
         "call-bound": "^1.0.3",
         "has-tostringtag": "^1.0.2"
       }
+    },
+    "is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true
     },
     "is-builtin-module": {
       "version": "3.2.1",
@@ -49023,6 +46673,12 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "lottie-web": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/lottie-web/-/lottie-web-5.13.0.tgz",
+      "integrity": "sha512-+gfBXl6sxXMPe8tKQm7qzLnUy5DUPJPKIyRHwtpCpyUEYjHYRJC/5gjUvdkuO2c3JllrPtHXH5UJJK8LRYl5yQ==",
+      "dev": true
+    },
     "loupe": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
@@ -49158,6 +46814,62 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
+    "mdast-util-definitions": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-5.1.2.tgz",
+      "integrity": "sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==",
+      "dev": true,
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "unist-util-visit": "^4.0.0"
+      }
+    },
+    "mdast-util-from-markdown": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
+      "integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
+      "dev": true,
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "mdast-util-to-string": "^3.1.0",
+        "micromark": "^3.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-decode-string": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "mdast-util-to-hast": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.3.0.tgz",
+      "integrity": "sha512-pits93r8PhnIoU4Vy9bjW39M2jJ6/tdHyja9rrot9uujkN7UTU9SDnE6WNJz/IGyQk3XHX6yNNtrBH6cQzm8Hw==",
+      "dev": true,
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "@types/mdast": "^3.0.0",
+        "mdast-util-definitions": "^5.0.0",
+        "micromark-util-sanitize-uri": "^1.1.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-generated": "^2.0.0",
+        "unist-util-position": "^4.0.0",
+        "unist-util-visit": "^4.0.0"
+      }
+    },
+    "mdast-util-to-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
+      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
+      "dev": true,
+      "requires": {
+        "@types/mdast": "^3.0.0"
+      }
     },
     "media-typer": {
       "version": "0.3.0",
@@ -49340,6 +47052,238 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true
+    },
+    "micromark": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
+      "integrity": "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==",
+      "dev": true,
+      "requires": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-core-commonmark": "^1.0.1",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-combine-extensions": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-core-commonmark": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz",
+      "integrity": "sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==",
+      "dev": true,
+      "requires": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-factory-destination": "^1.0.0",
+        "micromark-factory-label": "^1.0.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-factory-title": "^1.0.0",
+        "micromark-factory-whitespace": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-classify-character": "^1.0.0",
+        "micromark-util-html-tag-name": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-factory-destination": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.1.0.tgz",
+      "integrity": "sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==",
+      "dev": true,
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-factory-label": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.1.0.tgz",
+      "integrity": "sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==",
+      "dev": true,
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-factory-space": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
+      "integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
+      "dev": true,
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-factory-title": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.1.0.tgz",
+      "integrity": "sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==",
+      "dev": true,
+      "requires": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-factory-whitespace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.1.0.tgz",
+      "integrity": "sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==",
+      "dev": true,
+      "requires": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-util-character": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+      "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+      "dev": true,
+      "requires": {
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-util-chunked": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.1.0.tgz",
+      "integrity": "sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==",
+      "dev": true,
+      "requires": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "micromark-util-classify-character": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.1.0.tgz",
+      "integrity": "sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==",
+      "dev": true,
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-util-combine-extensions": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.1.0.tgz",
+      "integrity": "sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==",
+      "dev": true,
+      "requires": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-util-decode-numeric-character-reference": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz",
+      "integrity": "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==",
+      "dev": true,
+      "requires": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "micromark-util-decode-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz",
+      "integrity": "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==",
+      "dev": true,
+      "requires": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "micromark-util-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz",
+      "integrity": "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==",
+      "dev": true
+    },
+    "micromark-util-html-tag-name": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.2.0.tgz",
+      "integrity": "sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q==",
+      "dev": true
+    },
+    "micromark-util-normalize-identifier": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.1.0.tgz",
+      "integrity": "sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==",
+      "dev": true,
+      "requires": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "micromark-util-resolve-all": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.1.0.tgz",
+      "integrity": "sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==",
+      "dev": true,
+      "requires": {
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-util-sanitize-uri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz",
+      "integrity": "sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==",
+      "dev": true,
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "micromark-util-subtokenize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.1.0.tgz",
+      "integrity": "sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==",
+      "dev": true,
+      "requires": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-util-symbol": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+      "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==",
+      "dev": true
+    },
+    "micromark-util-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+      "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==",
       "dev": true
     },
     "micromatch": {
@@ -49889,6 +47833,25 @@
         }
       }
     },
+    "mongodb-query-util": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/mongodb-query-util/-/mongodb-query-util-2.6.8.tgz",
+      "integrity": "sha512-P5o9NVury4g7JElaYsL7BBeF7RyFuh34CZGbTsiwScW1B/w4QdE9d0ADZXbFKRUu90/owMpEFHXGBqg23gyqdw==",
+      "dev": true,
+      "requires": {
+        "bson": "^7.2.0",
+        "hadron-type-checker": "^7.5.8",
+        "lodash": "^4.18.1"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.2.tgz",
+          "integrity": "sha512-1w0ra+ho1cuE+w8jzwgzTFIimFtCfZeCoOsvIPQg6uyFCsp8M29U7bNNf5GrFh88TXbYg1g3TyKUGpd6O7q6zA==",
+          "dev": true
+        }
+      }
+    },
     "mongodb-redact": {
       "version": "file:packages/mongodb-redact",
       "requires": {
@@ -50158,6 +48121,12 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
       "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w=="
+    },
+    "mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.3",
@@ -51848,6 +49817,12 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "property-information": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz",
+      "integrity": "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==",
+      "dev": true
+    },
     "protocols": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.2.tgz",
@@ -52073,6 +50048,12 @@
         "scheduler": "^0.20.2"
       }
     },
+    "react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "dev": true
+    },
     "react-hotkeys-hook": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-4.5.0.tgz",
@@ -52090,6 +50071,65 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "react-keyed-flatten-children": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-keyed-flatten-children/-/react-keyed-flatten-children-2.2.1.tgz",
+      "integrity": "sha512-6yBLVO6suN8c/OcJk1mzIrUHdeEzf5rtRVBhxEXAHO49D7SlJ70cG4xrSJrBIAG7MMeQ+H/T151mM2dRDNnFaA==",
+      "dev": true,
+      "requires": {
+        "react-is": "^18.2.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.3.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+          "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+          "dev": true
+        }
+      }
+    },
+    "react-lottie-player": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/react-lottie-player/-/react-lottie-player-1.5.6.tgz",
+      "integrity": "sha512-t0GdTYbml0Ihski8ZPx+1WjpjM/EQlTqTcuGm5yeZGJAgFXTmoqrHbSX8bcREIxrHjibWAyIWnLVUK/iHLcqAQ==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.3",
+        "lottie-web": "^5.7.6",
+        "rfdc": "^1.3.0"
+      }
+    },
+    "react-markdown": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-8.0.7.tgz",
+      "integrity": "sha512-bvWbzG4MtOU62XqBx3Xx+zB2raaFFsq4mYiAzfjXJMEz2sixgeAfraA3tvzULF02ZdOMUOKTBFFaZJDDrq+BJQ==",
+      "dev": true,
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "@types/prop-types": "^15.0.0",
+        "@types/unist": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^2.0.0",
+        "prop-types": "^15.0.0",
+        "property-information": "^6.0.0",
+        "react-is": "^18.0.0",
+        "remark-parse": "^10.0.0",
+        "remark-rehype": "^10.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-object": "^0.4.0",
+        "unified": "^10.0.0",
+        "unist-util-visit": "^4.0.0",
+        "vfile": "^5.0.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.3.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+          "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+          "dev": true
+        }
+      }
+    },
     "react-shallow-renderer": {
       "version": "16.15.0",
       "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
@@ -52097,6 +50137,17 @@
       "requires": {
         "object-assign": "^4.1.1",
         "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "react-textarea-autosize": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
+      "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.20.13",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
       }
     },
     "react-transition-group": {
@@ -52110,6 +50161,12 @@
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
       }
+    },
+    "react-virtualized-auto-sizer": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.26.tgz",
+      "integrity": "sha512-CblNyiNVw2o+hsa5/49NH2ogGxZ+t+3aweRvNSq7TVjDIlwk7ir4lencEg5HxHeSzwNarSkNkiu0qJSOXtxm5A==",
+      "dev": true
     },
     "react-window": {
       "version": "1.8.10",
@@ -52351,12 +50408,6 @@
         "regenerate": "^1.4.2"
       }
     },
-    "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
-    },
     "regexp.escape": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexp.escape/-/regexp.escape-2.0.1.tgz",
@@ -52416,6 +50467,29 @@
       "dev": true,
       "requires": {
         "es6-error": "^4.0.1"
+      }
+    },
+    "remark-parse": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.2.tgz",
+      "integrity": "sha512-3ydxgHa/ZQzG8LvC7jTXccARYDcRld3VfcgIIFs7bI6vbRSxJJmzgLEIIoYKyrfhaY+ujuWaf/PJiMZXoiCXgw==",
+      "dev": true,
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-from-markdown": "^1.0.0",
+        "unified": "^10.0.0"
+      }
+    },
+    "remark-rehype": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-10.1.0.tgz",
+      "integrity": "sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==",
+      "dev": true,
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-hast": "^12.1.0",
+        "unified": "^10.0.0"
       }
     },
     "require-directory": {
@@ -52549,6 +50623,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
+    },
+    "rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true
     },
     "rimraf": {
       "version": "3.0.2",
@@ -52718,6 +50798,15 @@
           "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
           "dev": true
         }
+      }
+    },
+    "sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "requires": {
+        "mri": "^1.1.0"
       }
     },
     "safe-array-concat": {
@@ -53271,6 +51360,12 @@
         "source-map": "^0.6.0"
       }
     },
+    "space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true
+    },
     "sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
@@ -53605,6 +51700,15 @@
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
       "dev": true
     },
+    "style-to-object": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.4.tgz",
+      "integrity": "sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==",
+      "dev": true,
+      "requires": {
+        "inline-style-parser": "0.1.1"
+      }
+    },
     "stylis": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
@@ -53648,9 +51752,9 @@
       }
     },
     "tabbable": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
-      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
       "dev": true
     },
     "tapable": {
@@ -53913,6 +52017,12 @@
       "integrity": "sha512-gcANaAnd2QDZFmHFEOF4k7uc1J/6a6z3DJMd/QwEyxLoKGiptJRwid582r7QIsFlFMIZ3SnxfS52S4hm2DHkuQ==",
       "dev": true
     },
+    "trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true
+    },
     "trim-newlines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
@@ -53923,6 +52033,12 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
       "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "dev": true
+    },
+    "trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
       "dev": true
     },
     "ts-api-utils": {
@@ -54213,6 +52329,29 @@
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz",
       "integrity": "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ=="
     },
+    "unified": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "bail": "^2.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^5.0.0"
+      },
+      "dependencies": {
+        "is-plain-obj": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+          "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+          "dev": true
+        }
+      }
+    },
     "unique-filename": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-5.0.0.tgz",
@@ -54227,6 +52366,60 @@
       "integrity": "sha512-4Lup7Ezn8W3d52/xBhZBVdx323ckxa7DEvd9kPQHppTkLoJXw6ltrBCyj5pnrxj0qKDxYMJ56CoxNuFCscdTiw==",
       "requires": {
         "imurmurhash": "^0.1.4"
+      }
+    },
+    "unist-util-generated": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-2.0.1.tgz",
+      "integrity": "sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A==",
+      "dev": true
+    },
+    "unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0"
+      }
+    },
+    "unist-util-position": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-4.0.4.tgz",
+      "integrity": "sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0"
+      }
+    },
+    "unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0"
+      }
+    },
+    "unist-util-visit": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.1.1"
+      }
+    },
+    "unist-util-visit-parents": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
       }
     },
     "universal-user-agent": {
@@ -54278,6 +52471,33 @@
         "requires-port": "^1.0.0"
       }
     },
+    "use-composed-ref": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
+      "integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
+      "dev": true
+    },
+    "use-isomorphic-layout-effect": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
+      "dev": true
+    },
+    "use-latest": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
+      "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
+      "dev": true,
+      "requires": {
+        "use-isomorphic-layout-effect": "^1.1.1"
+      }
+    },
+    "use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "dev": true
+    },
     "util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
@@ -54306,6 +52526,26 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true
     },
+    "uvu": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
+      "integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
+      "dev": true,
+      "requires": {
+        "dequal": "^2.0.0",
+        "diff": "^5.0.0",
+        "kleur": "^4.0.3",
+        "sade": "^1.7.3"
+      },
+      "dependencies": {
+        "kleur": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+          "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+          "dev": true
+        }
+      }
+    },
     "v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -54330,6 +52570,28 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true
+    },
+    "vfile": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+      "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "vfile-message": "^3.0.0"
+      }
+    },
+    "vfile-message": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+      "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0"
+      }
     },
     "w3c-xmlserializer": {
       "version": "5.0.0",
@@ -54897,6 +53159,15 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.56.tgz",
       "integrity": "sha512-rd6eEF3BTNvQnR2e2wwolfTmUTnp70aUTqr0oaGbHifzC3BKJsoV+Gat8vxUMR1hwOKBs6El+qWehrHbCpW6SQ==",
       "dev": true
+    },
+    "zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "dev": true,
+      "requires": {
+        "use-sync-external-store": "^1.2.2"
+      }
     }
   }
 }

--- a/packages/oidc-http-server-pages/.depcheckrc
+++ b/packages/oidc-http-server-pages/.depcheckrc
@@ -4,5 +4,7 @@ ignores:
  - '@types/chai'
  - '@types/sinon-chai'
  - 'sinon'
+ # this is required due to the compass-components package
+ - 'mongodb-query-parser'
 ignore-patterns:
  - 'dist'

--- a/packages/oidc-http-server-pages/package.json
+++ b/packages/oidc-http-server-pages/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@leafygreen-ui/emotion": "^5.2.0",
-    "@mongodb-js/compass-components": "^1.6.0",
+    "@mongodb-js/compass-components": "^1.68.0",
     "@mongodb-js/eslint-config-devtools": "^0.11.8",
     "@mongodb-js/mocha-config-devtools": "^1.1.3",
     "@mongodb-js/prettier-config-devtools": "^1.0.4",
@@ -68,6 +68,7 @@
     "eslint": "^7.25.0 || ^8.0.0",
     "gen-esm-wrapper": "^1.1.3",
     "mocha": "^8.4.0",
+    "mongodb-query-parser": "^4.7.16",
     "nyc": "^15.1.0",
     "prettier": "^3.8.1",
     "react": "^17.0.2",


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  Use `feat`, `fix` for user facing changes that should be part of release notes.

  # Semantic Versioning:

  Package versions will be bumped automatically according to the PR title:

  - The words `BREAKING CHANGE` in the title will cause a **major** bump to all the packages changed in the PR. All dependants will also have a major bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - A subject starting with `feat` will cause a **minor** bump to all the packages changed in the PR. All dependants will also have a minor bump (dependencies, optionalDependencies, peerDependencies) or a patch bump (devDependencies).
  - Any other change to any package will cause a `patch` bump to the package and all its dependants.
-->

## Description

https://jira.mongodb.org/browse/COMPASS-10980

Bump the version of the `@mongodb-js/compass-components` lib as this was referencing a very old instance which was causing the callback from the login page to not render properly.

This issue was introduced when `leafgreen-ui/emotion` was bumped on [this change](https://github.com/mongodb-js/devtools-shared/commit/80755ed6d6e72d80c72d0ba16f2c2a0aec88ef7b). 

<details>
<summary>Before</summary>

<img width="1972" height="758" alt="image" src="https://github.com/user-attachments/assets/d6a930e0-2b40-436e-9b57-cbbe0c585281" />

</details>

<details>
<summary>After</summary>

<img width="3022" height="1818" alt="image" src="https://github.com/user-attachments/assets/ceac499d-7b1d-4c0d-a965-e219da9b5110" />

</details>

<!--- Any particular areas you'd like reviewers to pay attention to? -->

I have tested this by manually installing a local version of this lib into compass by running:
1. `cd packages/oidc-http-server-pages && npm pack`
2. In compass -> `npm install /path/to/devtools-shared/packages/oidc-http-server-pages/mongodb-js-oidc-http-server-pages-*.tgz`

## Checklist

- [x] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
