### PR TITLE
feat(query-parser)!: remove stringify

### DIFF
--- a/packages/query-parser/MIGRATION.md
+++ b/packages/query-parser/MIGRATION.md
@@ -6,7 +6,25 @@ This is a guide to help you make the switch when this happens.
 
 ## Table Of Contents
 
+- [Migrating from 4.x to 5.0](#migrating-from-4x-to-50)
 - [Migrating from 1.0 to 2.0](#migrating-from-10-to-20)
+
+## Migrating from 4.x to 5.0
+
+The deprecated `stringify` export has been removed. It collapsed newlines and
+runs of spaces into a single space, which silently corrupted string values in a
+query, so there is no drop-in replacement that keeps that behaviour.
+
+Use `toJSString` instead, which is lossless:
+
+```js
+-stringify(query);
++toJSString(query, 0); // compact, no indentation
+```
+
+Note that `toJSString` does not insert a space after `:` or `,` when called with
+an indentation of `0`, so the output is not byte-for-byte identical to what
+`stringify` produced.
 
 ## Migrating from 1.0 to 2.0
 

--- a/packages/query-parser/src/index.spec.ts
+++ b/packages/query-parser/src/index.spec.ts
@@ -16,7 +16,6 @@ import {
   parseFilter,
   parseProject,
   parseSort,
-  stringify,
   toJSString,
   DEFAULT_LIMIT,
   DEFAULT_MAX_TIME_MS,
@@ -446,66 +445,68 @@ e  s`,
     });
   });
 
-  describe('stringify', function () {
+  describe('toJSString with indent 0', function () {
+    const compact = (obj: unknown) => toJSString(obj, 0);
+
     it('should work', function () {
       const res = parseFilter('{_id: ObjectId("58c33a794d08b991e3648fd2")}');
-      const stringified = stringify(res);
-      assert.equal(stringified, "{_id: ObjectId('58c33a794d08b991e3648fd2')}");
+      assert.equal(compact(res), "{_id:ObjectId('58c33a794d08b991e3648fd2')}");
     });
-    it('should not added extra space when nesting', function () {
-      assert.equal(stringify({ a: { $exists: true } }), '{a: {$exists: true}}');
+    it('should not add extra space when nesting', function () {
+      assert.equal(compact({ a: { $exists: true } }), '{a:{$exists:true}}');
     });
 
-    // stringify is now deprecated as a result of this.
-    it('changes multi-space values', function () {
+    it('preserves multi-space and newline values', function () {
       assert.equal(
-        stringify({
+        compact({
           a: {
             name: `multi-line with s  p    a   c
         
 e  s`,
           },
         }),
-        "{a: {name: 'multi-line with s p a c\\n \\ne s'}}",
+        "{a:{name:'multi-line with s  p    a   c\\n        \\ne  s'}}",
       );
     });
 
     context('when providing a long', function () {
       it('correctly converts to NumberLong', function () {
-        const stringified = stringify({ test: bson.Long.fromNumber(5) });
-        assert.equal(stringified, "{test: NumberLong('5')}");
+        assert.equal(
+          compact({ test: bson.Long.fromNumber(5) }),
+          "{test:NumberLong('5')}",
+        );
 
         assert.equal(
-          stringify({ test: new bson.Long('123456789123456789') }),
-          "{test: NumberLong('123456789123456789')}",
+          compact({ test: new bson.Long('123456789123456789') }),
+          "{test:NumberLong('123456789123456789')}",
         );
       });
     });
 
     context('when providing a decimal128', function () {
       it('correctly converts to NumberDecimal', function () {
-        const stringified = stringify({
-          test: bson.Decimal128.fromString('5.5'),
-        });
-        assert.equal(stringified, "{test: NumberDecimal('5.5')}");
+        assert.equal(
+          compact({ test: bson.Decimal128.fromString('5.5') }),
+          "{test:NumberDecimal('5.5')}",
+        );
       });
     });
 
     context('when providing an int32', function () {
       it('correctly converts to Int32', function () {
-        const stringified = stringify({
-          test: new bson.Int32(123),
-        });
-        assert.equal(stringified, "{test: NumberInt('123')}");
+        assert.equal(
+          compact({ test: new bson.Int32(123) }),
+          "{test:NumberInt('123')}",
+        );
       });
     });
 
     context('when providing a Double', function () {
       it('correctly converts to Double', function () {
-        const stringified = stringify({
-          test: new bson.Double(0.8),
-        });
-        assert.equal(stringified, "{test: Double('0.8')}");
+        assert.equal(
+          compact({ test: new bson.Double(0.8) }),
+          "{test:Double('0.8')}",
+        );
       });
     });
 
@@ -518,11 +519,10 @@ e  s`,
         },
       };
 
-      it('correctly replaces nested tabs with single spaces', function () {
-        const stringified = stringify(query);
+      it('does not add any whitespace', function () {
         assert.equal(
-          stringified,
-          '{coordinates: {$geoWithin: { $centerSphere: [ [ -79, 28 ], 0.04 ]}}}',
+          compact(query),
+          '{coordinates:{$geoWithin:{$centerSphere:[[-79,28],0.04]}}}',
         );
       });
     });
@@ -530,27 +530,24 @@ e  s`,
     context('when providing a Date', function () {
       it('correctly converts to an ISODate', function () {
         const res = parseFilter("{test: new Date('2017-01-01T12:35:31.000Z')}");
-        const stringified = stringify(res);
         assert.equal(
-          stringified,
-          "{test: ISODate('2017-01-01T12:35:31.000Z')}",
+          compact(res),
+          "{test:ISODate('2017-01-01T12:35:31.000Z')}",
         );
       });
 
       it('falls back to an invalid ISODate if the provided Date is invalid', function () {
         const res = parseFilter("{test: new Date('invalid')}");
-        const stringified = stringify(res);
-        assert.equal(stringified, "{test: ISODate('Invalid Date')}");
+        assert.equal(compact(res), "{test:ISODate('Invalid Date')}");
       });
     });
 
     context('when providing an ISODate', function () {
       it('correctly converts to an ISODate', function () {
         const res = parseFilter("{test: ISODate('2017-01-01T12:35:31.000Z')}");
-        const stringified = stringify(res);
         assert.equal(
-          stringified,
-          "{test: ISODate('2017-01-01T12:35:31.000Z')}",
+          compact(res),
+          "{test:ISODate('2017-01-01T12:35:31.000Z')}",
         );
       });
 
@@ -565,57 +562,47 @@ e  s`,
     context('when providing a DBRef with (collection, oid)', function () {
       it('correctly converts to a DBRef', function () {
         const res = parseFilter("{dbref: DBRef('col', 1)}");
-        const stringified = stringify(res);
-        assert.equal(stringified, "{dbref: DBRef('col', '1')}");
+        assert.equal(compact(res), "{dbref:DBRef('col', '1')}");
       });
     });
 
     context('when providing a DBRef with (db.collection, oid)', function () {
       it('correctly converts to a DBRef', function () {
         const res = parseFilter("{dbref: DBRef('db.col', 1)}");
-        const stringified = stringify(res);
-        assert.equal(stringified, "{dbref: DBRef('col', '1', 'db')}");
+        assert.equal(compact(res), "{dbref:DBRef('col', '1', 'db')}");
       });
     });
 
     context('when providing a DBRef with (collection, oid, db)', function () {
       it('correctly converts to a DBRef', function () {
         const res = parseFilter("{dbref: DBRef('col', 1, 'db')}");
-        const stringified = stringify(res);
-        assert.equal(stringified, "{dbref: DBRef('col', '1', 'db')}");
+        assert.equal(compact(res), "{dbref:DBRef('col', '1', 'db')}");
       });
     });
 
     context('when provided a RegExp', function () {
       it('correctly formats the options', function () {
         const res = parseFilter('{name: /foo/i}');
-        const stringified = stringify(res);
-        assert.equal(stringified, '{name: RegExp("foo", \'i\')}');
+        assert.equal(compact(res), '{name:RegExp("foo", \'i\')}');
       });
 
       it('escapes quotes', function () {
         const res = parseFilter("{name: /'/}");
-        const stringified = stringify(res);
-        assert.equal(stringified, '{name: RegExp("\'")}');
+        assert.equal(compact(res), '{name:RegExp("\'")}');
       });
 
       it('handles $regex object format (keeps format)', function () {
         const res = parseFilter(
           '{"name": {"$regex": "pineapple", "$options": "i"}}',
         );
-        const stringified = stringify(res);
-        assert.equal(
-          stringified,
-          "{name: {$regex: 'pineapple',$options: 'i'}}",
-        );
+        assert.equal(compact(res), "{name:{$regex:'pineapple',$options:'i'}}");
       });
 
       it('handles /regex/ format', function () {
         const res = {
           name: /pineapple/,
         };
-        const stringified = stringify(res);
-        assert.equal(stringified, '{name: RegExp("pineapple")}');
+        assert.equal(compact(res), '{name:RegExp("pineapple")}');
       });
     });
 
@@ -624,24 +611,21 @@ e  s`,
         const res = {
           name: new bson.BSONRegExp('pineapple', 'i'),
         };
-        const stringified = stringify(res);
-        assert.equal(stringified, '{name: RegExp("pineapple", \'i\')}');
+        assert.equal(compact(res), '{name:RegExp("pineapple", \'i\')}');
       });
 
       it('stringifies correctly with quotes', function () {
         const res = {
           name: new bson.BSONRegExp('"\'', 'i'),
         };
-        const stringified = stringify(res);
-        assert.equal(stringified, '{name: RegExp("\\"\'", \'i\')}');
+        assert.equal(compact(res), '{name:RegExp("\\"\'", \'i\')}');
       });
 
       it('stringifies correctly without options', function () {
         const res = {
           name: new bson.BSONRegExp('pineapple'),
         };
-        const stringified = stringify(res);
-        assert.equal(stringified, '{name: RegExp("pineapple")}');
+        assert.equal(compact(res), '{name:RegExp("pineapple")}');
       });
 
       it('stringifies into BSONRegExp when js RegExp cannot handle an option', function () {
@@ -651,8 +635,7 @@ e  s`,
             'x' /* x flag is not valid in js but valid in BSONRegExp*/,
           ),
         };
