### PR TITLE
feat(connection-string-policy): add shared connection string policy checks VSCODE-821

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4912,6 +4912,10 @@
         "react": "^17.0.2"
       }
     },
+    "node_modules/@mongodb-js/connection-string-policy": {
+      "resolved": "packages/connection-string-policy",
+      "link": true
+    },
     "node_modules/@mongodb-js/device-id": {
       "resolved": "packages/device-id",
       "link": true
@@ -27947,6 +27951,48 @@
       "dev": true,
       "license": "MIT"
     },
+    "packages/connection-string-policy": {
+      "name": "@mongodb-js/connection-string-policy",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mongodb-build-info": "^1.9.12",
+        "mongodb-connection-string-url": "^7.0.1"
+      },
+      "devDependencies": {
+        "@mongodb-js/eslint-config-devtools": "^0.11.8",
+        "@mongodb-js/mocha-config-devtools": "^1.1.3",
+        "@mongodb-js/prettier-config-devtools": "^1.0.4",
+        "@mongodb-js/tsconfig-devtools": "^1.1.3",
+        "@types/chai": "^4.2.21",
+        "@types/mocha": "^9.1.1",
+        "@types/sinon-chai": "^4.0.0",
+        "chai": "^4.5.0",
+        "depcheck": "^1.4.7",
+        "eslint": "^7.25.0 || ^8.0.0",
+        "gen-esm-wrapper": "^1.1.3",
+        "mocha": "^8.4.0",
+        "mongodb": "^7.5.0",
+        "nyc": "^15.1.0",
+        "prettier": "^3.8.1",
+        "sinon": "^9.2.3",
+        "typescript": "^5.9.3"
+      },
+      "peerDependencies": {
+        "mongodb": "^7.0.0"
+      }
+    },
+    "packages/connection-string-policy/node_modules/@types/sinon-chai": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-4.0.0.tgz",
+      "integrity": "sha512-Uar+qk3TmeFsUWCwtqRNqNUE7vf34+MCJiQJR5M2rd4nCbhtE8RgTiHwN/mVwbfCjhmO6DiOel/MgzHkRMJJFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "*",
+        "@types/sinon": "*"
+      }
+    },
     "packages/device-id": {
       "name": "@mongodb-js/device-id",
       "version": "0.4.14",
@@ -34321,6 +34367,42 @@
       "dev": true,
       "requires": {
         "react": "^17.0.2"
+      }
+    },
+    "@mongodb-js/connection-string-policy": {
+      "version": "file:packages/connection-string-policy",
+      "requires": {
+        "@mongodb-js/eslint-config-devtools": "^0.11.8",
+        "@mongodb-js/mocha-config-devtools": "^1.1.3",
+        "@mongodb-js/prettier-config-devtools": "^1.0.4",
+        "@mongodb-js/tsconfig-devtools": "^1.1.3",
+        "@types/chai": "^4.2.21",
+        "@types/mocha": "^9.1.1",
+        "@types/sinon-chai": "^4.0.0",
+        "chai": "^4.5.0",
+        "depcheck": "^1.4.7",
+        "eslint": "^7.25.0 || ^8.0.0",
+        "gen-esm-wrapper": "^1.1.3",
+        "mocha": "^8.4.0",
+        "mongodb": "^7.5.0",
+        "mongodb-build-info": "^1.9.12",
+        "mongodb-connection-string-url": "^7.0.1",
+        "nyc": "^15.1.0",
+        "prettier": "^3.8.1",
+        "sinon": "^9.2.3",
+        "typescript": "^5.9.3"
+      },
+      "dependencies": {
+        "@types/sinon-chai": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-4.0.0.tgz",
+          "integrity": "sha512-Uar+qk3TmeFsUWCwtqRNqNUE7vf34+MCJiQJR5M2rd4nCbhtE8RgTiHwN/mVwbfCjhmO6DiOel/MgzHkRMJJFg==",
+          "dev": true,
+          "requires": {
+            "@types/chai": "*",
+            "@types/sinon": "*"
+          }
+        }
       }
     },
     "@mongodb-js/device-id": {

--- a/packages/connection-string-policy/.depcheckrc
+++ b/packages/connection-string-policy/.depcheckrc
@@ -1,0 +1,8 @@
+ignores:
+ - '@mongodb-js/prettier-config-devtools'
+ - '@mongodb-js/tsconfig-devtools'
+ - '@types/chai'
+ - '@types/sinon-chai'
+ - 'sinon'
+ignore-patterns:
+ - 'dist'

--- a/packages/connection-string-policy/.eslintignore
+++ b/packages/connection-string-policy/.eslintignore
@@ -1,0 +1,2 @@
+.nyc-output
+dist

--- a/packages/connection-string-policy/.eslintrc.js
+++ b/packages/connection-string-policy/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  root: true,
+  extends: ['@mongodb-js/eslint-config-devtools'],
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: ['./tsconfig-lint.json'],
+  },
+};

