### PR TITLE
fix(mongodb-constants): update $geoNear template COMPASS-6532

### DIFF
--- a/packages/mongodb-constants/src/stage-operators.ts
+++ b/packages/mongodb-constants/src/stage-operators.ts
@@ -385,7 +385,7 @@ const STAGE_OPERATORS = [
     namespaces: [...ANY_NAMESPACE],
     description: 'Returns documents based on proximity to a geospatial point.',
     comment: `/**
- * near: The point to search near.
+ * near: The point to search near, supports the let option and bound let option.
  * distanceField: The calculated distance.
  * maxDistance: Optional maximum distance, in meters, documents can be before being excluded from results.
  * minDistance: Optional minimum distance from the center point.
@@ -397,16 +397,16 @@ const STAGE_OPERATORS = [
  */
 `,
     snippet: `{
-      near: { type: 'Point', coordinates: [ \${1:number}, \${2:number} ] },
-      distanceField: '\${3:string}',
-      maxDistance: \${4:number},
-      minDistance: \${5:number},
-      query: {\${6}},
-      includeLocs: '\${7:string}',
-      distanceMultiplier: \${8:number},
-      key: '\${9:string}',
-      spherical: \${10:boolean}
-    }`,
+  near: { type: 'Point', coordinates: [ \${1:number}, \${2:number} ] },
+  distanceField: '\${3:string}',
+  maxDistance: \${4:number},
+  minDistance: \${5:number},
+  query: {\${6}},
+  includeLocs: '\${7:string}',
+  distanceMultiplier: \${8:number},
+  key: '\${9:string}',
+  spherical: \${10:boolean}
+}`,
   },
   {
     name: '$graphLookup',

--- a/packages/mongodb-constants/src/stage-operators.ts
+++ b/packages/mongodb-constants/src/stage-operators.ts
@@ -396,7 +396,6 @@ const STAGE_OPERATORS = [
  * spherical: Defaults to false. Specifies whether to use spherical geometry.
  */
 `,
-
     snippet: `{
       near: { type: 'Point', coordinates: [ \${1:number}, \${2:number} ] },
       distanceField: '\${3:string}',

--- a/packages/mongodb-constants/src/stage-operators.ts
+++ b/packages/mongodb-constants/src/stage-operators.ts
@@ -387,22 +387,27 @@ const STAGE_OPERATORS = [
     comment: `/**
  * near: The point to search near.
  * distanceField: The calculated distance.
- * maxDistance: The maximum distance, in meters, documents can be before being excluded from results.
- * query: Limits results that match the query
+ * maxDistance: Optional maximum distance, in meters, documents can be before being excluded from results.
+ * minDistance: Optional minimum distance from the center point.
+ * query: Limits results that match the query.
  * includeLocs: Optional. Labels and includes the point used to match the document.
- * num: Optional. The maximum number of documents to return.
+ * distanceMultiplier: Optional factor to multiply returned distances by.
+ * key: Optional geospatial indexed field to use.
  * spherical: Defaults to false. Specifies whether to use spherical geometry.
  */
 `,
+
     snippet: `{
-  near: { type: 'Point', coordinates: [ \${1:number}, \${2:number} ] },
-  distanceField: '\${3:string}',
-  maxDistance: \${4:number},
-  query: {\${5}},
-  includeLocs: '\${6}',
-  num: \${7:number},
-  spherical: \${8:boolean}
-}`,
+      near: { type: 'Point', coordinates: [ \${1:number}, \${2:number} ] },
+      distanceField: '\${3:string}',
+      maxDistance: \${4:number},
+      minDistance: \${5:number},
+      query: {\${6}},
+      includeLocs: '\${7:string}',
+      distanceMultiplier: \${8:number},
+      key: '\${9:string}',
+      spherical: \${10:boolean}
+    }`,
   },
   {
     name: '$graphLookup',


### PR DESCRIPTION

## Description

Update the `$geoNear` aggregation-stage template in `mongodb-constants`.

Jira Ticket: [COMPASS-6532](https://jira.mongodb.org/browse/COMPASS-6532)
Documentation: [$geoNear aggregation stage](https://www.mongodb.com/docs/manual/reference/operator/aggregation/geoNear/)

## Changes

* Remove the obsolete `num` option.
* Add `distanceMultiplier`.
* Add `key`.
* Add `minDistance`.
* Update the inline option documentation.
* Preserve the existing option order.
* Keep snippet placeholders unique and sequential.

## Testing

* `npm run test --workspace=@mongodb-js/mongodb-constants`
* `npm run check --workspace=@mongodb-js/mongodb-constants`
* `npm run compile --workspace=@mongodb-js/mongodb-constants`

## Checklist

- [ ] I have signed the Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