-        const stringified = stringify(res);
-        assert.equal(stringified, '{name: BSONRegExp("pineapple", \'x\')}');
+        assert.equal(compact(res), '{name:BSONRegExp("pineapple", \'x\')}');
       });
 
       it('stringifies into BSONRegExp when js RegExp cannot handle the regex', function () {
@@ -664,8 +647,7 @@ e  s`,
             'i',
           ),
         };
-        const stringified = stringify(res);
-        assert.equal(stringified, '{name: BSONRegExp("(?i)a(?-i)cme", \'i\')}');
+        assert.equal(compact(res), '{name:BSONRegExp("(?i)a(?-i)cme", \'i\')}');
       });
     });
 
@@ -674,10 +656,9 @@ e  s`,
         const res = parseFilter(
           `{name: new BinData(${bson.Binary.SUBTYPE_BYTE_ARRAY}, "OyQRAeK7QlWMr0E2xWapYg==")}`,
         );
-        const stringified = stringify(res);
         assert.equal(
-          stringified,
-          `{name: BinData(${bson.Binary.SUBTYPE_BYTE_ARRAY}, 'OyQRAeK7QlWMr0E2xWapYg==')}`,
+          compact(res),
+          `{name:BinData(${bson.Binary.SUBTYPE_BYTE_ARRAY}, 'OyQRAeK7QlWMr0E2xWapYg==')}`,
         );
       });
 