--- a/packages/connection-string-policy/.mocharc.js
+++ b/packages/connection-string-policy/.mocharc.js
@@ -1,0 +1,1 @@
+module.exports = require('@mongodb-js/mocha-config-devtools');

--- a/packages/connection-string-policy/.prettierignore
+++ b/packages/connection-string-policy/.prettierignore
@@ -1,0 +1,3 @@
+.nyc_output
+dist
+coverage

--- a/packages/connection-string-policy/.prettierrc.json
+++ b/packages/connection-string-policy/.prettierrc.json
@@ -1,0 +1,1 @@
+"@mongodb-js/prettier-config-devtools"

--- a/packages/connection-string-policy/LICENSE
+++ b/packages/connection-string-policy/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+(a) You must give any other recipients of the Work or
+Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works
+that You distribute, all copyright, patent, trademark, and
+attribution notices from the Source form of the Work,
+excluding those notices that do not pertain to any part of
+the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+distribution, then any Derivative Works that You distribute must
+include a readable copy of the attribution notices contained
+within such NOTICE file, excluding those notices that do not
+pertain to any part of the Derivative Works, in at least one
+of the following places: within a NOTICE text file distributed
+as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or,
+within a display generated by the Derivative Works, if and
+wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and
+do not modify the License. You may add Your own attribution
+notices within Derivative Works that You distribute, alongside
+or as an addendum to the NOTICE text from the Work, provided
+that such additional attribution notices cannot be construed
+as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "{}"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright {yyyy} {name of copyright owner}
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/connection-string-policy/README.md
+++ b/packages/connection-string-policy/README.md
@@ -1,0 +1,54 @@
+# @mongodb-js/connection-string-policy
+
+Checks a MongoDB connection string against a policy list of options, and reports the ones
+that fall outside it.
+
+Some connection string options change where credentials are sent, or whether the connection
+is verified. This package reports whether a connection string uses any of them, so that a
+tool can decide whether to accept it as-is, ask the user to confirm, or refuse it.
+
+It is not a connection string validator: it says nothing about whether a connection string
+is well-formed or whether connecting will succeed. It also does not decide what happens
+next — it returns data, never throws for policy reasons, and does no logging or prompting.
+
+## Usage
+
+```ts
+import { checkConnectionStringPolicy } from '@mongodb-js/connection-string-policy';
+
+const result = checkConnectionStringPolicy(connectionString);
+
+if (!result.withinPolicy) {
+  console.log(result.flaggedOptions);
+}
+```
+
+## What you get back
+
+| Field            | Meaning                                                                     |
+| ---------------- | --------------------------------------------------------------------------- |
+| `withinPolicy`   | `true` when nothing was flagged.                                            |
+| `flaggedOptions` | Names of the options that fall outside the policy list.                     |
+| `unparseable`    | `true` when the connection string could not be parsed; never within policy. |
+
+`flaggedOptions` contains option names only, never values, so it is safe to display or log
+without redacting it first. Two kinds of entry are not literal option names:
+
+- `'ssl/tls'` — the connection would not be TLS-protected (a non-SRV string to a non-local
+  host without `tls=true`, or an SRV string that sets `tls=false`).
+- `'authMechanismProperties.<NAME>'` — an individual auth mechanism property.
+
+## How the lists work
+
+Every connection string option known to the Node.js driver is listed as either allowed or
+disallowed, and two type-level functions make TypeScript fail to compile if an option
+appears in neither. That is deliberate: a new driver option being silently treated as
+acceptable is worse than the cost of maintaining the list, so a driver upgrade that adds an
+option is _supposed_ to break the build here.
+
+At runtime the check is an allow list — anything not explicitly allowed is flagged. The
+disallowed list is not consulted directly; it documents intent and feeds the exhaustiveness
+check. A test asserts the two lists never overlap.
+
+Because that check is only meaningful against one set of driver typings, this package
+declares its `mongodb` peer dependency on a single major version.

