### PR TITLE
chore(mongodb-schema): replace `@mongodb-js/compass-test-server` with an inline `mochaTestServer` COMPASS-11068

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4912,226 +4912,6 @@
         "react": "^17.0.2"
       }
     },
-    "node_modules/@mongodb-js/compass-test-server": {
-      "version": "0.3.22",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-test-server/-/compass-test-server-0.3.22.tgz",
-      "integrity": "sha512-iYoLWFePqjSgU0AW7I5EgOF0WKcm9Me4VWJYY4Nz5dN67S4JpiLA5YLF/7HMBPRwg0ymmPKOmEMknUUWoMUCZQ==",
-      "dev": true,
-      "license": "SSPL",
-      "dependencies": {
-        "mongodb-runner": "^5.8.0"
-      }
-    },
-    "node_modules/@mongodb-js/compass-test-server/node_modules/@mongodb-js/mongodb-downloader": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-downloader/-/mongodb-downloader-0.5.0.tgz",
-      "integrity": "sha512-N0ijRRNygm1xTQ3IhAMFcnZNhhF1CTwzFHqMk+tttm6LKD576t7j6olfuqSf8vFQ+tVpO6Z1JWOcquTKrpwOlQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "decompress": "^4.2.1",
-        "mongodb-download-url": "^1.7.0",
-        "node-fetch": "^2.7.0",
-        "tar": "^6.1.15"
-      }
-    },
-    "node_modules/@mongodb-js/compass-test-server/node_modules/@types/whatwg-url": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
-      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/webidl-conversions": "*"
-      }
-    },
-    "node_modules/@mongodb-js/compass-test-server/node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@mongodb-js/compass-test-server/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@mongodb-js/compass-test-server/node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@mongodb-js/compass-test-server/node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@mongodb-js/compass-test-server/node_modules/mongodb": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.21.0.tgz",
-      "integrity": "sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/saslprep": "^1.3.0",
-        "bson": "^6.10.4",
-        "mongodb-connection-string-url": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=16.20.1"
-      },
-      "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
-        "gcp-metadata": "^5.2.0",
-        "kerberos": "^2.0.1",
-        "mongodb-client-encryption": ">=6.0.0 <7",
-        "snappy": "^7.3.2",
-        "socks": "^2.7.1"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/credential-providers": {
-          "optional": true
-        },
-        "@mongodb-js/zstd": {
-          "optional": true
-        },
-        "gcp-metadata": {
-          "optional": true
-        },
-        "kerberos": {
-          "optional": true
-        },
-        "mongodb-client-encryption": {
-          "optional": true
-        },
-        "snappy": {
-          "optional": true
-        },
-        "socks": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mongodb-js/compass-test-server/node_modules/mongodb-connection-string-url": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
-      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/whatwg-url": "^11.0.2",
-        "whatwg-url": "^14.1.0 || ^13.0.0"
-      }
-    },
-    "node_modules/@mongodb-js/compass-test-server/node_modules/mongodb-runner": {
-      "version": "5.11.1",
-      "resolved": "https://registry.npmjs.org/mongodb-runner/-/mongodb-runner-5.11.1.tgz",
-      "integrity": "sha512-vgp9pKqnfRr5aXUCYqh0DHw0I3LmRjD+LvoiGi2scp1BCgTeftSEZGy9py8xkzeWxCGBr7S0uwdmfcUPiVYusg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/mongodb-downloader": "^0.5.0",
-        "@mongodb-js/saslprep": "^1.3.2",
-        "debug": "^4.4.0",
-        "mongodb": "^6.9.0",
-        "mongodb-connection-string-url": "^3.0.0",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "mongodb-runner": "bin/runner.js"
-      }
-    },
-    "node_modules/@mongodb-js/compass-test-server/node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@mongodb-js/compass-test-server/node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@mongodb-js/compass-test-server/node_modules/yargs": {
-      "version": "17.7.3",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
-      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@mongodb-js/compass-test-server/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@mongodb-js/device-id": {
       "resolved": "packages/device-id",
       "link": true
@@ -29105,7 +28885,6 @@
         "mongodb-schema": "bin/mongodb-schema"
       },
       "devDependencies": {
-        "@mongodb-js/compass-test-server": "^0.3.2",
         "@mongodb-js/eslint-config-devtools": "^0.11.8",
         "@mongodb-js/mocha-config-devtools": "^1.1.3",
         "@mongodb-js/prettier-config-devtools": "^1.0.4",
@@ -29124,6 +28903,7 @@
         "gen-esm-wrapper": "^1.1.3",
         "mocha": "^8.4.0",
         "mongodb": "^7.5.0",
+        "mongodb-runner": "^6.10.0",
         "nyc": "^15.1.0",
         "prettier": "^3.8.1",
         "sinon": "^9.2.3",
@@ -34543,153 +34323,6 @@
         "react": "^17.0.2"
       }
     },