@@ -685,43 +666,39 @@ e  s`,
         const res = parseFilter(
           '{name: UUID("3b241101-e2bb-4255-8caf-4136c566a962")}',
         );
-        const stringified = stringify(res);
         assert.equal(
-          stringified,
-          "{name: UUID('3b241101-e2bb-4255-8caf-4136c566a962')}",
+          compact(res),
+          "{name:UUID('3b241101-e2bb-4255-8caf-4136c566a962')}",
         );
       });
 
-      it('does not stringify LegacyJavaUUID', function () {
+      it('does not convert LegacyJavaUUID to UUID', function () {
         const res = parseFilter(
           '{name: LegacyJavaUUID("00112233-4455-6677-8899-aabbccddeeff")}',
         );
-        const stringified = stringify(res);
         assert.equal(
-          stringified,
-          "{name: BinData(3, 'd2ZVRDMiEQD/7t3Mu6qZiA==')}",
+          compact(res),
+          "{name:BinData(3, 'd2ZVRDMiEQD/7t3Mu6qZiA==')}",
         );
       });
 
-      it('does not stringify LegacyCSharpUUID', function () {
+      it('does not convert LegacyCSharpUUID to UUID', function () {
         const res = parseFilter(
           '{name: LegacyCSharpUUID("00112233-4455-6677-8899-aabbccddeeff")}',
         );
-        const stringified = stringify(res);
         assert.equal(
-          stringified,
-          "{name: BinData(3, 'MyIRAFVEd2aImaq7zN3u/w==')}",
+          compact(res),
+          "{name:BinData(3, 'MyIRAFVEd2aImaq7zN3u/w==')}",
         );
       });
 
-      it('does not stringify LegacyPythonUUID', function () {
+      it('does not convert LegacyPythonUUID to UUID', function () {
         const res = parseFilter(
           '{name: LegacyPythonUUID("00112233-4455-6677-8899-aabbccddeeff")}',
         );
-        const stringified = stringify(res);
         assert.equal(
-          stringified,
-          "{name: BinData(3, 'ABEiM0RVZneImaq7zN3u/w==')}",
+          compact(res),
+          "{name:BinData(3, 'ABEiM0RVZneImaq7zN3u/w==')}",
         );
       });
 
@@ -730,10 +707,9 @@ e  s`,
         const res = parseFilter(
           `{name: Binary.createFromHexString("deadbeef", ${bson.Binary.SUBTYPE_BYTE_ARRAY})}`,
         );