--- a/packages/connection-string-policy/README.md
+++ b/packages/connection-string-policy/README.md
@@ -3,13 +3,17 @@
 Checks a MongoDB connection string against a policy list of options, and reports the ones
 that fall outside it.
 
-Some connection string options change where credentials are sent, or whether the connection
-is verified. This package reports whether a connection string uses any of them, so that a
-tool can decide whether to accept it as-is, ask the user to confirm, or refuse it.
+Use it when a connection string comes from somewhere other than the user: a deep link, a
+protocol handler, a command line argument, or a tool call. Some options change where
+credentials are sent, and some disable TLS certificate verification, so connecting with one
+of those without asking the user first is a risk.
 
-It is not a connection string validator: it says nothing about whether a connection string
-is well-formed or whether connecting will succeed. It also does not decide what happens
-next — it returns data, never throws for policy reasons, and does no logging or prompting.
+The check looks at the connection string and nothing else. It reports whether the string is
+safe to connect with without asking the user, and which of its options are not. It does not
+tell you whether the connection string is well-formed, whether connecting will succeed, or
+anything about what happens once the connection is established. It also does not decide what
+to do next: it returns data, never throws for policy reasons, and does no logging or
+prompting.
 
 ## Usage
 

--- a/packages/connection-string-policy/package.json
+++ b/packages/connection-string-policy/package.json
@@ -1,0 +1,80 @@
+{
+  "name": "@mongodb-js/connection-string-policy",
+  "description": "Policy checks for MongoDB connection strings.",
+  "author": {
+    "name": "MongoDB Inc",
+    "email": "compass@mongodb.com"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "bugs": {
+    "url": "https://jira.mongodb.org/projects/COMPASS/issues",
+    "email": "compass@mongodb.com"
+  },
+  "homepage": "https://github.com/mongodb-js/devtools-shared",
+  "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mongodb-js/devtools-shared.git"
+  },
+  "files": [
+    "dist"
+  ],
+  "license": "Apache-2.0",
+  "main": "dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "require": {
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "import": {
+      "default": "./dist/.esm-wrapper.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "bootstrap": "npm run compile",
+    "prepublishOnly": "npm run compile",
+    "compile": "tsc -p tsconfig.json && gen-esm-wrapper . ./dist/.esm-wrapper.mjs",
+    "typecheck": "tsc --noEmit",
+    "eslint": "eslint",
+    "prettier": "prettier",
+    "lint": "npm run eslint . && npm run prettier -- --check .",
+    "depcheck": "depcheck",
+    "check": "npm run typecheck && npm run lint && npm run depcheck",
+    "check-ci": "npm run check",
+    "test": "mocha",
+    "test-cov": "nyc -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
+    "test-watch": "npm run test -- --watch",
+    "test-ci": "npm run test-cov",
+    "reformat": "npm run prettier -- --write ."
+  },
+  "devDependencies": {
+    "@mongodb-js/eslint-config-devtools": "^0.11.8",
+    "@mongodb-js/mocha-config-devtools": "^1.1.3",
+    "@mongodb-js/prettier-config-devtools": "^1.0.4",
+    "@mongodb-js/tsconfig-devtools": "^1.1.3",
+    "@types/chai": "^4.2.21",
+    "@types/mocha": "^9.1.1",
+    "@types/sinon-chai": "^4.0.0",
+    "chai": "^4.5.0",
+    "depcheck": "^1.4.7",
+    "eslint": "^7.25.0 || ^8.0.0",
+    "gen-esm-wrapper": "^1.1.3",
+    "mocha": "^8.4.0",
+    "mongodb": "^7.5.0",
+    "nyc": "^15.1.0",
+    "prettier": "^3.8.1",
+    "sinon": "^9.2.3",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "mongodb-build-info": "^1.9.12",
+    "mongodb-connection-string-url": "^7.0.1"
+  },
+  "peerDependencies": {
+    "mongodb": "^7.0.0"
+  }
+}