-    "@mongodb-js/compass-test-server": {
-      "version": "0.3.22",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-test-server/-/compass-test-server-0.3.22.tgz",
-      "integrity": "sha512-iYoLWFePqjSgU0AW7I5EgOF0WKcm9Me4VWJYY4Nz5dN67S4JpiLA5YLF/7HMBPRwg0ymmPKOmEMknUUWoMUCZQ==",
-      "dev": true,
-      "requires": {
-        "mongodb-runner": "^5.8.0"
-      },
-      "dependencies": {
-        "@mongodb-js/mongodb-downloader": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-downloader/-/mongodb-downloader-0.5.0.tgz",
-          "integrity": "sha512-N0ijRRNygm1xTQ3IhAMFcnZNhhF1CTwzFHqMk+tttm6LKD576t7j6olfuqSf8vFQ+tVpO6Z1JWOcquTKrpwOlQ==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.4.0",
-            "decompress": "^4.2.1",
-            "mongodb-download-url": "^1.7.0",
-            "node-fetch": "^2.7.0",
-            "tar": "^6.1.15"
-          }
-        },
-        "@types/whatwg-url": {
-          "version": "11.0.5",
-          "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
-          "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
-          "dev": true,
-          "requires": {
-            "@types/webidl-conversions": "*"
-          }
-        },
-        "chownr": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-          "dev": true
-        },
-        "cliui": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.1",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "fs-minipass": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-          "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0",
-            "yallist": "^4.0.0"
-          }
-        },
-        "mongodb": {
-          "version": "6.21.0",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.21.0.tgz",
-          "integrity": "sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A==",
-          "dev": true,
-          "requires": {
-            "@mongodb-js/saslprep": "^1.3.0",
-            "bson": "^6.10.4",
-            "mongodb-connection-string-url": "^3.0.2"
-          }
-        },
-        "mongodb-connection-string-url": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
-          "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
-          "dev": true,
-          "requires": {
-            "@types/whatwg-url": "^11.0.2",
-            "whatwg-url": "^14.1.0 || ^13.0.0"
-          }
-        },
-        "mongodb-runner": {
-          "version": "5.11.1",
-          "resolved": "https://registry.npmjs.org/mongodb-runner/-/mongodb-runner-5.11.1.tgz",
-          "integrity": "sha512-vgp9pKqnfRr5aXUCYqh0DHw0I3LmRjD+LvoiGi2scp1BCgTeftSEZGy9py8xkzeWxCGBr7S0uwdmfcUPiVYusg==",
-          "dev": true,
-          "requires": {
-            "@mongodb-js/mongodb-downloader": "^0.5.0",
-            "@mongodb-js/saslprep": "^1.3.2",
-            "debug": "^4.4.0",
-            "mongodb": "^6.9.0",
-            "mongodb-connection-string-url": "^3.0.0",
-            "yargs": "^17.7.2"
-          }
-        },
-        "tar": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-          "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-          "dev": true,
-          "requires": {
-            "chownr": "^2.0.0",
-            "fs-minipass": "^2.0.0",
-            "minipass": "^5.0.0",
-            "minizlib": "^2.1.1",
-            "mkdirp": "^1.0.3",
-            "yallist": "^4.0.0"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-              "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-              "dev": true
-            }
-          }
-        },
-        "yargs": {
-          "version": "17.7.3",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
-          "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
-          "dev": true,
-          "requires": {
-            "cliui": "^8.0.1",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.3",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^21.1.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "21.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-          "dev": true
-        }
-      }
-    },
     "@mongodb-js/device-id": {
       "version": "file:packages/device-id",
       "requires": {
@@ -35256,7 +34889,6 @@
     "@mongodb-js/mongodb-schema": {
       "version": "file:packages/mongodb-schema",
       "requires": {
-        "@mongodb-js/compass-test-server": "^0.3.2",
         "@mongodb-js/eslint-config-devtools": "^0.11.8",
         "@mongodb-js/mocha-config-devtools": "^1.1.3",
         "@mongodb-js/prettier-config-devtools": "^1.0.4",
@@ -35278,6 +34910,7 @@
         "mocha": "^8.4.0",
         "mongodb": "^7.5.0",
         "mongodb-ns": "^3.2.1",
+        "mongodb-runner": "^6.10.0",
         "numeral": "^2.0.6",
         "nyc": "^15.1.0",
         "prettier": "^3.8.1",

--- a/packages/mongodb-schema/package.json
+++ b/packages/mongodb-schema/package.json
@@ -82,7 +82,6 @@
     "yargs": "^18.0.0"
   },
   "devDependencies": {
-    "@mongodb-js/compass-test-server": "^0.3.2",
     "@mongodb-js/eslint-config-devtools": "^0.11.8",
     "@mongodb-js/mocha-config-devtools": "^1.1.3",
     "@mongodb-js/prettier-config-devtools": "^1.0.4",
@@ -101,6 +100,7 @@
     "gen-esm-wrapper": "^1.1.3",
     "mocha": "^8.4.0",
     "mongodb": "^7.5.0",
+    "mongodb-runner": "^6.10.0",
     "nyc": "^15.1.0",
     "prettier": "^3.8.1",
     "sinon": "^9.2.3",

--- a/packages/mongodb-schema/test/integration/generate-and-validate.test.ts
+++ b/packages/mongodb-schema/test/integration/generate-and-validate.test.ts
@@ -4,10 +4,41 @@ import Ajv2020 from 'ajv/dist/2020';
 import assert from 'assert';
 import { Double, Int32, ObjectId, EJSON } from 'bson';
 import { MongoClient, type Db } from 'mongodb';
-import { mochaTestServer } from '@mongodb-js/compass-test-server';
+import { MongoCluster } from 'mongodb-runner';
+import path from 'path';
+import { tmpdir } from 'os';
 
 import { allValidBSONTypesWithEdgeCasesDoc } from '../all-bson-types-fixture';
 import { analyzeDocuments } from '../../src';
+
+// Starts a standalone server for the enclosing suite and tears it down
+// afterwards. The returned accessor is only valid inside the suite's tests.
+function mochaTestServer(): () => MongoCluster {
+  let cluster: MongoCluster | undefined;
+
+  // The hooks are not top-level: they are registered when this function is
+  // called from inside a suite.
+  // eslint-disable-next-line mocha/no-top-level-hooks
+  before(async function () {
+    // Downloading the server binaries can take a long time in CI.
+    this.timeout(500_000);
+    cluster = await MongoCluster.start({
+      topology: 'standalone',
+      tmpDir: path.join(tmpdir(), 'mongodb-schema-tests'),
+    });
+  });
+
+  // eslint-disable-next-line mocha/no-top-level-hooks
+  after(async function () {
+    await cluster?.close();
+    cluster = undefined;
+  });
+
+  return () => {
+    if (!cluster) throw new Error('before() hook not ran yet');
+    return cluster;
+  };
+}
 
 const bsonDocuments = [
   {


### PR DESCRIPTION
## Description

`@mongodb-js/compass-test-server` has been private for a while now making it no longer update on npm, this package is forever going to pull in an old version of that compass package which uses an old mongodb-runner version making it impossible to remove old "tar" and other such vuln packages from the tree. 

This PR now makes mongodb-runner a direct dev dependency and copies the helper function it was using into this repo.

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Checklist

- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