-        const stringified = stringify(res);
         assert.equal(
-          stringified,
-          `{name: BinData(${bson.Binary.SUBTYPE_BYTE_ARRAY}, '3q2+7w==')}`,
+          compact(res),
+          `{name:BinData(${bson.Binary.SUBTYPE_BYTE_ARRAY}, '3q2+7w==')}`,
         );
       });
 
@@ -742,10 +718,9 @@ e  s`,
         const res = parseFilter(
           `{name: Binary.createFromBase64("3q2+7w==", ${bson.Binary.SUBTYPE_BYTE_ARRAY})}`,
         );
-        const stringified = stringify(res);
         assert.equal(
-          stringified,
-          `{name: BinData(${bson.Binary.SUBTYPE_BYTE_ARRAY}, '3q2+7w==')}`,
+          compact(res),
+          `{name:BinData(${bson.Binary.SUBTYPE_BYTE_ARRAY}, '3q2+7w==')}`,
         );
       });
     });

--- a/packages/query-parser/src/index.spec.ts
+++ b/packages/query-parser/src/index.spec.ts
@@ -446,19 +446,25 @@ e  s`,
   });
 
   describe('toJSString with indent 0', function () {
-    const compact = (obj: unknown) => toJSString(obj, 0);
+    const compactStringify = (obj: unknown) => toJSString(obj, 0);
 
     it('should work', function () {
       const res = parseFilter('{_id: ObjectId("58c33a794d08b991e3648fd2")}');
-      assert.equal(compact(res), "{_id:ObjectId('58c33a794d08b991e3648fd2')}");
+      assert.equal(
+        compactStringify(res),
+        "{_id:ObjectId('58c33a794d08b991e3648fd2')}",
+      );
     });
     it('should not add extra space when nesting', function () {
-      assert.equal(compact({ a: { $exists: true } }), '{a:{$exists:true}}');
+      assert.equal(
+        compactStringify({ a: { $exists: true } }),
+        '{a:{$exists:true}}',
+      );
     });
 
     it('preserves multi-space and newline values', function () {
       assert.equal(
-        compact({
+        compactStringify({
           a: {
             name: `multi-line with s  p    a   c
         
@@ -472,12 +478,12 @@ e  s`,
     context('when providing a long', function () {
       it('correctly converts to NumberLong', function () {
         assert.equal(
-          compact({ test: bson.Long.fromNumber(5) }),
+          compactStringify({ test: bson.Long.fromNumber(5) }),
           "{test:NumberLong('5')}",
         );
 
         assert.equal(
-          compact({ test: new bson.Long('123456789123456789') }),
+          compactStringify({ test: new bson.Long('123456789123456789') }),
           "{test:NumberLong('123456789123456789')}",
         );
       });
@@ -486,7 +492,7 @@ e  s`,
     context('when providing a decimal128', function () {
       it('correctly converts to NumberDecimal', function () {
         assert.equal(
-          compact({ test: bson.Decimal128.fromString('5.5') }),
+          compactStringify({ test: bson.Decimal128.fromString('5.5') }),
           "{test:NumberDecimal('5.5')}",
         );
       });
@@ -495,7 +501,7 @@ e  s`,
     context('when providing an int32', function () {
       it('correctly converts to Int32', function () {
         assert.equal(
-          compact({ test: new bson.Int32(123) }),
+          compactStringify({ test: new bson.Int32(123) }),
           "{test:NumberInt('123')}",
         );
       });
@@ -504,7 +510,7 @@ e  s`,
     context('when providing a Double', function () {
       it('correctly converts to Double', function () {
         assert.equal(
-          compact({ test: new bson.Double(0.8) }),
+          compactStringify({ test: new bson.Double(0.8) }),
           "{test:Double('0.8')}",
         );
       });
@@ -521,7 +527,7 @@ e  s`,
 
       it('does not add any whitespace', function () {
         assert.equal(
-          compact(query),
+          compactStringify(query),
           '{coordinates:{$geoWithin:{$centerSphere:[[-79,28],0.04]}}}',
         );
       });
@@ -531,14 +537,14 @@ e  s`,
       it('correctly converts to an ISODate', function () {
         const res = parseFilter("{test: new Date('2017-01-01T12:35:31.000Z')}");
         assert.equal(
-          compact(res),
+          compactStringify(res),
           "{test:ISODate('2017-01-01T12:35:31.000Z')}",
         );
       });
 
       it('falls back to an invalid ISODate if the provided Date is invalid', function () {
         const res = parseFilter("{test: new Date('invalid')}");
-        assert.equal(compact(res), "{test:ISODate('Invalid Date')}");
+        assert.equal(compactStringify(res), "{test:ISODate('Invalid Date')}");
       });
     });
 
@@ -546,7 +552,7 @@ e  s`,
       it('correctly converts to an ISODate', function () {
         const res = parseFilter("{test: ISODate('2017-01-01T12:35:31.000Z')}");
         assert.equal(
-          compact(res),
+          compactStringify(res),
           "{test:ISODate('2017-01-01T12:35:31.000Z')}",
         );
       });
@@ -562,47 +568,50 @@ e  s`,
     context('when providing a DBRef with (collection, oid)', function () {
       it('correctly converts to a DBRef', function () {
         const res = parseFilter("{dbref: DBRef('col', 1)}");
-        assert.equal(compact(res), "{dbref:DBRef('col', '1')}");
+        assert.equal(compactStringify(res), "{dbref:DBRef('col', '1')}");
       });
     });
 
     context('when providing a DBRef with (db.collection, oid)', function () {
       it('correctly converts to a DBRef', function () {
         const res = parseFilter("{dbref: DBRef('db.col', 1)}");
-        assert.equal(compact(res), "{dbref:DBRef('col', '1', 'db')}");
+        assert.equal(compactStringify(res), "{dbref:DBRef('col', '1', 'db')}");
       });
     });
 
     context('when providing a DBRef with (collection, oid, db)', function () {
       it('correctly converts to a DBRef', function () {
         const res = parseFilter("{dbref: DBRef('col', 1, 'db')}");
-        assert.equal(compact(res), "{dbref:DBRef('col', '1', 'db')}");
+        assert.equal(compactStringify(res), "{dbref:DBRef('col', '1', 'db')}");
       });
     });
 
     context('when provided a RegExp', function () {
       it('correctly formats the options', function () {
         const res = parseFilter('{name: /foo/i}');
-        assert.equal(compact(res), '{name:RegExp("foo", \'i\')}');
+        assert.equal(compactStringify(res), '{name:RegExp("foo", \'i\')}');
       });
 
       it('escapes quotes', function () {
         const res = parseFilter("{name: /'/}");
-        assert.equal(compact(res), '{name:RegExp("\'")}');
+        assert.equal(compactStringify(res), '{name:RegExp("\'")}');
       });
 
       it('handles $regex object format (keeps format)', function () {
         const res = parseFilter(
           '{"name": {"$regex": "pineapple", "$options": "i"}}',
         );
-        assert.equal(compact(res), "{name:{$regex:'pineapple',$options:'i'}}");
+        assert.equal(
+          compactStringify(res),
+          "{name:{$regex:'pineapple',$options:'i'}}",
+        );
       });
 
       it('handles /regex/ format', function () {
         const res = {
           name: /pineapple/,
         };
-        assert.equal(compact(res), '{name:RegExp("pineapple")}');
+        assert.equal(compactStringify(res), '{name:RegExp("pineapple")}');
       });
     });
 
@@ -611,21 +620,24 @@ e  s`,
         const res = {
           name: new bson.BSONRegExp('pineapple', 'i'),
         };
-        assert.equal(compact(res), '{name:RegExp("pineapple", \'i\')}');
+        assert.equal(
+          compactStringify(res),
+          '{name:RegExp("pineapple", \'i\')}',
+        );
       });
 
       it('stringifies correctly with quotes', function () {
         const res = {
           name: new bson.BSONRegExp('"\'', 'i'),
         };
-        assert.equal(compact(res), '{name:RegExp("\\"\'", \'i\')}');
+        assert.equal(compactStringify(res), '{name:RegExp("\\"\'", \'i\')}');
       });
 
       it('stringifies correctly without options', function () {
         const res = {
           name: new bson.BSONRegExp('pineapple'),
         };
-        assert.equal(compact(res), '{name:RegExp("pineapple")}');
+        assert.equal(compactStringify(res), '{name:RegExp("pineapple")}');
       });
 
       it('stringifies into BSONRegExp when js RegExp cannot handle an option', function () {
@@ -635,7 +647,10 @@ e  s`,
             'x' /* x flag is not valid in js but valid in BSONRegExp*/,
           ),
         };
-        assert.equal(compact(res), '{name:BSONRegExp("pineapple", \'x\')}');
+        assert.equal(
+          compactStringify(res),
+          '{name:BSONRegExp("pineapple", \'x\')}',
+        );
       });
 
       it('stringifies into BSONRegExp when js RegExp cannot handle the regex', function () {
@@ -647,7 +662,10 @@ e  s`,
             'i',
           ),
         };
-        assert.equal(compact(res), '{name:BSONRegExp("(?i)a(?-i)cme", \'i\')}');
+        assert.equal(
+          compactStringify(res),
+          '{name:BSONRegExp("(?i)a(?-i)cme", \'i\')}',
+        );
       });
     });
 
@@ -657,7 +675,7 @@ e  s`,
           `{name: new BinData(${bson.Binary.SUBTYPE_BYTE_ARRAY}, "OyQRAeK7QlWMr0E2xWapYg==")}`,
         );
         assert.equal(
-          compact(res),
+          compactStringify(res),
           `{name:BinData(${bson.Binary.SUBTYPE_BYTE_ARRAY}, 'OyQRAeK7QlWMr0E2xWapYg==')}`,
         );
       });
@@ -667,7 +685,7 @@ e  s`,
           '{name: UUID("3b241101-e2bb-4255-8caf-4136c566a962")}',
         );
         assert.equal(
-          compact(res),
+          compactStringify(res),
           "{name:UUID('3b241101-e2bb-4255-8caf-4136c566a962')}",
         );
       });
@@ -677,7 +695,7 @@ e  s`,
           '{name: LegacyJavaUUID("00112233-4455-6677-8899-aabbccddeeff")}',
         );
         assert.equal(
-          compact(res),
+          compactStringify(res),
           "{name:BinData(3, 'd2ZVRDMiEQD/7t3Mu6qZiA==')}",
         );
       });
@@ -687,7 +705,7 @@ e  s`,
           '{name: LegacyCSharpUUID("00112233-4455-6677-8899-aabbccddeeff")}',
         );
         assert.equal(
-          compact(res),
+          compactStringify(res),
           "{name:BinData(3, 'MyIRAFVEd2aImaq7zN3u/w==')}",
         );
       });
@@ -697,7 +715,7 @@ e  s`,
           '{name: LegacyPythonUUID("00112233-4455-6677-8899-aabbccddeeff")}',
         );
         assert.equal(
-          compact(res),
+          compactStringify(res),
           "{name:BinData(3, 'ABEiM0RVZneImaq7zN3u/w==')}",
         );
       });
@@ -708,7 +726,7 @@ e  s`,
           `{name: Binary.createFromHexString("deadbeef", ${bson.Binary.SUBTYPE_BYTE_ARRAY})}`,
         );
         assert.equal(
-          compact(res),
+          compactStringify(res),
           `{name:BinData(${bson.Binary.SUBTYPE_BYTE_ARRAY}, '3q2+7w==')}`,
         );
       });