--- a/packages/connection-string-policy/src/connection-string-policy.spec.ts
+++ b/packages/connection-string-policy/src/connection-string-policy.spec.ts
@@ -1,0 +1,139 @@
+import { expect } from 'chai';
+import { checkConnectionStringPolicy } from './connection-string-policy';
+
+describe('checkConnectionStringPolicy', function () {
+  describe('parsing', function () {
+    it('does not accept a connection string it cannot parse', function () {
+      const result = checkConnectionStringPolicy('not a connection string');
+      expect(result.unparseable).to.equal(true);
+      expect(result.withinPolicy).to.equal(false);
+    });
+
+    it('accepts a plain srv connection string', function () {
+      const result = checkConnectionStringPolicy(
+        'mongodb+srv://cluster0.example.net/',
+      );
+      expect(result).to.deep.equal({
+        withinPolicy: true,
+        unparseable: false,
+        flaggedOptions: [],
+      });
+    });
+  });
+
+  describe('tls', function () {
+    it('flags a non-srv connection to a remote host without tls', function () {
+      const result = checkConnectionStringPolicy('mongodb://example.net/');
+      expect(result.flaggedOptions).to.deep.equal(['ssl/tls']);
+      expect(result.withinPolicy).to.equal(false);
+    });
+
+    it('accepts a non-srv connection to a remote host with tls=true', function () {
+      const result = checkConnectionStringPolicy(
+        'mongodb://example.net/?tls=true',
+      );
+      expect(result.flaggedOptions).to.deep.equal([]);
+    });
+
+    it('accepts a non-srv connection to localhost without tls', function () {
+      const result = checkConnectionStringPolicy('mongodb://localhost:27017/');
+      expect(result.flaggedOptions).to.deep.equal([]);
+    });
+
+    it('flags an srv connection that opts out of tls', function () {
+      const result = checkConnectionStringPolicy(
+        'mongodb+srv://cluster0.example.net/?tls=false',
+      );
+      expect(result.flaggedOptions).to.deep.equal(['ssl/tls']);
+    });
+  });
+
+  describe('connection string options', function () {
+    it('accepts allowed options', function () {
+      const result = checkConnectionStringPolicy(
+        'mongodb+srv://cluster0.example.net/?appName=myApp&maxPoolSize=10&readPreference=primary',
+      );
+      expect(result.flaggedOptions).to.deep.equal([]);
+    });
+
+    it('flags disallowed options', function () {
+      const result = checkConnectionStringPolicy(
+        'mongodb+srv://cluster0.example.net/?proxyHost=proxy.example.net',
+      );
+      expect(result.flaggedOptions).to.deep.equal(['proxyHost']);
+    });
+
+    it('flags options it does not know about', function () {
+      const result = checkConnectionStringPolicy(
+        'mongodb+srv://cluster0.example.net/?somethingNewFromAFutureDriver=1',
+      );
+      expect(result.flaggedOptions).to.deep.equal([
+        'somethingNewFromAFutureDriver',
+      ]);
+    });
+
+    it('reports every flagged option, not just the tls one', function () {
+      // Regression test: an earlier version of this logic stopped collecting
+      // option names as soon as the tls check had flagged something, which hid
+      // the more interesting options from anyone displaying the result.
+      const result = checkConnectionStringPolicy(
+        'mongodb://example.net/?tls=false&proxyHost=proxy.example.net&serializeFunctions=true',
+      );
+      expect(result.flaggedOptions).to.have.members([
+        'ssl/tls',
+        'proxyHost',
+        'serializeFunctions',
+      ]);
+    });
+
+    it('reports a repeated option only once', function () {
+      const result = checkConnectionStringPolicy(
+        'mongodb+srv://cluster0.example.net/?proxyHost=a.example.net&proxyHost=b.example.net',
+      );
+      expect(result.flaggedOptions).to.deep.equal(['proxyHost']);
+    });
+  });
+
+  describe('authMechanismProperties', function () {
+    it('accepts allowed properties', function () {
+      const result = checkConnectionStringPolicy(
+        'mongodb+srv://cluster0.example.net/?authMechanismProperties=CANONICALIZE_HOST_NAME:forward',
+      );
+      expect(result.flaggedOptions).to.deep.equal([]);
+    });
+
+    it('accepts AWS_SESSION_TOKEN, which the driver no longer knows about', function () {
+      const result = checkConnectionStringPolicy(
+        'mongodb+srv://cluster0.example.net/?authMechanismProperties=AWS_SESSION_TOKEN:token',
+      );
+      expect(result.flaggedOptions).to.deep.equal([]);
+    });
+
+    it('flags kerberos service overrides', function () {
+      const result = checkConnectionStringPolicy(
+        'mongodb+srv://cluster0.example.net/?authMechanismProperties=SERVICE_HOST:evil.example.net',
+      );
+      expect(result.flaggedOptions).to.deep.equal([
+        'authMechanismProperties.SERVICE_HOST',
+      ]);
+    });
+
+    it('flags ENVIRONMENT', function () {
+      const result = checkConnectionStringPolicy(
+        'mongodb+srv://cluster0.example.net/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:azure',
+      );
+      expect(result.flaggedOptions).to.deep.equal([
+        'authMechanismProperties.ENVIRONMENT',
+      ]);
+    });
+
+    it('flags properties it does not know about', function () {
+      const result = checkConnectionStringPolicy(
+        'mongodb+srv://cluster0.example.net/?authMechanismProperties=SOMETHING_NEW:1',
+      );
+      expect(result.flaggedOptions).to.deep.equal([
+        'authMechanismProperties.SOMETHING_NEW',
+      ]);
+    });
+  });
+});

