### PR TITLE
feat(mongodb-runner): add download dir as env, cache mongodb download on windows ci COMPASS-10932

### DIFF
--- a/.github/workflows/check-test.yaml
+++ b/.github/workflows/check-test.yaml
@@ -122,7 +122,7 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ runner.temp }}/mongodb-binaries
-          key: v1-mongodb-binaries-${{ runner.os }}-group${{ matrix.group }}-${{ steps.cache-week.outputs.week }}
+          key: v1-mongodb-binaries-${{ runner.os }}-${{ steps.cache-week.outputs.week }}
 
       - name: Set MongoDB binaries download dir
         if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/check-test.yaml
+++ b/.github/workflows/check-test.yaml
@@ -103,6 +103,32 @@ jobs:
         run: npm run check-ci -- --stream
         shell: bash
 
+      # Downloading and extracting MongoDB server binaries is slow on Windows,
+      # so we cache them between runs.
+      #
+      # Cache directories are named after the requested version range ('8.x',
+      # '*'), not the version it resolved to, so a cache entry pins tests to
+      # whichever release was current when it was written. Including the ISO
+      # week in the key rotates that weekly, keeping us at most a week behind.
+      # Bump `v1` to force a refresh.
+      - name: Compute cache week
+        if: ${{ runner.os == 'Windows' }}
+        id: cache-week
+        run: echo "week=$(date -u +%G-%V)" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Cache MongoDB binaries
+        if: ${{ runner.os == 'Windows' }}
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ runner.temp }}/mongodb-binaries
+          key: v1-mongodb-binaries-${{ runner.os }}-group${{ matrix.group }}-${{ steps.cache-week.outputs.week }}
+
+      - name: Set MongoDB binaries download dir
+        if: ${{ runner.os == 'Windows' }}
+        run: echo "MONGODB_RUNNER_DOWNLOAD_DIR=${RUNNER_TEMP}/mongodb-binaries" >> $GITHUB_ENV
+        shell: bash
+
       - name: Run Tests
         run: |
           scopes=$(node .github/scripts/compute-test-group.mjs "${{ matrix.group }}" "${TOTAL_GROUPS}")

--- a/.github/workflows/check-test.yaml
+++ b/.github/workflows/check-test.yaml
@@ -114,7 +114,7 @@ jobs:
       - name: Compute cache week
         if: ${{ runner.os == 'Windows' }}
         id: cache-week
-        run: echo "week=$(date -u +%G-%V)" >> $GITHUB_OUTPUT
+        run: echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
         shell: bash
 
       - name: Cache MongoDB binaries

--- a/packages/mongodb-runner/README.md
+++ b/packages/mongodb-runner/README.md
@@ -70,6 +70,16 @@ try {
 }
 ```
 
+## Environment variables
+
+Any CLI option can also be set through a `MONGODB_RUNNER_`-prefixed environment
+variable, e.g. `MONGODB_RUNNER_DOWNLOAD_DIR` for `--downloadDir`. Explicitly
+passed options take precedence.
+
+`MONGODB_RUNNER_DOWNLOAD_DIR` is additionally honored when using `MongoCluster`
+programmatically, which is useful for caching server binaries in CI without
+having to change each call site.
+
 ## Config file
 
 You can specify a config file for the CLI using `--config`:

--- a/packages/mongodb-runner/src/mongocluster.ts
+++ b/packages/mongodb-runner/src/mongocluster.ts
@@ -80,6 +80,8 @@ export interface RSMemberOptions {
 export interface CommonOptions {
   /**
    * Directory where server binaries will be downloaded and stored.
+   * Defaults to the `MONGODB_RUNNER_DOWNLOAD_DIR` environment variable if set,
+   * otherwise to `tmpDir`.
    */
   downloadDir?: string;
   /**
@@ -380,7 +382,9 @@ export class MongoCluster extends EventEmitter<MongoClusterEvents> {
     cluster.defaultConnectionOptions = { ...options.internalClientOptions };
     if (!options.binDir) {
       options.binDir = await this.downloadMongoDb(
-        options.downloadDir ?? options.tmpDir,
+        options.downloadDir ??
+          process.env.MONGODB_RUNNER_DOWNLOAD_DIR ??
+          options.tmpDir,
         options.version,
         options.downloadOptions,
       );


### PR DESCRIPTION
Only uses them for a week so we avoid getting stale ones. Github automatically cleans up unused cache items. This does mean once a week CI will be that slower run.