### PR TITLE
feat(mongodb-runner): remove support for 4.2 servers

### DIFF
--- a/packages/mongodb-runner/src/mongocluster.spec.ts
+++ b/packages/mongodb-runner/src/mongocluster.spec.ts
@@ -365,50 +365,47 @@ describe('MongoCluster', function () {
       if (process.platform !== 'linux') return this.skip(); // No docker
     });
 
-    // This is the easiest way to ensure that MongoServer can handle the
-    // pre-4.4 log format (because in the devtools-shared CI, we only
-    // test ubuntu-latest).
-    it('can spawn a 4.2.x replset using docker', async function () {
+    it('can spawn a 8.0.x replset using docker', async function () {
       cluster = await MongoCluster.start({
-        version: '4.2.x',
+        version: '8.0.x',
         topology: 'replset',
         tmpDir,
-        docker: 'mongo:4.2',
+        docker: 'mongo:8.0',
         downloadOptions: {
-          distro: 'ubuntu1804',
+          distro: 'ubuntu2404',
         },
       });
       expect(cluster.connectionString).to.be.a('string');
-      expect(cluster.serverVersion).to.match(/^4\./);
+      expect(cluster.serverVersion).to.match(/^8\./);
       const hello = await cluster.withClient(async (client) => {
         return await client.db('admin').command({ hello: 1 });
       });
       expect(+hello.passives.length + +hello.hosts.length).to.equal(3);
     });
 
-    it('can spawn a 4.2.x sharded env using docker', async function () {
+    it('can spawn a 8.0.x sharded env using docker', async function () {
       cluster = await MongoCluster.start({
-        version: '4.2.x',
+        version: '8.0.x',
         topology: 'sharded',
         tmpDir,
-        docker: 'mongo:4.2',
+        docker: 'mongo:8.0',
         shards: 1,
         secondaries: 0,
         downloadOptions: {
-          distro: 'ubuntu1604',
+          distro: 'ubuntu2404',
         },
       });
       expect(cluster.connectionString).to.be.a('string');
-      expect(cluster.serverVersion).to.match(/^4\./);
+      expect(cluster.serverVersion).to.match(/^8\./);
       const hello = await cluster.withClient(async (client) => {
         return await client.db('admin').command({ hello: 1 });
       });
       expect(hello.msg).to.equal('isdbgrid');
     });
 
-    it('can spawn a 4.2.x standalone mongod with TLS enabled and get build info', async function () {
+    it('can spawn a 8.0.x standalone mongod with TLS enabled and get build info', async function () {
       cluster = await MongoCluster.start({
-        version: '4.2.x',
+        version: '8.0.x',
         topology: 'standalone',
         tmpDir,
         args: [
@@ -421,14 +418,14 @@ describe('MongoCluster', function () {
         ],
         docker: [
           `--volume=${path.resolve(__dirname, '..')}:/projectroot:ro`,
-          'mongo:4.2',
+          'mongo:8.0',
         ],
         downloadOptions: {
-          distro: 'ubuntu1604',
+          distro: 'ubuntu2404',
         },
       });
       expect(cluster.connectionString).to.be.a('string');
-      expect(cluster.serverVersion).to.match(/^4\./);
+      expect(cluster.serverVersion).to.match(/^8\./);
       expect(cluster.serverVariant).to.equal('community');
     });
   });

--- a/packages/mongodb-runner/src/mongologreader.ts
+++ b/packages/mongodb-runner/src/mongologreader.ts
@@ -84,20 +84,10 @@ export function isFailureToSetupListener(entry: LogEntry): boolean {
  * @returns The port in question, or an -1 if the log line did not match.
  */
 function getPortFromLogEntry(logEntry: LogEntry): number {
-  let match;
   // Log message id 23016 has the format
   // { t: <timestamp>, s: 'I', c: 'NETWORK', id: 23016, ctx: 'listener', msg: '...', attr: { port: 27020 } }
   if (logEntry.id === 23016) {
     return logEntry.attr.port;
-  }
-  // Or, 4.2-style: <timestamp> I  NETWORK  [listener] waiting for connections on port 27020
-  if (
-    logEntry.id === undefined &&
-    (match = /^waiting for connections on port (?<port>\d+)( ssl)?$/i.exec(
-      logEntry.message,
-    ))
-  ) {
-    return +(match.groups?.port ?? '0');
   }
   if (isFailureToSetupListener(logEntry)) {
     throw new Error(
@@ -150,28 +140,10 @@ export type BuildInfo = { version: string | null; modules: string[] | null };
  * @returns Partial build info.
  */
 function getBuildInfoFromLogEntry(logEntry: LogEntry): Partial<BuildInfo> {
-  let match;
   // Log message id 23403 has the format
-  // { t: <timestamp>, s: 'I', c: 'CONTROL', id: 23403, ctx: 'initandlisten', msg: '...', attr: { buildInfO: { ... } } }
+  // { t: <timestamp>, s: 'I', c: 'CONTROL', id: 23403, ctx: 'initandlisten', msg: '...', attr: { buildInfo: { ... } } }
   if (logEntry.id === 23403) {
     return logEntry.attr.buildInfo;
-  }
-  // Or, 4.2-style, split across multiple lines
-  if (
-    logEntry.id === undefined &&
-    (match = /^(?:db|mongos) version v(?<version>.+)$/i.exec(logEntry.message))
-  ) {
-    return { version: match.groups?.version };
-  }
-  if (
-    logEntry.id === undefined &&
-    (match = /^modules: (?<moduleList>.+)$/i.exec(logEntry.message))
-  ) {
-    return {
-      modules: match.groups?.moduleList
-        ?.split(' ')
-        ?.filter((module) => module !== 'none'),
-    };
   }
   return {};
 }


### PR DESCRIPTION

## Description

Copying the driver notification here:

### Support for MongoDB 4.2 is removed

> [!WARNING]
> When the driver connects to a MongoDB server of version 4.2 or less, it will now throw an error.

In order to update the nodejs driver used in mongodb-runner then this package also needs to drop support.

## Open Questions

https://www.mongodb.com/legal/support-policy/lifecycles


## Checklist

- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