--- a/packages/connection-string-policy/src/connection-string-policy.ts
+++ b/packages/connection-string-policy/src/connection-string-policy.ts
@@ -65,6 +65,11 @@ const allowedConnectionStringOptions = [
   'ssl', // Only if value is `true` or target host is local.
   'timeoutMS',
   'tls', // Only if value is `true` or target host is local.
+  // `tlsCertificateKeyFile` and `tlsCRLFile` name local files, which looks alarming but
+  // is allowed on purpose: a client sends its certificate and public key during the TLS
+  // handshake, never the private key, so the residual risk is a socially engineered
+  // certificate extraction. That was weighed up when these lists were drawn up and
+  // accepted as low. `tlsCAFile` is disallowed for an unrelated reason, see below.
   'tlsCertificateKeyFile',
   'tlsCertificateKeyFilePassword',
   'tlsCRLFile',
@@ -104,6 +109,8 @@ const disallowedConnectionStringOptions = [
   'session',
   'tlsAllowInvalidCertificates',
   'tlsAllowInvalidHostnames',
+  // Unlike the other TLS options here, this one changes which certificate authorities
+  // are trusted, which can make an attacker's certificate look valid.
   'tlsCAFile',
   'tlsInsecure',
 ] as const;
@@ -208,11 +215,11 @@ export interface ConnectionStringPolicyResult {
 }
 
 /**
- * Check a connection string against the policy list, and report the options that fall
- * outside it.
+ * Check a connection string against the policy list. Reports whether the string is safe to
+ * connect with without asking the user first, and which of its options are not.
  *
- * This is *not* a general-purpose connection string validator: it makes no claim about
- * whether a connection string is valid or whether connecting will succeed.
+ * It says nothing about whether the connection string is valid, whether connecting will
+ * succeed, or what happens once the connection is established.
  */
 export function checkConnectionStringPolicy(
   connectionString: string,

--- a/packages/connection-string-policy/src/connection-string-policy.ts
+++ b/packages/connection-string-policy/src/connection-string-policy.ts
@@ -1,0 +1,285 @@
+import ConnectionStringUrl, {
+  CommaAndColonSeparatedRecord,
+} from 'mongodb-connection-string-url';
+import type { MongoClientOptions, AuthMechanismProperties } from 'mongodb';
+import { isLocalhost } from 'mongodb-build-info';
+
+const allowedConnectionStringOptions = [
+  'appName',
+  'authMechanism',
+  'authMechanismProperties', // Partially. See allowed and disallowed AuthMechanismProperties below.
+  'authSource',
+  'autoSelectFamily',
+  'autoSelectFamilyAttemptTimeout',
+  'bsonRegExp',
+  'cert',
+  'checkKeys',
+  'compressors',
+  'connectTimeoutMS',
+  'directConnection',
+  'driverInfo',
+  'enableOverloadRetargeting',
+  'enableUtf8Validation',
+  'family',
+  'fieldsAsRaw',
+  'forceServerObjectId',
+  'heartbeatFrequencyMS',
+  'hints',
+  'ignoreUndefined',
+  'journal',
+  'key',
+  'loadBalanced',
+  'localAddress',
+  'localPort',
+  'localThresholdMS',
+  'maxAdaptiveRetries',
+  'maxConnecting',
+  'maxIdleTimeMS',
+  'maxPoolSize',
+  'maxStalenessSeconds',
+  'minHeartbeatFrequencyMS',
+  'minPoolSize',
+  'monitorCommands',
+  'noDelay',
+  'passphrase',
+  'pfx',
+  'promoteBuffers',
+  'promoteLongs',
+  'promoteValues',
+  'proxyPassword',
+  'proxyUsername',
+  'readConcern',
+  'readConcernLevel',
+  'readPreference',
+  'readPreferenceTags',
+  'replicaSet',
+  'retryReads',
+  'retryWrites',
+  'runtimeAdapters',
+  'serverApi',
+  'serverMonitoringMode',
+  'serverSelectionTimeoutMS',
+  'socketTimeoutMS',
+  'srvMaxHosts',
+  'srvServiceName',
+  'ssl', // Only if value is `true` or target host is local.
+  'timeoutMS',
+  'tls', // Only if value is `true` or target host is local.
+  'tlsCertificateKeyFile',
+  'tlsCertificateKeyFilePassword',
+  'tlsCRLFile',
+  'useBigInt64',
+  'w',
+  'waitQueueTimeoutMS',
+  'writeConcern',
+  'wtimeoutMS',
+  'zlibCompressionLevel',
+] as const;
+
+const disallowedConnectionStringOptions = [
+  'allowPartialTrustChain',
+  'ALPNProtocols',
+  'auth',
+  'autoEncryption',
+  'ca',
+  'checkServerIdentity',
+  'ciphers',
+  'crl',
+  'ecdhCurve',
+  'keepAliveInitialDelay',
+  'lookup',
+  'minDHSize',
+  'mongodbLogComponentSeverities',
+  'mongodbLogMaxDocumentLength',
+  'mongodbLogPath',
+  'pkFactory',
+  'proxyHost',
+  'proxyPort',
+  'raw',
+  'rejectUnauthorized',
+  'secureContext',
+  'secureProtocol',
+  'serializeFunctions',
+  'servername',
+  'session',
+  'tlsAllowInvalidCertificates',
+  'tlsAllowInvalidHostnames',
+  'tlsCAFile', // !
+  'tlsInsecure',
+] as const;
+
+const allowedAuthMechanismProperties = [
+  'CANONICALIZE_HOST_NAME',
+  'TOKEN_RESOURCE',
+  'AWS_CREDENTIAL_PROVIDER',
+] as const;
+
+// AWS_SESSION_TOKEN is not supported by the driver anymore, but devtools-shared provides
+// it as a compatibility mechanism with pre-7.x driver behavior. It is kept in a separate
+// list because it is no longer part of `AuthMechanismProperties` and therefore cannot take
+// part in the exhaustiveness check below.
+const additionalAllowedAuthMechanismProperties = ['AWS_SESSION_TOKEN'] as const;
+
+const disallowedAuthMechanismProperties = [
+  'ENVIRONMENT',
+  'SERVICE_HOST',
+  'SERVICE_NAME',
+  'SERVICE_REALM',
+  'ALLOWED_HOSTS',
+  'OIDC_CALLBACK',
+  'OIDC_HUMAN_CALLBACK',
+] as const;
+
+// Ensure that all connection string options known to the Node.js driver
+// appear either in the allowed or the disallowed ConnectionStringOptions list.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function checkAllowedPlusDisallowedEqualsOptionsKeys(
+  input1:
+    | (typeof allowedConnectionStringOptions)[number]
+    | (typeof disallowedConnectionStringOptions)[number],
+  input2: keyof MongoClientOptions,
+): [
+  keyof MongoClientOptions,
+  (
+    | (typeof allowedConnectionStringOptions)[number]
+    | (typeof disallowedConnectionStringOptions)[number]
+  ),
+] {
+  return [input1, input2];
+}
+
+type ExactAuthMechanismProperties = {
+  [K in keyof AuthMechanismProperties as string extends K
+    ? never
+    : K]: AuthMechanismProperties[K];
+};
+
+// Ensure that all auth mechanism properties known to the Node.js driver
+// appear either in the allowed or the disallowed AuthMechanismProperties list.
+// TODO: remove ExactAuthMechanismProperties when https://jira.mongodb.org/browse/NODE-4100 is done.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function checkAllowedPlusDisallowedEqualsAuthMechanismKeys(
+  input1:
+    | (typeof allowedAuthMechanismProperties)[number]
+    | (typeof disallowedAuthMechanismProperties)[number],
+  input2: keyof ExactAuthMechanismProperties,
+): [
+  keyof ExactAuthMechanismProperties,
+  (
+    | (typeof allowedAuthMechanismProperties)[number]
+    | (typeof disallowedAuthMechanismProperties)[number]
+  ),
+] {
+  return [input1, input2];
+}
+
+// Ensure that no option or property is listed as both allowed and disallowed, since
+// only the allow list is consulted at runtime.
+type AssertNever<T extends never> = T;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type NoConnectionStringOptionOverlap = AssertNever<
+  Extract<
+    (typeof allowedConnectionStringOptions)[number],
+    (typeof disallowedConnectionStringOptions)[number]
+  >
+>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type NoAuthMechanismPropertyOverlap = AssertNever<
+  Extract<
+    | (typeof allowedAuthMechanismProperties)[number]
+    | (typeof additionalAllowedAuthMechanismProperties)[number],
+    (typeof disallowedAuthMechanismProperties)[number]
+  >
+>;
+
+/** The result of checking a connection string against the policy. */
+export interface ConnectionStringPolicyResult {
+  withinPolicy: boolean;
+
+  /** Unparseable connection strings are never within policy. */
+  unparseable: boolean;
+
+  /**
+   * Option names, never values, so that this can be displayed or logged without
+   * redacting it first. `'ssl/tls'` is used for connections that would not be
+   * TLS-protected.
+   */
+  flaggedOptions: string[];
+}
+
+/**
+ * Check a connection string against the policy list, and report the options that fall
+ * outside it.
+ *
+ * This is *not* a general-purpose connection string validator: it makes no claim about
+ * whether a connection string is valid or whether connecting will succeed.
+ */
+export function checkConnectionStringPolicy(
+  connectionString: string,
+): ConnectionStringPolicyResult {
+  let connectionStringUrl: ConnectionStringUrl;
+  try {
+    connectionStringUrl = new ConnectionStringUrl(connectionString, {
+      looseValidation: false,
+    });
+  } catch {
+    return {
+      withinPolicy: false,
+      unparseable: true,
+      flaggedOptions: [],
+    };
+  }
+
+  const searchParams =
+    connectionStringUrl.typedSearchParams<MongoClientOptions>();
+  const flaggedOptions: string[] = [];
+
+  const hasNonLocalhostTarget = connectionStringUrl.hosts.some(
+    (host) => !isLocalhost(host),
+  );
+  const wouldNotUseTls = connectionStringUrl.isSRV
+    ? searchParams.get('ssl') === 'false' || searchParams.get('tls') === 'false'
+    : !(
+        searchParams.get('ssl') === 'true' || searchParams.get('tls') === 'true'
+      );
+
+  if (hasNonLocalhostTarget && wouldNotUseTls) {
+    flaggedOptions.push('ssl/tls');
+  }
+
+  for (const [name, value] of searchParams) {
+    // Checking the allow list is enough: the type-level checks above guarantee that
+    // every option is categorised, and options the driver does not know about yet
+    // should be flagged too.
+    if (!(allowedConnectionStringOptions as readonly string[]).includes(name)) {
+      flaggedOptions.push(name);
+    }
+
+    if (name === 'authMechanismProperties') {
+      const authMechanismProperties =
+        new CommaAndColonSeparatedRecord<AuthMechanismProperties>(value);
+      for (const [authMechanismPropName] of authMechanismProperties) {
+        if (
+          !(allowedAuthMechanismProperties as readonly string[]).includes(
+            authMechanismPropName,
+          ) &&
+          !(
+            additionalAllowedAuthMechanismProperties as readonly string[]
+          ).includes(authMechanismPropName)
+        ) {
+          flaggedOptions.push(
+            `authMechanismProperties.${authMechanismPropName}`,
+          );
+        }
+      }
+    }
+  }
+
+  const uniqueFlaggedOptions = [...new Set(flaggedOptions)];
+
+  return {
+    withinPolicy: uniqueFlaggedOptions.length === 0,
+    unparseable: false,
+    flaggedOptions: uniqueFlaggedOptions,
+  };
+}

