### PR TITLE
chore: bump @mongodb-js/socksv5 to 0.0.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7509,15 +7509,24 @@
       "link": true
     },
     "node_modules/@mongodb-js/socksv5": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/socksv5/-/socksv5-0.0.10.tgz",
-      "integrity": "sha512-JDz2fLKsjMiSNUxKrCpGptsgu7DzsXfu4gnUQ3RhUaBS1d4YbLrt6HejpckAiHIAa+niBpZAeiUsoop0IihWsw==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/socksv5/-/socksv5-0.0.11.tgz",
+      "integrity": "sha512-vA4OvtpE/A4dWBlnrkVN1HqwQSJeTdC16AyJ2Gd0jmUbqYDUkEogjkXDRZM0flM6ZD8PErlD4QHhXKC1c2uPNw==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^9.0.5"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@mongodb-js/socksv5/node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/@mongodb-js/tracking-plan": {
@@ -28944,7 +28953,7 @@
       "version": "0.7.18",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/socksv5": "^0.0.10",
+        "@mongodb-js/socksv5": "^0.0.11",
         "agent-base": "^7.1.1",
         "debug": "^4.4.0",
         "http-proxy-agent": "^7.0.2",
@@ -37448,7 +37457,7 @@
         "@mongodb-js/eslint-config-devtools": "^0.11.8",
         "@mongodb-js/mocha-config-devtools": "^1.1.3",
         "@mongodb-js/prettier-config-devtools": "^1.0.4",
-        "@mongodb-js/socksv5": "^0.0.10",
+        "@mongodb-js/socksv5": "^0.0.11",
         "@mongodb-js/tsconfig-devtools": "^1.1.3",
         "@types/chai": "^4.2.21",
         "@types/mocha": "^9.1.1",
@@ -39152,11 +39161,18 @@
       }
     },
     "@mongodb-js/socksv5": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/socksv5/-/socksv5-0.0.10.tgz",
-      "integrity": "sha512-JDz2fLKsjMiSNUxKrCpGptsgu7DzsXfu4gnUQ3RhUaBS1d4YbLrt6HejpckAiHIAa+niBpZAeiUsoop0IihWsw==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/socksv5/-/socksv5-0.0.11.tgz",
+      "integrity": "sha512-vA4OvtpE/A4dWBlnrkVN1HqwQSJeTdC16AyJ2Gd0jmUbqYDUkEogjkXDRZM0flM6ZD8PErlD4QHhXKC1c2uPNw==",
       "requires": {
-        "ip-address": "^9.0.5"
+        "ip-address": "^10.2.0"
+      },
+      "dependencies": {
+        "ip-address": {
+          "version": "10.5.0",
+          "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+          "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g=="
+        }
       }
     },
     "@mongodb-js/tracking-plan": {

--- a/packages/devtools-proxy-support/package.json
+++ b/packages/devtools-proxy-support/package.json
@@ -64,7 +64,7 @@
     "reformat": "npm run prettier -- --write ."
   },
   "dependencies": {
-    "@mongodb-js/socksv5": "^0.0.10",
+    "@mongodb-js/socksv5": "^0.0.11",
     "agent-base": "^7.1.1",
     "debug": "^4.4.0",
     "http-proxy-agent": "^7.0.2",


### PR DESCRIPTION
## Description

Bumps `@mongodb-js/socksv5` from `^0.0.10` to `^0.0.11` in `devtools-proxy-support`.