@@ -719,7 +737,7 @@ e  s`,
           `{name: Binary.createFromBase64("3q2+7w==", ${bson.Binary.SUBTYPE_BYTE_ARRAY})}`,
         );
         assert.equal(
-          compact(res),
+          compactStringify(res),
           `{name:BinData(${bson.Binary.SUBTYPE_BYTE_ARRAY}, '3q2+7w==')}`,
         );
       });

--- a/packages/query-parser/src/index.ts
+++ b/packages/query-parser/src/index.ts
@@ -6,7 +6,7 @@ import _ from 'lodash';
 import _debug from 'debug';
 
 import { COLLATION_OPTIONS } from './constants';
-import { stringify, toJSString } from './stringify';
+import { toJSString } from './stringify';
 
 const debug = _debug('mongodb-query-parser');
 
@@ -383,7 +383,6 @@ export default function queryParser(
 }
 
 export {
-  stringify,
   toJSString,
   DEFAULT_FILTER,
   DEFAULT_SORT,

--- a/packages/query-parser/src/stringify.ts
+++ b/packages/query-parser/src/stringify.ts
@@ -168,15 +168,3 @@ export function toJSString(
     ind,
   );
 }
-
-/**
- * @public
- * @deprecated
- * This function is deprecated and not recommended as it replaces
- * double spaces, newline values, and indents with only one space.
- **/
-export function stringify(obj: unknown): string | undefined {
-  return toJSString(obj, 1)
-    ?.replace(/ ?\n ? ?/g, '')
-    .replace(/ {2,}/g, ' ');
-}


### PR DESCRIPTION
`stringify` was not a good function. It could lead to data loss. We deprecated it, however, [we still ended up using it](https://github.com/mongodb-js/compass/blob/f2b69ca8578fd97facdd758bee8b8fdf31375e4b/packages/compass-components/src/components/bson-value.tsx#L10), this will make it so we don't do that in future.