--- a/packages/connection-string-policy/src/connection-string-policy.ts
+++ b/packages/connection-string-policy/src/connection-string-policy.ts
@@ -104,7 +104,7 @@ const disallowedConnectionStringOptions = [
   'session',
   'tlsAllowInvalidCertificates',
   'tlsAllowInvalidHostnames',
-  'tlsCAFile', // !
+  'tlsCAFile',
   'tlsInsecure',
 ] as const;
 

--- a/packages/connection-string-policy/src/index.ts
+++ b/packages/connection-string-policy/src/index.ts
@@ -1,0 +1,2 @@
+export { checkConnectionStringPolicy } from './connection-string-policy';
+export type { ConnectionStringPolicyResult } from './connection-string-policy';

--- a/packages/connection-string-policy/tsconfig-lint.json
+++ b/packages/connection-string-policy/tsconfig-lint.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/connection-string-policy/tsconfig.json
+++ b/packages/connection-string-policy/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@mongodb-js/tsconfig-devtools/tsconfig.common.json"
+}


### PR DESCRIPTION
## Description

Adds new package to check connection string policy and be reusable across different clients (i.e. compass, vscode, mcp).

## Open Questions

- The `mongodb` peer dependency is pinned to a single major on purpose: the type-level checks that keep the lists exhaustive are only meaningful against one set of driver typings. Is this safe to assume?
- It was suggested that this could live in `devtools-connect` instead. I went with a separate package to avoid pulling its dependencies into a client that needs none of them, but happy to re-export it from there if preferred.

## Checklist

- [x] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
